### PR TITLE
fix(textfield): fix overlap of label and placeholder

### DIFF
--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -84,6 +84,12 @@ class TextField extends React.Component<Props> {
     },
   };
 
+  componentDidMount() {
+    if (this.props.placeholder) {
+      this._minmizeLabel();
+    }
+  }
+
   componentDidUpdate(prevProps: Props, prevState: State) {
     if (
       prevState.focused !== this.state.focused ||
@@ -91,7 +97,12 @@ class TextField extends React.Component<Props> {
     ) {
       // The label should be minimized if the text input is focused, or has text
       // In minimized mode, the label moves up and becomes small
-      if (this.state.value || this.state.focused || this.props.error) {
+      if (
+        this.state.value ||
+        this.state.focused ||
+        this.props.error ||
+        this.props.placeholder
+      ) {
         this._minmizeLabel();
       } else {
         this._restoreLabel();


### PR DESCRIPTION
Fixed the issue where label text overlaps the placeholder for the TextField component.

Before:
![Screen Shot 2020-11-30 at 9 01 34 PM](https://user-images.githubusercontent.com/13050124/100687971-4d76db00-334f-11eb-9b5f-32dd4f41b20c.png)

After:
![Screen Shot 2020-11-30 at 9 01 46 PM](https://user-images.githubusercontent.com/13050124/100687978-4fd93500-334f-11eb-855c-d7dba7484346.png)
