### PR TITLE
fix: button margins going inside elevation

### DIFF
--- a/packages/react-native-jigsaw/src/components/Button.tsx
+++ b/packages/react-native-jigsaw/src/components/Button.tsx
@@ -146,15 +146,38 @@ const Button: React.FC<Props> = ({
     },
   ];
 
+  const {
+    margin,
+    marginEnd,
+    marginTop,
+    marginLeft,
+    marginRight,
+    marginBottom,
+    marginHorizontal,
+    marginVertical,
+    ...innerStyles
+  } = StyleSheet.flatten(style);
+
+  const margins = {
+    margin,
+    marginEnd,
+    marginTop,
+    marginLeft,
+    marginRight,
+    marginBottom,
+    marginHorizontal,
+    marginVertical,
+  };
+
   return (
-    <Elevation style={{ elevation, alignSelf: "stretch" }}>
+    <Elevation style={{ elevation, alignSelf: "stretch", ...margins }}>
       <Touchable
         {...rest}
         onPress={onPress}
         accessibilityState={{ disabled }}
         accessibilityRole="button"
         disabled={disabled || loading}
-        style={[styles.button, buttonStyle, style]}
+        style={[styles.button, buttonStyle, innerStyles]}
       >
         <View style={styles.content}>
           {icon && loading !== true ? (


### PR DESCRIPTION
See: https://community.draftbit.com/c/help/button-margin-causes-background-to-be-wonky

![image](https://user-images.githubusercontent.com/2559043/114793102-432e0a00-9d4f-11eb-9562-1e23b4800cb3.png)
