### PR TITLE
Fix RadioButtonGroup seed data and add missing flatlist/progress seed data

### DIFF
--- a/src/components/ProgressBar.js
+++ b/src/components/ProgressBar.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import { Animated, Easing, View, I18nManager } from "react-native";
+import { COMPONENT_TYPES, FORM_TYPES } from "../core/component-types";
 
 const INDETERMINATE_WIDTH_FACTOR = 0.3;
 const BAR_WIDTH_ZERO_POSITION =
@@ -156,3 +157,91 @@ export default class ProgressBar extends Component {
     );
   }
 }
+
+export const SEED_DATA = [
+  {
+    name: "Progress Bar",
+    tag: "ProgressBar",
+    description: "A horizontal bar used to show completed progress",
+    category: COMPONENT_TYPES.formControl,
+    preview_image_url: "{CLOUDINARY_URL}/Status_Progress.png",
+    supports_list_render: false,
+    props: {
+      progress: {
+        label: "Progress",
+        description: "The amount of progress to display. A number 0-1.",
+        type: FORM_TYPES.number,
+        value: 0.5,
+        min: 0,
+        max: 1,
+        step: 0.01,
+        precision: 2,
+        editable: true,
+        required: true,
+      },
+      color: {
+        label: "Progress Color",
+        description: "Custom color for the progress shown",
+        type: FORM_TYPES.color,
+        value: null,
+        editable: true,
+        required: true,
+      },
+      unfilledColor: {
+        label: "Unfilled Color",
+        description:
+          "The color of the unfilled portion of the progress bar(eg. if at 50% then this is the color of the other 50%)",
+        type: FORM_TYPES.color,
+        value: null,
+        editable: true,
+        required: true,
+      },
+      borderRadius: {
+        label: "Border Radius",
+        description: "The border radius of the bar",
+        type: FORM_TYPES.number,
+        value: 10,
+        min: 0,
+        max: 100,
+        step: 1,
+        precision: 1,
+        editable: true,
+        required: true,
+      },
+      borderWidth: {
+        label: "Border Width",
+        description: "The width of the border that surrounds the bar.",
+        type: FORM_TYPES.number,
+        value: 1,
+        min: 0,
+        max: 15,
+        step: 1,
+        precision: 1,
+        editable: true,
+        required: true,
+      },
+      borderColor: {
+        label: "Border Color",
+        description: "Custom color for border of the entire bar",
+        type: FORM_TYPES.color,
+        value: null,
+        editable: true,
+        required: true,
+      },
+      animationType: {
+        label: "Animation Type",
+        description:
+          "The type of animation that occurs when the bar is filled(Default is Spring)",
+        type: FORM_TYPES.flatArray,
+        value: "spring",
+        options: ["decay", "timing", "spring"],
+        editable: true,
+        required: true,
+      },
+    },
+    layout: {
+      width: 200,
+      height: 20,
+    },
+  },
+];

--- a/src/components/RadioButtonGroup.js
+++ b/src/components/RadioButtonGroup.js
@@ -3,6 +3,11 @@ import { withTheme } from "../core/theming";
 import { View, Text, StyleSheet } from "react-native";
 import Icon from "./Icon";
 import Touchable from "./Touchable";
