### PR TITLE
Fix iOS DateTimePicker closing too early bug

### DIFF
--- a/packages/react-native-jigsaw/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-native-jigsaw/src/components/DatePicker/DatePicker.tsx
@@ -131,7 +131,7 @@ const DatePicker: React.FC<Props> = ({
                 isVisible={pickerVisible}
                 toggleVisibility={toggleVisibility}
                 onChange={(_event: any, data: any) => {
-                  toggleVisibility();
+                  Platform.OS === 'ios' ? null : toggleVisibility();
                   onDateChange(data);
                 }}
               />

--- a/packages/react-native-jigsaw/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-native-jigsaw/src/components/DatePicker/DatePicker.tsx
@@ -131,7 +131,7 @@ const DatePicker: React.FC<Props> = ({
                 isVisible={pickerVisible}
                 toggleVisibility={toggleVisibility}
                 onChange={(_event: any, data: any) => {
-                  Platform.OS === 'ios' ? null : toggleVisibility();
+                  Platform.OS === "ios" ? null : toggleVisibility();
                   onDateChange(data);
                 }}
               />


### PR DESCRIPTION
Fixes iOS DateTimePicker bug where the time selection modal would close every time the value changed (whenever the scroll wheel stopped moving). 1-line PR.