### PR TITLE
chore(icon): icon `name` should be `data` prop

### DIFF
--- a/packages/react-native-jigsaw/src/components/Icon.tsx
+++ b/packages/react-native-jigsaw/src/components/Icon.tsx
@@ -97,7 +97,7 @@ export const SEED_DATA = {
   supports_list_render: false,
   props: {
     name: {
-      group: GROUPS.basic,
+      group: GROUPS.data,
       label: "Name",
       description: "Name of the icon",
       formType: FORM_TYPES.icon,


### PR DESCRIPTION
The name field needs to live under the data tab in the builder and not in the config tab of the builder