### PR TITLE
Fixed aspect ratio for native devices

### DIFF
--- a/src/components/AspectRatio.web.tsx
+++ b/src/components/AspectRatio.web.tsx
@@ -21,9 +21,9 @@ const AspectRatio: React.FC<Props> = (props) => {
   if (layout) {
     const { width = 0, height = 0 } = layout;
     if (width === 0) {
-      style.push({ width: height * aspectRatio, height });
+      style.push({ width: height * (1 / aspectRatio), height });
     } else {
-      style.push({ width, height: width * aspectRatio });
+      style.push({ width, height: width * (1 / aspectRatio) });
     }
   }
   return (

--- a/src/components/Image.tsx
+++ b/src/components/Image.tsx
@@ -1,5 +1,10 @@
 import React from "react";
-import { Image as NativeImage, ImageProps } from "react-native";
+import {
+  Image as NativeImage,
+  ImageProps,
+  ImageStyle,
+  View,
+} from "react-native";
 import Config from "./Config";
 import {
   COMPONENT_TYPES,
@@ -11,14 +16,34 @@ import {
 const Image: React.FC<ImageProps> = ({
   source = Config.placeholderImageURL,
   resizeMode = "cover",
+  style,
   ...props
 }) => {
   return (
-    <NativeImage
-      source={typeof source === "string" ? { uri: source } : source}
-      resizeMode={resizeMode}
-      {...props}
-    />
+    <>
+      {style &&
+      (style as ImageStyle).aspectRatio &&
+      typeof source !== "string" ? (
+        <View style={style}>
+          <NativeImage
+            source={typeof source === "string" ? { uri: source } : source}
+            resizeMode={resizeMode}
+            style={[
+              style,
+              { aspectRatio: undefined },
+              { width: "100%", height: "100%" },
+            ]}
+            {...props}
+          />
+        </View>
+      ) : (
+        <NativeImage
+          source={typeof source === "string" ? { uri: source } : source}
+          resizeMode={resizeMode}
+          {...props}
+        />
+      )}
+    </>
   );
 };
 

--- a/src/components/Image.tsx
+++ b/src/components/Image.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import {
   Image as NativeImage,
   ImageProps,
-  ImageStyle,
+  StyleSheet,
   View,
 } from "react-native";
 import Config from "./Config";
@@ -22,9 +22,9 @@ const Image: React.FC<ImageProps> = ({
   return (
     <>
       {style &&
-      (style as ImageStyle).aspectRatio &&
+      StyleSheet.flatten(style).aspectRatio &&
       typeof source !== "string" ? (
-        <View style={style}>
+        <View style={[style]}>
           <NativeImage
             source={typeof source === "string" ? { uri: source } : source}
             resizeMode={resizeMode}

--- a/src/components/Image.web.tsx
+++ b/src/components/Image.web.tsx
@@ -4,6 +4,7 @@ import {
   ImageStyle,
   ImageProps,
   ImageSourcePropType,
+  StyleSheet,
 } from "react-native";
 import AspectRatio from "./AspectRatio.web";
 import Config from "./Config";
@@ -14,15 +15,15 @@ const Image: React.FC<ImageProps> = ({
   resizeMode = "cover",
   ...props
 }) => {
-  if (style && (style as ImageStyle).aspectRatio) {
+  if (style && StyleSheet.flatten(style).aspectRatio) {
     return (
       <AspectRatio style={style as ImageStyle}>
         <NativeImage
           style={[
             style,
             {
-              width: "100%",
               height: "100%",
+              width: "100%",
             },
           ]}
           source={source as ImageSourcePropType}


### PR DESCRIPTION
For some reason, aspect ratio refused to work whenever a local image was used but worked fine with any network image. Wrapping it in a View and having aspect ratio set there seemed to do the trick, so that's what I changed. Whenever it is a local image and uses aspect ratio, it will automatically be wrapped in a View.