### PR TITLE
Fix container background image to respect gutter width and work on web

### DIFF
--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -62,13 +62,8 @@ const Container: React.FC<Props> = ({
             }
             resizeMode={backgroundImageResizeMode}
             style={{
-              position: "absolute",
-              top: 0,
-              bottom: 0,
-              left: 0,
-              right: 0,
-              width: style ? (style as ViewStyle).width : 0,
-              height: style ? (style as ViewStyle).height : 0,
+              width: "100%",
+              height: "100%",
             }}
           />
         ) : null}


### PR DESCRIPTION
## Before

### Gutter padding on

#### iOS/Android

<img width="324" alt="image" src="https://user-images.githubusercontent.com/2578537/100920004-2d0a6600-34a0-11eb-953d-f4e44e45179c.png">

#### Web

<img width="335" alt="image" src="https://user-images.githubusercontent.com/2578537/100920105-48757100-34a0-11eb-9351-4ae899b19332.png">

### Gutter padding off

#### iOS/Android

<img width="334" alt="image" src="https://user-images.githubusercontent.com/2578537/100920201-6347e580-34a0-11eb-980d-5bf745f16e68.png">

#### Web

<img width="335" alt="image" src="https://user-images.githubusercontent.com/2578537/100920145-56c38d00-34a0-11eb-90f9-04f8d7a455d5.png">

## After

### Gutter padding on

#### iOS/Android

<img width="333" alt="image" src="https://user-images.githubusercontent.com/2578537/100920241-72c72e80-34a0-11eb-9a0e-eccc6def7bd0.png">

#### Web

<img width="335" alt="image" src="https://user-images.githubusercontent.com/2578537/100920317-8bcfdf80-34a0-11eb-9806-7c81c2977ffc.png">

### Gutter padding off

#### iOS/Android

<img width="332" alt="image" src="https://user-images.githubusercontent.com/2578537/100920277-7bb80000-34a0-11eb-8d9b-d0733671b248.png">

#### Web

<img width="334" alt="image" src="https://user-images.githubusercontent.com/2578537/100920296-82df0e00-34a0-11eb-9140-03811ae3d0b0.png">