### PR TITLE
feat(core): Add FocusProps into most of the components

### DIFF
--- a/files/Icon.web.tsx
+++ b/files/Icon.web.tsx
@@ -1,12 +1,12 @@
 // @ts-nocheck
 import { ViewProps, StyleProp, ImageStyle } from "react-native";
 
-interface Props extends ViewProps {
+type Props = {
   name: string | number | { uri: string };
   color?: string;
   size: number;
   style?: StyleProp<ImageStyle>;
-}
+} & ViewProps;
 
 const Icon: React.FC<Props> = ({ _name, _color, _size, _style }) => {
   return null;

--- a/src/components/AnimatedCircularProgress.tsx
+++ b/src/components/AnimatedCircularProgress.tsx
@@ -11,14 +11,14 @@ import CircularProgress, {
 } from "./CircularProgress";
 const AnimatedProgress = Animated.createAnimatedComponent(CircularProgress);
 
-interface Props extends CircularProgressProps {
+type Props = {
   duration?: number;
   easing?: EasingFunction;
   prefill?: number;
   useNativeDriver?: boolean;
   tintColorSecondary?: string;
   onAnimationComplete?: Animated.EndCallback | undefined;
-}
+} & CircularProgressProps;
 
 const AnimatedCircularProgress: React.FC<Props> = ({
   duration = 500,

--- a/src/components/AspectRatio.web.tsx
+++ b/src/components/AspectRatio.web.tsx
@@ -7,10 +7,10 @@ import {
   ViewStyle,
 } from "react-native";
 
-interface Props {
+type Props = {
   children?: React.ReactNode;
   style?: StyleProp<ViewStyle>;
-}
+};
 
 const AspectRatio: React.FC<Props> = (props) => {
   const [layout, setLayout] = React.useState<LayoutRectangle | null>(null);

--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -3,12 +3,13 @@ import { Image, StyleProp, ImageStyle } from "react-native";
 import Config from "./Config";
 
 import { GROUPS, COMPONENT_TYPES, FORM_TYPES } from "../core/component-types";
+import { FocusProps } from "src/types";
 
-interface Props {
+type Props = {
   image?: string | Blob;
   size?: number;
   style?: StyleProp<ImageStyle>;
-}
+} & FocusProps;
 
 const Avatar: React.FC<Props> = ({
   image = Config.avatarImageUrl,

--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -3,13 +3,12 @@ import { Image, StyleProp, ImageStyle } from "react-native";
 import Config from "./Config";
 
 import { GROUPS, COMPONENT_TYPES, FORM_TYPES } from "../core/component-types";
-import { FocusProps } from "src/types";
 
 type Props = {
   image?: string | Blob;
   size?: number;
   style?: StyleProp<ImageStyle>;
-} & FocusProps;
+};
 
 const Avatar: React.FC<Props> = ({
   image = Config.avatarImageUrl,

--- a/src/components/AvatarEdit.tsx
+++ b/src/components/AvatarEdit.tsx
@@ -7,7 +7,6 @@ import { withTheme } from "../core/theming";
 
 import { GROUPS, COMPONENT_TYPES, FORM_TYPES } from "../core/component-types";
 import theme from "../styles/DefaultTheme";
-import { FocusProps } from "src/types";
 
 type Props = {
   image: string | Blob;
@@ -15,7 +14,7 @@ type Props = {
   onPress?: () => void;
   style?: StyleProp<ViewStyle>;
   theme: typeof theme;
-} & FocusProps;
+};
 
 const AvatarEdit: React.FC<Props> = ({
   image,

--- a/src/components/AvatarEdit.tsx
+++ b/src/components/AvatarEdit.tsx
@@ -7,14 +7,15 @@ import { withTheme } from "../core/theming";
 
 import { GROUPS, COMPONENT_TYPES, FORM_TYPES } from "../core/component-types";
 import theme from "../styles/DefaultTheme";
+import { FocusProps } from "src/types";
 
-interface Props {
+type Props = {
   image: string | Blob;
   size?: number;
   onPress?: () => void;
   style?: StyleProp<ViewStyle>;
   theme: typeof theme;
-}
+} & FocusProps;
 
 const AvatarEdit: React.FC<Props> = ({
   image,
@@ -22,6 +23,7 @@ const AvatarEdit: React.FC<Props> = ({
   onPress = () => {},
   style,
   theme: { colors },
+  ...rest
 }) => {
   const colorStyles = {
     editBackgroundColor: colors.primary,
@@ -35,7 +37,7 @@ const AvatarEdit: React.FC<Props> = ({
   };
 
   return (
-    <View style={[style, dimensions]}>
+    <View style={[style, dimensions]} {...rest}>
       <Touchable onPress={onPress}>
         <Avatar image={image} size={size} />
         <View

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -23,7 +23,6 @@ import {
   COMPONENT_TYPES,
 } from "../core/component-types";
 import theme from "../styles/DefaultTheme";
-import { FocusProps } from "src/types";
 
 /**
  * A button is component that the user can press to trigger an action.

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -23,6 +23,7 @@ import {
   COMPONENT_TYPES,
 } from "../core/component-types";
 import theme from "../styles/DefaultTheme";
+import { FocusProps } from "src/types";
 
 /**
  * A button is component that the user can press to trigger an action.
@@ -57,7 +58,7 @@ import theme from "../styles/DefaultTheme";
  * ```
  */
 
-interface Props extends TouchableHighlightProps {
+type Props = {
   disabled?: boolean;
   type?: "solid" | "outline" | "text";
   loading?: boolean;
@@ -69,7 +70,8 @@ interface Props extends TouchableHighlightProps {
   elevation?: number;
   style?: StyleProp<ViewStyle>;
   theme: typeof theme;
-}
+} & TouchableHighlightProps &
+  FocusProps;
 
 const Button: React.FC<Props> = ({
   disabled = false,

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -4,20 +4,23 @@ import Touchable from "./Touchable";
 import Config from "./Config";
 import { StyleProp, ViewStyle } from "react-native";
 import theme from "../styles/DefaultTheme";
+import { FocusProps } from "src/types";
 
-interface Props {
+type Props = {
   numColumns?: number;
   children?: React.ReactNode;
   onPress?: () => void;
   style?: StyleProp<ViewStyle>;
   theme: typeof theme;
-}
+} & FocusProps;
+
 const Card: React.FC<Props> = ({
   numColumns = 3,
   children,
   onPress,
   theme: { spacing },
   style,
+  ...rest
 }) => {
   let cardStyle;
   if (numColumns === 1) {
@@ -33,7 +36,12 @@ const Card: React.FC<Props> = ({
   }
 
   return (
-    <Touchable disabled={!onPress} onPress={onPress} style={[cardStyle, style]}>
+    <Touchable
+      disabled={!onPress}
+      onPress={onPress}
+      style={[cardStyle, style]}
+      {...rest}
+    >
       {children}
     </Touchable>
   );

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -4,7 +4,6 @@ import Touchable from "./Touchable";
 import Config from "./Config";
 import { StyleProp, ViewStyle } from "react-native";
 import theme from "../styles/DefaultTheme";
-import { FocusProps } from "src/types";
 
 type Props = {
   numColumns?: number;
@@ -12,7 +11,7 @@ type Props = {
   onPress?: () => void;
   style?: StyleProp<ViewStyle>;
   theme: typeof theme;
-} & FocusProps;
+};
 
 const Card: React.FC<Props> = ({
   numColumns = 3,

--- a/src/components/CardBlock.tsx
+++ b/src/components/CardBlock.tsx
@@ -42,6 +42,7 @@ const CardBlock: React.FC<Props> = ({
   theme: { colors, borderRadius, typography, spacing },
   style,
   onPress,
+  ...rest
 }) => {
   let titleJustification: justificationType;
 
@@ -66,7 +67,7 @@ const CardBlock: React.FC<Props> = ({
   ];
 
   return (
-    <Card style={style} onPress={onPress} numColumns={numColumns}>
+    <Card style={style} onPress={onPress} numColumns={numColumns} {...rest}>
       <View style={{ backgroundColor: colors.background }}>
         <Elevation style={{ elevation, borderRadius: borderRadius.global }}>
           <Image

--- a/src/components/CardBlock.tsx
+++ b/src/components/CardBlock.tsx
@@ -16,7 +16,7 @@ import Config from "./Config";
 import theme from "../styles/DefaultTheme";
 import { justificationType } from "./Justification";
 
-interface Props {
+type Props = {
   image?: string | Blob;
   title?: string;
   leftDescription?: string;
@@ -28,7 +28,7 @@ interface Props {
   theme: typeof theme;
   style?: StyleProp<ViewStyle>;
   onPress: () => void;
-}
+};
 
 const CardBlock: React.FC<Props> = ({
   image = Config.cardImageUrl,

--- a/src/components/CardContainer.tsx
+++ b/src/components/CardContainer.tsx
@@ -17,7 +17,6 @@ import {
 import Config from "./Config";
 import theme from "../styles/DefaultTheme";
 import { justificationType } from "./Justification";
-import { FocusProps } from "src/types";
 
 const ICON_CONTAINER_SIZE = Config.cardIconSize * 2;
 const ICON_CONTAINER_PADDING = Config.cardIconSize / 2 - 1;
@@ -35,7 +34,7 @@ type Props = {
   theme: typeof theme;
   style?: StyleProp<ViewStyle>;
   onPress: () => void;
-} & FocusProps;
+};
 
 const CardContainer: React.FC<Props> = ({
   image = Config.cardImageUrl,

--- a/src/components/CardContainer.tsx
+++ b/src/components/CardContainer.tsx
@@ -17,11 +17,12 @@ import {
 import Config from "./Config";
 import theme from "../styles/DefaultTheme";
 import { justificationType } from "./Justification";
+import { FocusProps } from "src/types";
 
 const ICON_CONTAINER_SIZE = Config.cardIconSize * 2;
 const ICON_CONTAINER_PADDING = Config.cardIconSize / 2 - 1;
 
-interface Props {
+type Props = {
   image?: string | Blob;
   title?: string;
   leftDescription?: string;
@@ -34,7 +35,7 @@ interface Props {
   theme: typeof theme;
   style?: StyleProp<ViewStyle>;
   onPress: () => void;
-}
+} & FocusProps;
 
 const CardContainer: React.FC<Props> = ({
   image = Config.cardImageUrl,
@@ -49,6 +50,7 @@ const CardContainer: React.FC<Props> = ({
   theme: { colors, borderRadius, typography, spacing },
   style,
   onPress,
+  ...rest
 }) => {
   let textJustification: justificationType;
 
@@ -70,7 +72,7 @@ const CardContainer: React.FC<Props> = ({
   }
 
   return (
-    <Card style={style} onPress={onPress} numColumns={numColumns}>
+    <Card style={style} onPress={onPress} numColumns={numColumns} {...rest}>
       <Elevation style={{ elevation, borderRadius: borderRadius.global }}>
         <View
           style={{

--- a/src/components/CardContainerRating.tsx
+++ b/src/components/CardContainerRating.tsx
@@ -16,7 +16,6 @@ import {
 } from "../core/component-types";
 import Config from "./Config";
 import theme from "../styles/DefaultTheme";
-import { FocusProps } from "src/types";
 
 const ICON_CONTAINER_SIZE = Config.cardIconSize * 2;
 const ICON_CONTAINER_PADDING = Config.cardIconSize / 2 - 1;
@@ -35,7 +34,7 @@ type Props = {
   theme: typeof theme;
   style?: StyleProp<ViewStyle>;
   onPress: () => void;
-} & FocusProps;
+};
 
 const CardContainerRating: React.FC<Props> = ({
   image = Config.cardImageUrl,

--- a/src/components/CardContainerRating.tsx
+++ b/src/components/CardContainerRating.tsx
@@ -16,11 +16,12 @@ import {
 } from "../core/component-types";
 import Config from "./Config";
 import theme from "../styles/DefaultTheme";
+import { FocusProps } from "src/types";
 
 const ICON_CONTAINER_SIZE = Config.cardIconSize * 2;
 const ICON_CONTAINER_PADDING = Config.cardIconSize / 2 - 1;
 
-interface Props {
+type Props = {
   image?: string | Blob;
   title?: string;
   leftDescription?: string;
@@ -34,7 +35,7 @@ interface Props {
   theme: typeof theme;
   style?: StyleProp<ViewStyle>;
   onPress: () => void;
-}
+} & FocusProps;
 
 const CardContainerRating: React.FC<Props> = ({
   image = Config.cardImageUrl,
@@ -49,6 +50,7 @@ const CardContainerRating: React.FC<Props> = ({
   theme: { colors, borderRadius, typography, spacing },
   style,
   onPress,
+  ...rest
 }) => {
   let titleStyle, rightDescriptionStyle;
   switch (numColumns) {
@@ -63,7 +65,7 @@ const CardContainerRating: React.FC<Props> = ({
   }
 
   return (
-    <Card style={style} onPress={onPress} numColumns={numColumns}>
+    <Card style={style} onPress={onPress} numColumns={numColumns} {...rest}>
       <Elevation style={{ elevation, borderRadius: borderRadius.global }}>
         <View
           style={{

--- a/src/components/CardContainerShortImage.tsx
+++ b/src/components/CardContainerShortImage.tsx
@@ -13,8 +13,9 @@ import {
 } from "../core/component-types";
 import Config from "./Config";
 import theme from "../styles/DefaultTheme";
+import { FocusProps } from "src/types";
 
-interface Props {
+type Props = {
   image?: string | Blob;
   title?: string;
   subtitle?: string;
@@ -24,7 +25,7 @@ interface Props {
   theme: typeof theme;
   style?: StyleProp<ViewStyle>;
   onPress: () => void;
-}
+} & FocusProps;
 
 const CardContainerShortImage: React.FC<Props> = ({
   image = Config.squareImageUrl,
@@ -36,9 +37,10 @@ const CardContainerShortImage: React.FC<Props> = ({
   theme: { colors, borderRadius, typography, spacing },
   style,
   onPress,
+  ...rest
 }) => {
   return (
-    <Card style={style} onPress={onPress}>
+    <Card style={style} onPress={onPress} {...rest}>
       <Elevation
         style={{
           elevation,

--- a/src/components/CardContainerShortImage.tsx
+++ b/src/components/CardContainerShortImage.tsx
@@ -13,7 +13,6 @@ import {
 } from "../core/component-types";
 import Config from "./Config";
 import theme from "../styles/DefaultTheme";
-import { FocusProps } from "src/types";
 
 type Props = {
   image?: string | Blob;
@@ -25,7 +24,7 @@ type Props = {
   theme: typeof theme;
   style?: StyleProp<ViewStyle>;
   onPress: () => void;
-} & FocusProps;
+};
 
 const CardContainerShortImage: React.FC<Props> = ({
   image = Config.squareImageUrl,

--- a/src/components/CardInline.tsx
+++ b/src/components/CardInline.tsx
@@ -13,7 +13,6 @@ import {
 } from "../core/component-types";
 import Config from "./Config";
 import theme from "../styles/DefaultTheme";
-import { FocusProps } from "src/types";
 
 type Props = {
   image?: string | Blob;
@@ -26,7 +25,7 @@ type Props = {
   theme: typeof theme;
   style?: StyleProp<ViewStyle>;
   onPress: () => void;
-} & FocusProps;
+};
 
 const CardInline: React.FC<Props> = ({
   image = Config.cardImageUrl,

--- a/src/components/CardInline.tsx
+++ b/src/components/CardInline.tsx
@@ -13,8 +13,9 @@ import {
 } from "../core/component-types";
 import Config from "./Config";
 import theme from "../styles/DefaultTheme";
+import { FocusProps } from "src/types";
 
-interface Props {
+type Props = {
   image?: string | Blob;
   title?: string;
   description?: string;
@@ -25,7 +26,7 @@ interface Props {
   theme: typeof theme;
   style?: StyleProp<ViewStyle>;
   onPress: () => void;
-}
+} & FocusProps;
 
 const CardInline: React.FC<Props> = ({
   image = Config.cardImageUrl,
@@ -38,6 +39,7 @@ const CardInline: React.FC<Props> = ({
   theme: { colors, borderRadius, typography, spacing },
   style,
   onPress,
+  ...rest
 }) => {
   let titleStyle, descriptionStyle;
   switch (numColumns) {
@@ -56,7 +58,7 @@ const CardInline: React.FC<Props> = ({
   }
 
   return (
-    <Card style={style} onPress={onPress} numColumns={numColumns}>
+    <Card style={style} onPress={onPress} numColumns={numColumns} {...rest}>
       <Elevation style={{ elevation, borderRadius: borderRadius.global }}>
         <Image
           style={{

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -23,10 +23,11 @@ import {
 import Config from "./Config";
 import theme from "../styles/DefaultTheme";
 import { ResizeModeType } from "./ResizeMode";
+import { FocusProps } from "src/types";
 
 const screenWidth = Dimensions.get("window").width;
 
-interface Props {
+type Props = {
   images: string[] | Blob[];
   aspectRatio?: number;
   swiperPalette?: "surface" | "non-sruface";
@@ -34,7 +35,8 @@ interface Props {
   dotColor?: string;
   theme: typeof theme;
   style?: StyleProp<ViewStyle>;
-}
+} & FocusProps;
+
 const Carousel: React.FC<Props> = ({
   images = [
     Config.placeholderImageURL,
@@ -51,6 +53,7 @@ const Carousel: React.FC<Props> = ({
   dotColor,
   theme: { colors, spacing },
   style = { height: screenWidth * 0.5 },
+  ...rest
 }) => {
   const [scrollOffset, setScrollOffset] = useState(0);
   const [width, setWidth] = useState(0);
@@ -72,6 +75,7 @@ const Carousel: React.FC<Props> = ({
     <View
       style={[styles.container, { aspectRatio, width }, style]}
       onLayout={onPageLayout}
+      {...rest}
     >
       <ScrollView
         onScroll={handleScroll}

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -23,7 +23,6 @@ import {
 import Config from "./Config";
 import theme from "../styles/DefaultTheme";
 import { ResizeModeType } from "./ResizeMode";
-import { FocusProps } from "src/types";
 
 const screenWidth = Dimensions.get("window").width;
 
@@ -35,7 +34,7 @@ type Props = {
   dotColor?: string;
   theme: typeof theme;
   style?: StyleProp<ViewStyle>;
-} & FocusProps;
+};
 
 const Carousel: React.FC<Props> = ({
   images = [

--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -10,7 +10,6 @@ import {
   PROP_TYPES,
   FIELD_NAME,
 } from "../core/component-types";
-import { FocusProps } from "src/types";
 
 type Props = {
   status?: "checked" | "indeterminate" | "unchecked";

--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -10,13 +10,15 @@ import {
   PROP_TYPES,
   FIELD_NAME,
 } from "../core/component-types";
+import { FocusProps } from "src/types";
 
-interface Props extends TouchableOpacityProps {
+type Props = {
   status?: "checked" | "indeterminate" | "unchecked";
   disabled?: boolean;
   onPress?: () => void;
   color?: string;
-}
+} & TouchableOpacityProps &
+  FocusProps;
 
 export default function Checkbox(props: Props) {
   return Platform.OS === "ios" ? (

--- a/src/components/CheckboxAndroid.tsx
+++ b/src/components/CheckboxAndroid.tsx
@@ -9,14 +9,16 @@ import Icon from "./Icon";
 import Touchable from "./Touchable";
 import { withTheme } from "../core/theming";
 import themeT from "../styles/DefaultTheme";
+import { FocusProps } from "src/types";
 
-interface Props extends TouchableHighlightProps {
+type Props = {
   status?: "checked" | "indeterminate" | "unchecked";
   disabled?: boolean;
   onPress?: () => void;
   theme: typeof themeT;
   color?: string;
-}
+} & TouchableHighlightProps &
+  FocusProps;
 
 const CheckboxAndroid: React.FC<Props> = ({
   status = "unchecked",

--- a/src/components/CheckboxAndroid.tsx
+++ b/src/components/CheckboxAndroid.tsx
@@ -9,7 +9,6 @@ import Icon from "./Icon";
 import Touchable from "./Touchable";
 import { withTheme } from "../core/theming";
 import themeT from "../styles/DefaultTheme";
-import { FocusProps } from "src/types";
 
 type Props = {
   status?: "checked" | "indeterminate" | "unchecked";

--- a/src/components/CheckboxIOS.tsx
+++ b/src/components/CheckboxIOS.tsx
@@ -4,14 +4,16 @@ import Icon from "./Icon";
 import Touchable from "./Touchable";
 import { withTheme } from "../core/theming";
 import themeT from "../styles/DefaultTheme";
+import { FocusProps } from "src/types";
 
-interface Props extends TouchableHighlightProps {
+type Props = {
   status?: "checked" | "indeterminate" | "unchecked";
   disabled?: boolean;
   onPress?: () => void;
   theme: typeof themeT;
   color?: string;
-}
+} & TouchableHighlightProps &
+  FocusProps;
 
 const CheckboxIOS: React.FC<Props> = ({
   status = "unchecked",

--- a/src/components/CheckboxIOS.tsx
+++ b/src/components/CheckboxIOS.tsx
@@ -4,7 +4,6 @@ import Icon from "./Icon";
 import Touchable from "./Touchable";
 import { withTheme } from "../core/theming";
 import themeT from "../styles/DefaultTheme";
-import { FocusProps } from "src/types";
 
 type Props = {
   status?: "checked" | "indeterminate" | "unchecked";

--- a/src/components/CircularProgress.tsx
+++ b/src/components/CircularProgress.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { View, StyleProp, ViewStyle } from "react-native";
 import { Svg, Path, G } from "react-native-svg";
 
-export interface Props {
+export type Props = {
   size: number;
   width: number;
   backgroundWidth?: number;
@@ -20,7 +20,7 @@ export interface Props {
   renderCap?: (obj: { center: { x: number; y: number } }) => React.ReactNode;
   dashedBackground?: { width: number; gap: number };
   dashedTint?: { width: number; gap: number };
-}
+};
 
 class CircularProgress extends React.Component<Props> {
   polarToCartesian = (

--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -7,7 +7,7 @@ import {
   ViewStyle,
 } from "react-native";
 import { withTheme } from "../core/theming";
-import { FocusProps } from "../types";
+
 import Elevation from "./Elevation";
 import {
   GROUPS,
@@ -29,7 +29,7 @@ type Props = {
   elevation?: number;
   style?: StyleProp<ViewStyle>;
   children?: React.ReactNode;
-} & FocusProps;
+};
 
 const Container: React.FC<Props> = ({
   theme: { spacing },

--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -7,6 +7,7 @@ import {
   ViewStyle,
 } from "react-native";
 import { withTheme } from "../core/theming";
+import { FocusProps } from "../types";
 import Elevation from "./Elevation";
 import {
   GROUPS,
@@ -17,7 +18,7 @@ import {
 import theme from "../styles/DefaultTheme";
 import { ResizeModeType } from "./ResizeMode";
 
-interface Props {
+type Props = {
   theme: typeof theme;
   useThemeGutterPadding: boolean;
   borderColor: string;
@@ -28,7 +29,7 @@ interface Props {
   elevation?: number;
   style?: StyleProp<ViewStyle>;
   children?: React.ReactNode;
-}
+} & FocusProps;
 
 const Container: React.FC<Props> = ({
   theme: { spacing },
@@ -41,6 +42,7 @@ const Container: React.FC<Props> = ({
   elevation,
   style,
   children,
+  ...rest
 }) => {
   const { flexDirection, justifyContent, alignItems, ...styleProp } =
     StyleSheet.flatten(style) || {};
@@ -68,7 +70,7 @@ const Container: React.FC<Props> = ({
   }
 
   return (
-    <Wrap style={[containerStyle, style]}>
+    <Wrap style={[containerStyle, style]} {...rest}>
       {backgroundImage ? (
         <ImageBackground
           source={

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -11,8 +11,9 @@ import TextField, { Props as TextFieldProps } from "../TextField";
 import Touchable from "../Touchable";
 import theme from "../../styles/DefaultTheme";
 import DateTimePicker from "./DatePickerComponent";
+import { FocusProps } from "src/types";
 
-interface Props extends TextFieldProps {
+type Props = {
   style?: StyleProp<ViewStyle>;
   theme: typeof theme;
   // initialDate?: string;
@@ -26,7 +27,8 @@ interface Props extends TextFieldProps {
   onDateChange?: (data?: any) => void;
   disabled?: boolean;
   mode?: "date" | "time" | "datetime";
-}
+} & TextFieldProps &
+  FocusProps;
 
 const MONTHS = [
   "January",

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -11,7 +11,6 @@ import TextField, { Props as TextFieldProps } from "../TextField";
 import Touchable from "../Touchable";
 import theme from "../../styles/DefaultTheme";
 import DateTimePicker from "./DatePickerComponent";
-import { FocusProps } from "src/types";
 
 type Props = {
   style?: StyleProp<ViewStyle>;

--- a/src/components/Divider.tsx
+++ b/src/components/Divider.tsx
@@ -8,19 +8,21 @@ import {
   COMPONENT_TYPES,
 } from "../core/component-types";
 import theme from "../styles/DefaultTheme";
+import { FocusProps } from "src/types";
 
-interface Props {
+type Props = {
   style?: StyleProp<ViewStyle>;
   color?: string;
   height?: number;
   theme: typeof theme;
-}
+} & FocusProps;
 
 const Divider: React.FC<Props> = ({
   style,
   color,
   height,
   theme: { colors },
+  ...rest
 }) => {
   return (
     <View
@@ -29,6 +31,7 @@ const Divider: React.FC<Props> = ({
         style,
         { height: height || StyleSheet.hairlineWidth },
       ]}
+      {...rest}
     />
   );
 };

--- a/src/components/Divider.tsx
+++ b/src/components/Divider.tsx
@@ -8,14 +8,13 @@ import {
   COMPONENT_TYPES,
 } from "../core/component-types";
 import theme from "../styles/DefaultTheme";
-import { FocusProps } from "src/types";
 
 type Props = {
   style?: StyleProp<ViewStyle>;
   color?: string;
   height?: number;
   theme: typeof theme;
-} & FocusProps;
+};
 
 const Divider: React.FC<Props> = ({
   style,

--- a/src/components/Elevation.tsx
+++ b/src/components/Elevation.tsx
@@ -10,10 +10,10 @@ import shadow from "../styles/shadow";
 import { withTheme } from "../core/theming";
 import themeT from "../styles/DefaultTheme";
 
-interface Props extends ViewProps {
+type Props = {
   style?: StyleProp<ViewStyle>;
   theme: typeof themeT;
-}
+} & ViewProps;
 
 const Elevation: React.FC<Props> = ({ style, theme, ...rest }) => {
   const flattenedStyles = StyleSheet.flatten(style) || {};

--- a/src/components/FAB.tsx
+++ b/src/components/FAB.tsx
@@ -60,7 +60,7 @@ import theme from "../styles/DefaultTheme";
  * ```
  */
 
-interface Props extends TouchableHighlightProps {
+type Props = {
   disabled?: boolean;
   type?: "solid" | "extended" | "outline" | "fixed" | "standard";
   loading?: boolean;
@@ -72,7 +72,7 @@ interface Props extends TouchableHighlightProps {
   theme: typeof theme;
   IconOverride: typeof Icon;
   style?: StyleProp<ViewStyle>;
-}
+} & TouchableHighlightProps;
 
 const FAB: React.FC<Props> = ({
   disabled = false,

--- a/src/components/FieldCheckbox.tsx
+++ b/src/components/FieldCheckbox.tsx
@@ -14,14 +14,14 @@ import Checkbox from "./Checkbox";
 import color from "color";
 import theme from "../styles/DefaultTheme";
 
-interface Props {
+type Props = {
   title?: string;
   status: "checked" | "indeterminate" | "unchecked";
   onPress?: () => void;
   color: string;
   disabled?: boolean;
   theme: typeof theme;
-}
+};
 
 const FieldCheckbox: React.FC<Props> = ({
   title,

--- a/src/components/FieldRadioButton.tsx
+++ b/src/components/FieldRadioButton.tsx
@@ -8,14 +8,14 @@ import RadioButton from "./RadioButton";
 import { GROUPS, COMPONENT_TYPES, FORM_TYPES } from "../core/component-types";
 import themeT from "../styles/DefaultTheme";
 
-interface Props {
+type Props = {
   onPress?: () => void;
   title?: string;
   selected: boolean;
   disabled?: boolean;
   color: string;
   theme: typeof themeT;
-}
+};
 
 const FieldRadioButton: React.FC<Props> = ({
   onPress = () => {},

--- a/src/components/FieldSearchBarFull.tsx
+++ b/src/components/FieldSearchBarFull.tsx
@@ -20,7 +20,7 @@ import Icon from "./Icon";
 import Config from "./Config";
 import theme from "../styles/DefaultTheme";
 
-interface Props {
+type Props = {
   icon?: string;
   placeholder?: string;
   style?: StyleProp<ViewStyle>;
@@ -28,7 +28,7 @@ interface Props {
   onChange: (text: string) => void;
   onSubmit?: (e: NativeSyntheticEvent<TextInputSubmitEditingEventData>) => void;
   value: string;
-}
+};
 
 const FieldSearchBarFull: React.FC<Props> = ({
   icon = "search",

--- a/src/components/FieldSlider.tsx
+++ b/src/components/FieldSlider.tsx
@@ -10,12 +10,12 @@ import {
   FIELD_NAME,
 } from "../core/component-types";
 
-interface Props extends SliderProps {
+type Props = {
   title?: string;
   minimumLabel: string;
   maximumLabel: string;
   style?: StyleProp<ViewStyle>;
-}
+} & SliderProps;
 
 const FieldSlider: React.FC<Props> = ({
   title,

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -14,7 +14,7 @@ import Touchable from "./Touchable";
 import Config from "./Config";
 import theme from "../styles/DefaultTheme";
 
-interface Props {
+type Props = {
   titleTypeStyle?: StyleProp<TextStyle>;
   titleColor: string;
   title: string;
@@ -24,7 +24,7 @@ interface Props {
   onPress: () => void;
   style?: StyleProp<ViewStyle>;
   theme: typeof theme;
-}
+};
 
 const Header: React.FC<Props> = ({
   titleTypeStyle,

--- a/src/components/HeaderLarge.tsx
+++ b/src/components/HeaderLarge.tsx
@@ -5,14 +5,14 @@ import Header from "./Header";
 import theme from "../styles/DefaultTheme";
 import { StyleProp, ViewStyle } from "react-native";
 
-interface Props {
+type Props = {
   title: string;
   buttonText: string;
   icon: string;
   onPress?: () => void;
   style?: StyleProp<ViewStyle>;
   theme: typeof theme;
-}
+};
 
 const HeaderLarge: React.FC<Props> = ({
   title,

--- a/src/components/HeaderMedium.tsx
+++ b/src/components/HeaderMedium.tsx
@@ -10,14 +10,14 @@ import Header from "./Header";
 import theme from "../styles/DefaultTheme";
 import { StyleProp, ViewStyle } from "react-native";
 
-interface Props {
+type Props = {
   title: string;
   buttonText: string;
   icon: string;
   onPress?: () => void;
   style?: StyleProp<ViewStyle>;
   theme: typeof theme;
-}
+};
 
 const HeaderMedium: React.FC<Props> = ({
   title,

--- a/src/components/HeaderOverline.tsx
+++ b/src/components/HeaderOverline.tsx
@@ -10,14 +10,14 @@ import Header from "./Header";
 import theme from "../styles/DefaultTheme";
 import { StyleProp, ViewStyle } from "react-native";
 
-interface Props {
+type Props = {
   title: string;
   buttonText: string;
   icon: string;
   onPress?: () => void;
   style?: StyleProp<ViewStyle>;
   theme: typeof theme;
-}
+};
 
 const HeaderOverline: React.FC<Props> = ({
   title,

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -18,12 +18,12 @@ import {
 // This must use require to work in both web as a published project and in Snack
 const VectorIcons = require("@expo/vector-icons");
 
-interface Props extends ViewProps {
+type Props = {
   name: string | number | { uri: string };
   color?: string;
   size: number;
   style?: StyleProp<ImageStyle>;
-}
+} & ViewProps;
 
 const Icon: React.FC<Props> = ({ name, color, size, style, ...rest }) => {
   if (!name) return null;

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -16,8 +16,9 @@ import {
   PROP_TYPES,
 } from "../core/component-types";
 import themeT from "../styles/DefaultTheme";
+import { FocusProps } from "src/types";
 
-interface Props {
+type Props = {
   icon?: string;
   color?: string;
   size?: number;
@@ -27,7 +28,7 @@ interface Props {
   onPress: () => void;
   theme: typeof themeT;
   style?: StyleProp<ViewStyle>;
-}
+} & FocusProps;
 
 const IconButton: React.FC<Props> = ({
   icon,

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -16,7 +16,6 @@ import {
   PROP_TYPES,
 } from "../core/component-types";
 import themeT from "../styles/DefaultTheme";
-import { FocusProps } from "src/types";
 
 type Props = {
   icon?: string;
@@ -28,7 +27,7 @@ type Props = {
   onPress: () => void;
   theme: typeof themeT;
   style?: StyleProp<ViewStyle>;
-} & FocusProps;
+};
 
 const IconButton: React.FC<Props> = ({
   icon,

--- a/src/components/Picker/Picker.tsx
+++ b/src/components/Picker/Picker.tsx
@@ -12,10 +12,10 @@ import {
   FIELD_NAME,
 } from "../../core/component-types";
 
-interface Props extends PickerComponentProps {
+type Props = {
   placeholder?: string;
   value: string;
-}
+} & PickerComponentProps;
 
 const Picker: React.FC<Props> = ({
   options = [],

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -20,7 +20,7 @@ const INDETERMINATE_WIDTH_FACTOR = 0.3;
 const BAR_WIDTH_ZERO_POSITION =
   INDETERMINATE_WIDTH_FACTOR / (1 + INDETERMINATE_WIDTH_FACTOR);
 
-interface Props extends ViewProps {
+type Props = {
   borderColor?: string;
   borderRadius?: number;
   borderWidth?: number;
@@ -37,7 +37,7 @@ interface Props extends ViewProps {
   useNativeDriver?: boolean;
   animationConfig?: Animated.AnimationConfig;
   animationType?: "decay" | "timing" | "spring";
-}
+} & ViewProps;
 
 interface State {
   width: number;

--- a/src/components/ProgressCircle.tsx
+++ b/src/components/ProgressCircle.tsx
@@ -11,7 +11,7 @@ import { withTheme } from "../core/theming";
 import themeT from "../styles/DefaultTheme";
 import { colorTypes } from "../types";
 
-interface Props {
+type Props = {
   progress?: number;
   style?: StyleProp<ViewStyle>;
   color?: colorTypes;
@@ -22,7 +22,7 @@ interface Props {
   textStyle?: StyleProp<TextStyle>;
   thickness?: number;
   theme: typeof themeT;
-}
+};
 
 const ProgressCircle: React.FC<Props> = ({
   progress = 0.5,

--- a/src/components/ProgressIndicator.tsx
+++ b/src/components/ProgressIndicator.tsx
@@ -10,7 +10,7 @@ import {
 import themeT from "../styles/DefaultTheme";
 import { colorTypes } from "../types";
 
-interface Props {
+type Props = {
   numberOfSteps: number;
   currentStep: number;
   currentStepStrokeWidth?: number;
@@ -25,7 +25,7 @@ interface Props {
   unfinishedColor?: colorTypes;
   finishedColor?: colorTypes;
   theme: typeof themeT;
-}
+};
 
 const ProgressIndicator: React.FC<Props> = ({
   numberOfSteps,

--- a/src/components/RadioButton.tsx
+++ b/src/components/RadioButton.tsx
@@ -6,8 +6,9 @@ import { GROUPS, COMPONENT_TYPES, FORM_TYPES } from "../core/component-types";
 import Config from "./Config";
 import IconButton from "./IconButton";
 import themeT from "../styles/DefaultTheme";
+import { FocusProps } from "src/types";
 
-interface Props {
+type Props = {
   selected: boolean;
   disabled?: boolean;
   color?: string;
@@ -15,7 +16,7 @@ interface Props {
   onPress?: () => void;
   theme: typeof themeT;
   style?: StyleProp<ViewStyle>;
-}
+} & FocusProps;
 
 const RadioButton: React.FC<Props> = ({
   selected,
@@ -24,6 +25,7 @@ const RadioButton: React.FC<Props> = ({
   unselectedColor,
   onPress = () => {},
   style,
+  ...rest
 }) => {
   return (
     <IconButton
@@ -37,6 +39,7 @@ const RadioButton: React.FC<Props> = ({
       disabled={disabled}
       onPress={() => onPress()}
       size={Config.radioButtonSize}
+      {...rest}
     />
   );
 };

--- a/src/components/RadioButton.tsx
+++ b/src/components/RadioButton.tsx
@@ -6,7 +6,6 @@ import { GROUPS, COMPONENT_TYPES, FORM_TYPES } from "../core/component-types";
 import Config from "./Config";
 import IconButton from "./IconButton";
 import themeT from "../styles/DefaultTheme";
-import { FocusProps } from "src/types";
 
 type Props = {
   selected: boolean;
@@ -16,7 +15,7 @@ type Props = {
   onPress?: () => void;
   theme: typeof themeT;
   style?: StyleProp<ViewStyle>;
-} & FocusProps;
+};
 
 const RadioButton: React.FC<Props> = ({
   selected,

--- a/src/components/RadioButtonFieldGroup.tsx
+++ b/src/components/RadioButtonFieldGroup.tsx
@@ -12,7 +12,7 @@ interface RadioButtonOption {
   value: string;
 }
 
-interface Props {
+type Props = {
   options: RadioButtonOption[];
   label?: string;
   onSelect?: (value: string) => void;
@@ -26,7 +26,7 @@ interface Props {
   itemStyle?: StyleProp<ViewStyle>;
   itemLabelStyle?: StyleProp<TextStyle>;
   theme: typeof themeT;
-}
+};
 
 const RadioButtonFieldGroup: React.FC<Props> = ({
   options,

--- a/src/components/RadioButtonFieldRow.tsx
+++ b/src/components/RadioButtonFieldRow.tsx
@@ -13,7 +13,7 @@ import { View } from "react-native";
 import Text from "./Text";
 import { colorTypes } from "../types";
 
-interface Props {
+type Props = {
   label: string;
   backgroundColor?: colorTypes;
   labelColor?: colorTypes;
@@ -23,7 +23,7 @@ interface Props {
   onPress?: () => void;
   selected: boolean;
   theme: typeof themeT;
-}
+};
 
 const RadioButtonFieldRow: React.FC<Props> = ({
   label,

--- a/src/components/RadioButtonGroup.tsx
+++ b/src/components/RadioButtonGroup.tsx
@@ -25,7 +25,7 @@ interface RadioButtonOption {
   icon?: string;
 }
 
-interface Props {
+type Props = {
   direction?: "horizontal" | "vertical";
   options?: RadioButtonOption[];
   activeColor?: colorTypes;
@@ -41,7 +41,7 @@ interface Props {
   value: string;
   onSelect?: (label: string) => void;
   theme: typeof themeT;
-}
+};
 const RadioButtonGroup: React.FC<Props> = ({
   direction = "horizontal",
   options = [],

--- a/src/components/Row.tsx
+++ b/src/components/Row.tsx
@@ -12,7 +12,7 @@ import { withTheme } from "../core/theming";
 import Config from "./Config";
 import theme from "../styles/DefaultTheme";
 
-interface Props {
+type Props = {
   titleTypeStyle?: StyleProp<TextStyle>;
   titleColor?: string;
   subtitleTypeStyle?: StyleProp<TextStyle>;
@@ -24,7 +24,7 @@ interface Props {
   right?: () => React.ReactNode;
   style?: StyleProp<ViewStyle>;
   theme: typeof theme;
-}
+};
 
 const Row: React.FC<Props> = ({
   titleTypeStyle,

--- a/src/components/RowBodyCheckbox.tsx
+++ b/src/components/RowBodyCheckbox.tsx
@@ -10,7 +10,7 @@ import Checkbox from "./Checkbox";
 import theme from "../styles/DefaultTheme";
 import { StyleProp, ViewStyle } from "react-native";
 
-interface Props {
+type Props = {
   title?: string;
   subtitle?: string;
   style?: StyleProp<ViewStyle>;
@@ -18,7 +18,7 @@ interface Props {
   onPress?: () => void;
   color?: string;
   theme: typeof theme;
-}
+};
 
 const RowBodyCheckbox: React.FC<Props> = ({
   title,

--- a/src/components/RowBodyIcon.tsx
+++ b/src/components/RowBodyIcon.tsx
@@ -12,13 +12,13 @@ import Config from "./Config";
 import theme from "../styles/DefaultTheme";
 import { StyleProp, ViewStyle } from "react-native";
 
-interface Props {
+type Props = {
   title?: string;
   subtitle?: string;
   icon: string;
   style?: StyleProp<ViewStyle>;
   theme: typeof theme;
-}
+};
 
 const RowBodyIcon: React.FC<Props> = ({
   title,

--- a/src/components/RowBodySwitch.tsx
+++ b/src/components/RowBodySwitch.tsx
@@ -10,7 +10,7 @@ import Switch from "./Switch";
 import theme from "../styles/DefaultTheme";
 import { StyleProp, ViewStyle } from "react-native";
 
-interface Props {
+type Props = {
   title?: string;
   subtitle?: string;
   style?: StyleProp<ViewStyle>;
@@ -18,7 +18,7 @@ interface Props {
   onValueChange?: (value: boolean) => void;
   color?: string;
   theme: typeof theme;
-}
+};
 
 const RowBodySwitch: React.FC<Props> = ({
   title,

--- a/src/components/RowHeadlineImageCaption.tsx
+++ b/src/components/RowHeadlineImageCaption.tsx
@@ -10,14 +10,14 @@ import {
 import Row from "./Row";
 import theme from "../styles/DefaultTheme";
 
-interface Props {
+type Props = {
   title?: string;
   subtitle?: string;
   caption?: string;
   image: string | Blob;
   style?: StyleProp<ViewStyle>;
   theme: typeof theme;
-}
+};
 
 const RowHeadlineImageCaption: React.FC<Props> = ({
   title,

--- a/src/components/RowHeadlineImageIcon.tsx
+++ b/src/components/RowHeadlineImageIcon.tsx
@@ -8,7 +8,7 @@ import Config from "./Config";
 import theme from "../styles/DefaultTheme";
 import { StyleProp, ViewStyle } from "react-native";
 
-interface Props {
+type Props = {
   title?: string;
   image: string | Blob;
   subtitle?: string;
@@ -16,7 +16,7 @@ interface Props {
   icon: string;
   style?: StyleProp<ViewStyle>;
   theme: typeof theme;
-}
+};
 
 const RowHeadlineImageIcon: React.FC<Props> = ({
   title,

--- a/src/components/ScreenContainer.tsx
+++ b/src/components/ScreenContainer.tsx
@@ -11,13 +11,13 @@ import {
 import { withTheme } from "../core/theming";
 import Config from "./Config";
 import themeT from "../styles/DefaultTheme";
-interface Props {
+type Props = {
   children?: React.ReactNode;
   style?: StyleProp<ViewStyle>;
   theme: typeof themeT;
   hasSafeArea?: boolean;
   scrollable?: boolean;
-}
+};
 
 class ScreenContainer extends React.Component<Props> {
   renderScrollableSafeAreaView(themeStyles: ViewStyle) {

--- a/src/components/Slider.tsx
+++ b/src/components/Slider.tsx
@@ -13,7 +13,7 @@ import { StyleProp, ViewStyle } from "react-native";
 import themeT from "../styles/DefaultTheme";
 import { colorTypes } from "../types";
 
-export interface Props {
+export type Props = {
   style?: StyleProp<ViewStyle>;
   value?: number;
   minimumTrackTintColor: colorTypes;
@@ -30,7 +30,7 @@ export interface Props {
   //trackBorderRadius?: number;
   //thumbBorderRadius?: number;
   //thumbSize: number;
-}
+};
 
 const Slider: React.FC<Props> = ({
   style = { height: 4 },

--- a/src/components/StarRating.tsx
+++ b/src/components/StarRating.tsx
@@ -4,13 +4,13 @@ import Icon from "./Icon";
 import { withTheme } from "../core/theming";
 import theme from "../styles/DefaultTheme";
 
-interface Props {
+type Props = {
   starSize?: number;
   maxStars?: number;
   rating?: number;
   theme: typeof theme;
   style?: StyleProp<ViewStyle>;
-}
+};
 
 const StarRating: React.FC<Props> = ({
   starSize = 16,

--- a/src/components/StepIndicator.tsx
+++ b/src/components/StepIndicator.tsx
@@ -42,18 +42,18 @@ interface CustomStyles {
   labelFontFamily?: string;
 }
 
-interface Props {
+type Props = {
   stepCount: number;
   currentPosition: number;
   customStyles: CustomStyles;
-}
+};
 
-interface State {
+type State = {
   width: number;
   height: number;
   progressBarSize: number;
   customStyles: CustomStyles;
-}
+};
 
 export default class StepIndicator extends Component<Props, State> {
   constructor(props: Props) {

--- a/src/components/Stepper.tsx
+++ b/src/components/Stepper.tsx
@@ -12,7 +12,7 @@ import {
 import IconButton from "./IconButton";
 import theme from "../styles/DefaultTheme";
 
-interface Props {
+type Props = {
   value?: number;
   theme: typeof theme;
   style?: StyleProp<ViewStyle>;
@@ -21,7 +21,7 @@ interface Props {
   iconColor?: string;
   borderRadius?: number;
   typeStyle?: StyleProp<TextStyle>;
-}
+};
 
 const Stepper: React.FC<Props> = ({
   value = 0,

--- a/src/components/Switch.tsx
+++ b/src/components/Switch.tsx
@@ -10,13 +10,13 @@ import {
 } from "../core/component-types";
 import themeT from "../styles/DefaultTheme";
 
-interface Props extends SwitchProps {
+type Props = {
   value: boolean;
   disabled?: boolean;
   onValueChange?: (value: boolean) => void;
   color?: string;
   theme: typeof themeT;
-}
+} & SwitchProps;
 
 const Switch: React.FC<Props> = ({
   value,

--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -9,9 +9,9 @@ import {
 } from "../core/component-types";
 import themeT from "../styles/DefaultTheme";
 
-interface Props extends TextProps {
+type Props = {
   theme: typeof themeT;
-}
+} & TextProps;
 
 class Text extends React.Component<Props> {
   _root: any;

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -24,7 +24,6 @@ import {
   FIELD_NAME,
   TEXT_INPUT_PROPS,
 } from "../core/component-types";
-import { FocusProps } from "../types";
 
 import Icon from "./Icon";
 import theme from "../styles/DefaultTheme";

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -24,6 +24,7 @@ import {
   FIELD_NAME,
   TEXT_INPUT_PROPS,
 } from "../core/component-types";
+import { FocusProps } from "../types";
 
 import Icon from "./Icon";
 import theme from "../styles/DefaultTheme";
@@ -34,7 +35,7 @@ const FOCUS_ANIMATION_DURATION = 150;
 const BLUR_ANIMATION_DURATION = 180;
 const ICON_SIZE = 24;
 
-export interface Props extends TextInputProps {
+export type Props = {
   type?: "solid" | "underline";
   disabled?: boolean;
   label?: string;
@@ -49,7 +50,8 @@ export interface Props extends TextInputProps {
   render?: (
     props: TextInputProps & { ref: (c: NativeTextInput) => void }
   ) => React.ReactNode;
-}
+} & TextInputProps &
+  FocusProps;
 
 interface State {
   labeled: Animated.Value;

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -70,3 +70,8 @@ export type $RemoveChildren<T extends React.ComponentType<any>> = $Omit<
 >;
 
 export type EllipsizeProp = "head" | "middle" | "tail" | "clip";
+
+export interface FocusProps {
+  "data-focus"?: boolean;
+  "data-content"?: string;
+}

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -70,8 +70,3 @@ export type $RemoveChildren<T extends React.ComponentType<any>> = $Omit<
 >;
 
 export type EllipsizeProp = "head" | "middle" | "tail" | "clip";
-
-export interface FocusProps {
-  "data-focus"?: boolean;
-  "data-content"?: string;
-}


### PR DESCRIPTION
Allow destructuring props being passed into Container was the origin of this PR, later I found out that some components miss that too, so I added to a bunch of them.

- Added rest on `AvatarEdir, Button, Card, CardBlock, CardContainer, CardContainerRating, CardInline, Carousel, Checkbox Android / IOS, CircularProgress, CardContainer, DatePicker, Divider, StepIndicator`.
- Migrated a bunch of Props to type alias instead of interfaces:  https://medium.com/@martin_hotell/interface-vs-type-alias-in-typescript-2-7-2a8f1777af4c#722b
