### PR TITLE
fix: fix inability to flex inside container

### DIFF
--- a/packages/react-native-jigsaw/src/components/Container.tsx
+++ b/packages/react-native-jigsaw/src/components/Container.tsx
@@ -48,8 +48,17 @@ const Container: React.FC<Props> = ({
   theme, // eslint-disable-line @typescript-eslint/no-unused-vars
   ...rest
 }) => {
-  const { flexDirection, justifyContent, alignItems, ...styleProp } =
-    StyleSheet.flatten(style) || {};
+  const {
+    flex,
+    flexGrow,
+    flexWrap,
+    flexBasis,
+    flexShrink,
+    flexDirection,
+    justifyContent,
+    alignItems,
+    ...styleProp
+  } = StyleSheet.flatten(style) || {};
 
   const containerStyle: StyleProp<ViewStyle> = {
     backgroundColor,
@@ -61,6 +70,11 @@ const Container: React.FC<Props> = ({
 
   const innerStyle: StyleProp<ViewStyle> = {
     paddingHorizontal: useThemeGutterPadding ? 16 : 0,
+    flex,
+    flexGrow,
+    flexWrap,
+    flexBasis,
+    flexShrink,
     flexDirection,
     justifyContent,
     alignItems,

--- a/packages/react-native-jigsaw/src/components/Container.tsx
+++ b/packages/react-native-jigsaw/src/components/Container.tsx
@@ -55,6 +55,7 @@ const Container: React.FC<Props> = ({
     flexBasis,
     flexShrink,
     flexDirection,
+    alignContent,
     justifyContent,
     alignItems,
     ...styleProp
@@ -76,6 +77,7 @@ const Container: React.FC<Props> = ({
     flexBasis,
     flexShrink,
     flexDirection,
+    alignContent,
     justifyContent,
     alignItems,
   };


### PR DESCRIPTION
See linear for details.

This *shouldn't* breaky other layouts, since there's only ever one div inside
the external container.  But maybe a good idea would be to start introducing 
https://www.npmjs.com/package/jest-image-snapshot here as a way to avoid
regresssions like this in the future -- a lot of this actually is pure design
that benefits most from this kind of testing.

Also:
Fixes: P-2275
