### PR TITLE
Ensure newly created RadioButtonRows don't appear erroneously selected

### DIFF
--- a/packages/core/src/components/RadioButton/RadioButtonRow.tsx
+++ b/packages/core/src/components/RadioButton/RadioButtonRow.tsx
@@ -119,7 +119,7 @@ const RadioButtonRow: React.FC<RadioButtonRowProps & IconSlot> = ({
       >
         <RadioButton
           Icon={Icon}
-          selected={selected || contextValue === value}
+          selected={selected || (contextValue != null && contextValue === value)}
           color={color}
           unselectedColor={unselectedColor}
           onPress={handlePress}

--- a/packages/core/src/components/RadioButton/RadioButtonRow.tsx
+++ b/packages/core/src/components/RadioButton/RadioButtonRow.tsx
@@ -119,7 +119,9 @@ const RadioButtonRow: React.FC<RadioButtonRowProps & IconSlot> = ({
       >
         <RadioButton
           Icon={Icon}
-          selected={selected || (contextValue != null && contextValue === value)}
+          selected={
+            selected || (contextValue != null && contextValue === value)
+          }
           color={color}
           unselectedColor={unselectedColor}
           onPress={handlePress}


### PR DESCRIPTION
This matches the functionality of RadioButton components