### PR TITLE
Radio button group fixes

### DIFF
--- a/packages/example/src/RadioButtonExample.js
+++ b/packages/example/src/RadioButtonExample.js
@@ -18,25 +18,25 @@ const SingleRadioButtonWrapper = ({ label, children }) => (
   </View>
 );
 
-const RadioButtonGroupExample = ({ theme }) => {
+const RadioButtonGroupExample = () => {
   const [selected, onSelect] = React.useState("1");
   const handleSelect = (value) => onSelect(value);
   return (
     <Container>
       <Section title="Single Radio Buttons">
         <Row>
-          <LoneRadioButtonWrapper label="Selected">
+          <SingleRadioButtonWrapper label="Selected">
             <RadioButton selected />
-          </LoneRadioButtonWrapper>
-          <LoneRadioButtonWrapper label="Unselected">
+          </SingleRadioButtonWrapper>
+          <SingleRadioButtonWrapper label="Unselected">
             <RadioButton />
-          </LoneRadioButtonWrapper>
-          <LoneRadioButtonWrapper label="Disabled">
+          </SingleRadioButtonWrapper>
+          <SingleRadioButtonWrapper label="Disabled">
             <RadioButton selected disabled />
-          </LoneRadioButtonWrapper>
-          <LoneRadioButtonWrapper label="Custom color">
-            <RadioButton selected color={theme.colors.error} />
-          </LoneRadioButtonWrapper>
+          </SingleRadioButtonWrapper>
+          <SingleRadioButtonWrapper label="Custom color">
+            <RadioButton selected color="error" />
+          </SingleRadioButtonWrapper>
         </Row>
       </Section>
 
@@ -154,4 +154,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default withTheme(RadioButtonGroupExample);
+export default RadioButtonGroupExample;

--- a/packages/example/src/RadioButtonExample.js
+++ b/packages/example/src/RadioButtonExample.js
@@ -1,10 +1,5 @@
 import * as React from "react";
-import {
-  Icon,
-  RadioButton,
-  Row,
-  RadioButtonFieldGroup,
-} from "@draftbit/ui";
+import { Icon, RadioButton, Row, RadioButtonFieldGroup } from "@draftbit/ui";
 import Section, { Container } from "./Section";
 import { Text, View, StyleSheet } from "react-native";
 

--- a/packages/example/src/RadioButtonExample.js
+++ b/packages/example/src/RadioButtonExample.js
@@ -4,7 +4,6 @@ import {
   RadioButton,
   Row,
   RadioButtonFieldGroup,
-  withTheme,
 } from "@draftbit/ui";
 import Section, { Container } from "./Section";
 import { Text, View, StyleSheet } from "react-native";

--- a/packages/react-native-jigsaw/src/components/FieldRadioButton.tsx
+++ b/packages/react-native-jigsaw/src/components/FieldRadioButton.tsx
@@ -6,15 +6,16 @@ import Touchable from "./Touchable";
 import RadioButton from "./RadioButton/RadioButton";
 
 import { GROUPS, COMPONENT_TYPES, FORM_TYPES } from "../core/component-types";
-import themeT from "../styles/DefaultTheme";
+import type { Theme } from "../styles/DefaultTheme";
+import { colorTypes } from "../types";
 
 type Props = {
   onPress?: () => void;
   title?: string;
   selected: boolean;
   disabled?: boolean;
-  color: string;
-  theme: typeof themeT;
+  color: colorTypes;
+  theme: Theme;
 };
 
 const FieldRadioButton: React.FC<Props> = ({
@@ -34,12 +35,7 @@ const FieldRadioButton: React.FC<Props> = ({
   return (
     <Touchable onPress={() => onPress()} disabled={disabled}>
       <View style={{ flexDirection: "row" }}>
-        <RadioButton
-          theme={theme}
-          color={color}
-          selected={selected}
-          disabled={disabled}
-        />
+        <RadioButton color={color} selected={selected} disabled={disabled} />
         <Text
           style={[
             theme.typography.body1,
@@ -59,7 +55,6 @@ export const SEED_DATA = {
   name: "Field Radio Button",
   tag: "FieldRadioButton",
   category: COMPONENT_TYPES.deprecated,
-  preview_image_url: "{CLOUDINARY_URL}/Field_Radio.png",
   props: {
     title: {
       group: GROUPS.data,

--- a/packages/react-native-jigsaw/src/components/RadioButton/RadioButton.tsx
+++ b/packages/react-native-jigsaw/src/components/RadioButton/RadioButton.tsx
@@ -12,12 +12,14 @@ import {
 } from "../../core/component-types";
 import Config from "../Config";
 import IconButton from "../IconButton";
+import { colorTypes } from "../../types";
+import { useTheme } from "../../core/theming";
 
 export type RadioButtonProps = {
   selected: boolean;
   disabled?: boolean;
-  color?: string;
-  unselectedColor?: string;
+  color?: colorTypes;
+  unselectedColor?: colorTypes;
   onPress?: () => void;
   style?: StyleProp<ViewStyle>;
   size?: number;
@@ -28,8 +30,8 @@ export type RadioButtonProps = {
 const RadioButton: React.FC<RadioButtonProps> = ({
   selected,
   disabled = false,
-  color,
-  unselectedColor,
+  color = "primary",
+  unselectedColor = "primary",
   onPress = () => {},
   size = Config.radioButtonSize,
   selectedIcon = "MaterialIcons/radio-button-checked",
@@ -37,10 +39,11 @@ const RadioButton: React.FC<RadioButtonProps> = ({
   style,
   ...rest
 }) => {
+  const { colors } = useTheme();
   return (
     <IconButton
       icon={selected ? selectedIcon : unselectedIcon}
-      color={selected ? color : unselectedColor}
+      color={selected ? colors[color] : colors[unselectedColor]}
       disabled={disabled}
       onPress={onPress}
       size={size}

--- a/packages/react-native-jigsaw/src/components/RadioButton/RadioButtonRow.tsx
+++ b/packages/react-native-jigsaw/src/components/RadioButton/RadioButtonRow.tsx
@@ -5,6 +5,7 @@ import {
   StyleSheet,
   TextStyle,
   View,
+  Platform,
 } from "react-native";
 import RadioButton, {
   SEED_DATA as RADIO_BUTTON_SEED_DATA,
@@ -36,7 +37,7 @@ export interface RadioButtonRowProps extends Omit<RadioButtonProps, "onPress"> {
 }
 
 const getRadioButtonAlignment = (
-  parentDirection: GroupDirection,
+  parentDirection: GroupDirection | undefined,
   direction: Direction
 ) => {
   if (parentDirection === GroupDirection.Horizontal) {
@@ -67,6 +68,7 @@ const RadioButtonRow: React.FC<RadioButtonRowProps> = ({
   labelStyle,
   radioButtonStyle,
   direction = Direction.Row,
+  selected,
   style,
   ...rest
 }) => {
@@ -78,7 +80,7 @@ const RadioButtonRow: React.FC<RadioButtonRowProps> = ({
 
   const handlePress = () => {
     onPress(value);
-    onValueChange(value);
+    onValueChange && onValueChange(value);
   };
 
   return (
@@ -104,11 +106,10 @@ const RadioButtonRow: React.FC<RadioButtonRowProps> = ({
         }}
       >
         <RadioButton
+          selected={selected || contextValue === value}
           onPress={handlePress}
           style={radioButtonStyle}
           {...rest}
-          /* Must stay below rest */
-          selected={contextValue === value}
         />
       </View>
     </Touchable>
@@ -123,6 +124,12 @@ const styles = StyleSheet.create({
     minHeight: 50,
     paddingEnd: 20,
     flex: 1,
+    ...Platform.select({
+      web: {
+        cursor: "pointer",
+        userSelect: "none",
+      },
+    }),
   },
   label: {
     flex: 3,

--- a/packages/react-native-jigsaw/src/components/RadioButton/context.tsx
+++ b/packages/react-native-jigsaw/src/components/RadioButton/context.tsx
@@ -7,13 +7,13 @@ export enum Direction {
 interface RadioButtonGroupContext {
   onValueChange: (value: string) => void;
   value: string;
-  direction: Direction;
+  direction?: Direction;
 }
 
 export const radioButtonGroupContext = createContext<RadioButtonGroupContext>({
   onValueChange: () => {},
   value: "",
-  direction: Direction.Horizontal,
+  direction: undefined,
 });
 
 export function useRadioButtonGroupContext() {

--- a/packages/react-native-jigsaw/src/components/RadioButton/index.tsx
+++ b/packages/react-native-jigsaw/src/components/RadioButton/index.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import RadioButtonGroup, { RadioButtonGroupProps } from "./RadioButtonGroup";
 import RadioButtonRow, { RadioButtonRowProps } from "./RadioButtonRow";
 import { RadioButtonProps, default as SingleRadioButton } from "./RadioButton";
-import { withTheme } from "../../core/theming";
 interface RadioButtonComposition {
   Row: React.FC<RadioButtonRowProps>;
   Group: React.FC<RadioButtonGroupProps>;
@@ -14,4 +13,4 @@ const RadioButton: React.FC<RadioButtonProps> &
   Row: RadioButtonRow,
 });
 
-export default withTheme(RadioButton);
+export default RadioButton;


### PR DESCRIPTION
- Add option to pass `selected` prop to RadioButton.Row in order to allow the component to be used separately (outside RadioButton.Group). If passed a "selected" value, the value of the RadioButton.Group will be ignored.
- Use `useTheme` hook instead of `withTheme` HOC in RadioButton in order to avoid `Theme` type incompatibilities 
- Use `colorTypes` instead of plain strings for theming
- Removed unnecessary `withTheme` usage for some components
- Fix linting errors and references