### PR TITLE
Fix(Jigsaw): swapped image property of cover to contain (P-1119)

### DIFF
--- a/src/components/CardContainerRating.js
+++ b/src/components/CardContainerRating.js
@@ -65,7 +65,7 @@ class CardContainerRating extends React.PureComponent {
             <Image
               style={{ aspectRatio }}
               source={typeof image === "string" ? { uri: image } : image}
-              resizeMode="cover"
+              resizeMode="contain"
             />
             <View style={{ padding: spacing.large }}>
               {title ? (


### PR DESCRIPTION
**Linear Task:**
https://linear.app/draftbit/issue/P-1119/card-bitsblocks-are-overflowing-due-to-image-sizes-on-web-preview
**Screenshots:**
![image](https://user-images.githubusercontent.com/16307737/84442204-c304b880-ac02-11ea-83aa-f26a6424896a.png)
