### PR TITLE
fix(button): expose text align on button varieties

### DIFF
--- a/packages/react-native-jigsaw/src/components/Button.tsx
+++ b/packages/react-native-jigsaw/src/components/Button.tsx
@@ -117,7 +117,7 @@ function Base({
           size={CONSTANTS.icon}
         />
       ) : null}
-      <Text style={titleStyles}>{title}</Text>
+      <Text style={[styles.title, titleStyles]}>{title}</Text>
     </Pressable>
   );
 }
@@ -179,7 +179,6 @@ const styles = StyleSheet.create({
     position: "relative",
     flexDirection: "row",
     alignItems: "center",
-    justifyContent: "center",
     minHeight: CONSTANTS.baseHeight,
     paddingHorizontal: 12,
     fontFamily: "System",
@@ -197,7 +196,6 @@ const styles = StyleSheet.create({
   },
   bare: {
     backgroundColor: "transparent",
-    alignSelf: "flex-start",
     padding: 0,
     minHeight: undefined,
   },
@@ -217,6 +215,9 @@ const styles = StyleSheet.create({
         alignSelf: "center",
       },
     }),
+  },
+  title: {
+    flex: 1,
   },
 });
 
@@ -253,6 +254,7 @@ export const SEED_DATA = [
       ...LAYOUT,
       backgroundColor: "transparent",
       borderWidth: 1,
+      textAlign: "center",
     },
     props: SEED_DATA_PROPS,
   },
@@ -263,6 +265,7 @@ export const SEED_DATA = [
     layout: {
       ...LAYOUT,
       backgroundColor: "primary",
+      textAlign: "center",
     },
     props: SEED_DATA_PROPS,
   },


### PR DESCRIPTION
Allows user to set text align property on button/link components, and sets seed data defaults

Example: https://snack.expo.io/@donald/(draftbit)-basic-profile