### PR TITLE
Fixes issue with non-fully-qualified icon names.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,13 @@
   "license": "ISC",
   "private": false,
   "scripts": {
+    "babel:build": "babel src -d --out-dir dist --ignore \"**/__tests__\" --copy-files",
     "clean": "del-cli ./dist",
     "lint": "eslint src",
     "test": "jest",
     "seed:db": "node scripts/collector.js",
     "pretty": "prettier --config ./package.json --write '{example,src}/**/*.{js,css,json}'",
-    "build:web": "yarn clean && babel src -d --out-dir dist --ignore \"**/__tests__\" && cp -r src/assets dist/.",
+    "build:web": "yarn clean && yarn babel:build",
     "sync:glyphmaps": "aws s3 sync glyphmaps s3://static.draftbit.com/fonts/glyphmaps --profile DraftbitS3SharedStatic --exclude \"*\" --include \"*.json\" --acl public-read"
   },
   "jest": {

--- a/src/components/Icon.web.js
+++ b/src/components/Icon.web.js
@@ -50,9 +50,20 @@ function Icon({ loading, iconSets, name: path, color, size }) {
     return null
   }
 
-  const [set, name] = path.split("/")
+  // Originally, only MaterialIcons were supported, so not all legacy
+  // apps in draftbit define icons with fully-qualified icon names.
+  let set = "MaterialIcons"
+  let name = path
 
-  const icons = iconSets[set].icons
+  if (path.includes("/")) {
+    ;[set, name] = path.split("/")
+  }
+
+  const icons = iconSets[set] && iconSets[set].icons
+
+  if (!icons) {
+    return null
+  }
 
   return (
     <span


### PR DESCRIPTION
Also streamlines build:web command, which would randomly fail when
`yarn link`ing in Create React App.