### PR TITLE
Fix DateTimePicker display in iOS 14

### DIFF
--- a/src/components/DatePicker/DatePickerComponent.tsx
+++ b/src/components/DatePicker/DatePickerComponent.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Platform } from 'react-native';
 import DateTimePicker from "@react-native-community/datetimepicker";
 import { DatePickerComponentProps as Props } from "./DatePickerComponentType";
 
@@ -13,9 +14,10 @@ const DatePickerComponent: React.FC<Props> = ({
       value={value}
       mode={mode}
       onChange={(_event: any, data: any) => {
-        toggleVisibility();
+        Platform.OS === 'ios' ? null : toggleVisibility();
         onChange(null, data);
       }}
+      display={Platform.OS === 'ios' ? 'spinner' : 'default'}
     />
   );
 };


### PR DESCRIPTION
Two small fixes in this PR. 

First, the current picker closes on every value change, which is a very bad UX when paired with a spinner. Fixed by only toggling visibility on change if the platform isn't iOS.

Second, in iOS 14, this component defaults to an inline datetime picker, which looks horrible in the space designed for a spinner. Fixed by defaulting the picker to a spinner on iOS.

I've already implemented this change in my local copy of Draftbit, and everything seems to work as it should.