### PR TITLE
Progress indicator theme fix

### DIFF
--- a/example/src/ProgressIndicatorExample.js
+++ b/example/src/ProgressIndicatorExample.js
@@ -12,7 +12,7 @@ function ProgressIndicatorExample({ theme }) {
           currentStepStrokeWidth={3}
           stepIndicatorSize={28}
           stepIndicatorLabelFontSize={12}
-          stepNumberFinishedColor={"strongInverse"}
+          stepNumberFinishedColor={"primary"}
           stepNumberUnfinishedColor={"strongInverse"}
           unfinishedColor={"light"}
           finishedColor={"primary"}

--- a/example/src/ProgressIndicatorExample.js
+++ b/example/src/ProgressIndicatorExample.js
@@ -9,13 +9,13 @@ function ProgressIndicatorExample({ theme }) {
         <ProgressIndicator
           numberOfSteps={5}
           currentStep={3}
-          currentStepStrokeWidth={0}
+          currentStepStrokeWidth={3}
           stepIndicatorSize={28}
-          stepIndicatorLabelFontSize={16}
-          stepNumberFinishedColor={"#5a45ff"}
-          stepNumberUnfinishedColor={"#ffffff"}
-          unfinishedColor={"#eee"}
-          finishedColor={"#5a45ff"}
+          stepIndicatorLabelFontSize={12}
+          stepNumberFinishedColor={"strongInverse"}
+          stepNumberUnfinishedColor={"strongInverse"}
+          unfinishedColor={"light"}
+          finishedColor={"primary"}
         />
       </Section>
     </Container>

--- a/src/components/ProgressIndicator.tsx
+++ b/src/components/ProgressIndicator.tsx
@@ -8,38 +8,39 @@ import {
   PROP_TYPES,
 } from "../core/component-types";
 import themeT from "../styles/DefaultTheme";
+import { colorTypes } from "../types";
 
 interface Props {
   numberOfSteps?: number;
   currentStep: number;
   currentStepStrokeWidth?: number;
-  stepStrokeCurrentColor?: string;
+  stepStrokeCurrentColor?: colorTypes;
   stepIndicatorSize?: number;
   currentStepIndicatorSize?: number;
-  stepIndicatorCurrentColor?: string;
-  stepIndicatorLabelCurrentColor?: string;
+  stepIndicatorCurrentColor?: colorTypes;
+  stepIndicatorLabelCurrentColor?: colorTypes;
   stepIndicatorLabelFontSize?: number;
-  stepNumberFinishedColor?: string;
-  stepNumberUnfinishedColor?: string;
-  unfinishedColor?: string;
-  finishedColor?: string;
+  stepNumberFinishedColor?: colorTypes;
+  stepNumberUnfinishedColor?: colorTypes;
+  unfinishedColor?: colorTypes;
+  finishedColor?: colorTypes;
   theme: typeof themeT;
 }
 
 const ProgressIndicator: React.FC<Props> = ({
   numberOfSteps,
   currentStep,
-  currentStepStrokeWidth,
-  stepStrokeCurrentColor,
+  currentStepStrokeWidth = 3,
+  stepStrokeCurrentColor = "primary",
   stepIndicatorSize,
   currentStepIndicatorSize,
   stepIndicatorCurrentColor,
   stepIndicatorLabelCurrentColor,
-  stepIndicatorLabelFontSize,
-  stepNumberFinishedColor,
-  stepNumberUnfinishedColor,
-  unfinishedColor,
-  finishedColor,
+  stepIndicatorLabelFontSize = 12,
+  stepNumberFinishedColor = "strongInverse",
+  stepNumberUnfinishedColor = "primary",
+  unfinishedColor = "light",
+  finishedColor = "primary",
   theme,
 }) => {
   const currentPosition = currentStep - 1;
@@ -52,24 +53,32 @@ const ProgressIndicator: React.FC<Props> = ({
         currentStepIndicatorSize: currentStepIndicatorSize
           ? currentStepIndicatorSize
           : stepIndicatorSize,
-        stepStrokeFinishedColor: finishedColor,
-        stepStrokeUnFinishedColor: unfinishedColor,
-        separatorFinishedColor: finishedColor,
-        separatorUnFinishedColor: unfinishedColor,
-        stepIndicatorFinishedColor: finishedColor,
-        stepIndicatorUnFinishedColor: unfinishedColor,
+        stepStrokeFinishedColor: finishedColor && theme.colors[finishedColor],
+        stepStrokeUnFinishedColor:
+          unfinishedColor && theme.colors[unfinishedColor],
+        separatorFinishedColor: finishedColor && theme.colors[finishedColor],
+        separatorUnFinishedColor:
+          unfinishedColor && theme.colors[unfinishedColor],
+        stepIndicatorFinishedColor:
+          finishedColor && theme.colors[finishedColor],
+        stepIndicatorUnFinishedColor:
+          unfinishedColor && theme.colors[unfinishedColor],
         currentStepStrokeWidth,
         stepStrokeCurrentColor: stepStrokeCurrentColor
-          ? stepStrokeCurrentColor
-          : stepIndicatorCurrentColor,
-        stepIndicatorLabelUnFinishedColor: stepNumberUnfinishedColor,
-        stepIndicatorLabelFinishedColor: stepNumberFinishedColor,
+          ? theme.colors[stepStrokeCurrentColor]
+          : stepIndicatorCurrentColor &&
+            theme.colors[stepIndicatorCurrentColor],
+        stepIndicatorLabelUnFinishedColor:
+          stepNumberUnfinishedColor && theme.colors[stepNumberUnfinishedColor],
+        stepIndicatorLabelFinishedColor:
+          stepNumberFinishedColor && theme.colors[stepNumberFinishedColor],
         stepIndicatorCurrentColor: stepIndicatorCurrentColor
-          ? stepIndicatorCurrentColor
-          : unfinishedColor,
+          ? theme.colors[stepIndicatorCurrentColor]
+          : unfinishedColor && theme.colors[unfinishedColor],
         stepIndicatorLabelCurrentColor: stepIndicatorLabelCurrentColor
-          ? stepIndicatorLabelCurrentColor
-          : stepNumberFinishedColor,
+          ? theme.colors[stepIndicatorLabelCurrentColor]
+          : stepNumberUnfinishedColor &&
+            theme.colors[stepNumberUnfinishedColor],
         stepIndicatorLabelFontSize,
         labelFontFamily: theme.typography.body1.fontFamily,
       }}


### PR DESCRIPTION
I know you asked for the current item to be same bg as finished, but the library used doesn't seem to allow/support that. Best I could do was add a stroke on it to identify the that it is the current. This looks better in my opinion, but let me know if that is not what you want.