+import {
+  COMPONENT_TYPES,
+  FORM_TYPES,
+  FIELD_NAME,
+} from "../core/component-types";
 
 function RadioButtonGroup({
   direction,
@@ -12,6 +17,7 @@ function RadioButtonGroup({
   labelStyle,
   iconSize,
   contentColor,
+  unselectedContentColor,
   borderRadius,
   optionSpacing,
   borderColor,
@@ -66,10 +72,19 @@ function RadioButtonGroup({
               }}
             >
               {option.icon ? (
-                <Icon name={option.icon} size={iconSize} color={contentColor} />
+                <Icon
+                  name={option.icon}
+                  size={iconSize}
+                  color={selected ? contentColor : unselectedContentColor}
+                />
               ) : null}
               {option.label ? (
-                <Text style={[labelStyle, { color: contentColor }]}>
+                <Text
+                  style={[
+                    labelStyle,
+                    { color: selected ? contentColor : unselectedContentColor },
+                  ]}
+                >
                   {option.label}
                 </Text>
               ) : null}
@@ -86,3 +101,119 @@ RadioButtonGroup.defaultProps = {
 };
 
 export default withTheme(RadioButtonGroup);
+
+export const SEED_DATA = {
+  name: "Radio Button Group",
+  tag: "RadioButtonGroup",
+  category: COMPONENT_TYPES.button,
+  preview_image_url: "{CLOUDINARY_URL}/Control_Radio.png",
+  props: {
+    options: {
+      label: "Options",
+      description: "Options for the button group.",
+      type: FORM_TYPES.arrayInput,
+      value: [],
+      editable: true,
+      required: true,
+    },
+    direction: {
+      label: "Horizontal/Vertical",
+      description: "Whether the buttons should be Horizontal or Vertical",
+      type: FORM_TYPES.flatArray,
+      value: "horizontal",
+      options: ["horizontal", "vertical"],
+      editable: true,
+      required: true,
+    },
+    activeColor: {
+      label: "Active Color",
+      description: "Color of the button when it's selected",
+      value: null,
+      type: FORM_TYPES.color,
+      editable: true,
+      required: true,
+    },
+    inactiveColor: {
+      label: "Inactive Color",
+      description: "Color of the button when it's selected not selected",
+      value: null,
+      type: FORM_TYPES.color,
+      editable: true,
+      required: true,
+    },
+    contentColor: {
+      label: "Selected Content Color",
+      description: "Color of the content(Icon and Label)",
+      value: null,
+      type: FORM_TYPES.color,
+      editable: true,
+      required: true,
+    },
+    unselectedContentColor: {
+      label: "Unselected Content Color",
+      description: "Unfinished Color of the content(Icon and Label)",
+      value: null,
+      type: FORM_TYPES.color,
+      editable: true,
+      required: true,
+    },
+    borderColor: {
+      label: "Border Color",
+      description: "Border color of the option",
+      value: null,
+      type: FORM_TYPES.color,
+      editable: true,
+      required: true,
+    },
+    labelStyle: {
+      label: "Label Style",
+      description: "Font and weight of the Label",
+      type: FORM_TYPES.typeStyle,
+      value: "Button",
+      editable: true,
+      required: true,
+    },
+    optionSpacing: {
+      label: "Option Spacing",
+      description: "The spacing between each option",
+      type: FORM_TYPES.number,
+      value: 1,
+      min: 0,
+      max: 20,
+      step: 1,
+      precision: 1,
+      editable: true,
+      required: false,
+    },
+    borderRadius: {
+      label: "Border Radius",
+      description: "The border radius for the container or options",
+      type: FORM_TYPES.number,
+      value: 0,
+      min: 0,
+      max: 100,
+      step: 1,
+      precision: 1,
+      editable: true,
+      required: false,
+    },
+    iconSize: {
+      label: "Icon Size",
+      description: "The size of the icon if enabled",
+      type: FORM_TYPES.number,
+      value: 0,
+      min: 0,
+      max: 50,
+      step: 1,
+      precision: 1,
+      editable: true,
+      required: false,
+    },
+    fieldName: {
+      ...FIELD_NAME,
+      value: "radioButtonValue",
+      handlerPropName: "onSelect",
+    },
+  },
+  layout: {},
+};

--- a/src/mappings/FlatList.js
+++ b/src/mappings/FlatList.js
@@ -1,0 +1,34 @@
+import { COMPONENT_TYPES, FORM_TYPES } from "../core/component-types";
+
+export const SEED_DATA = {
+  name: "List",
+  tag: "FlatList",
+  description: "A basic List component",
+  category: COMPONENT_TYPES.data,
+  supports_list_render: false,
+  preview_image_url:
+    "https://res.cloudinary.com/altos/image/upload/draftbit/Jigsaw/List.svg",
+  layout: {},
+  props: {
+    horizontal: {
+      label: "Horizontal",
+      description: "Render list horizontally",
+      editable: true,
+      required: true,
+      type: FORM_TYPES.boolean,
+      value: false,
+    },
+    numColumns: {
+      label: "Number of columns",
+      description: "Number of columns (vertical list only)",
+      editable: true,
+      required: false,
+      type: FORM_TYPES.number,
+      min: 1,
+      max: 4,
+      step: 1,
+      precision: 0,
+      value: null,
+    },
+  },
+};


### PR DESCRIPTION
Fixes RadioButtonGroup:
- Incorrectly named change handler prop
- Adds usage of unused unselectedContentColor prop

Adds missing seed data for
- FlatList
- ProgressBar