### PR TITLE
Add initialValue functionality to all form components

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -51,6 +51,7 @@ import SwitchExample from "./SwitchExample";
 import StepperExample from "./StepperExample";
 
 import TextFieldExample from "./TextFieldExample";
+import TextInputExample from "./TextInputExample";
 import CheckboxExample from "./CheckboxExample";
 import WebViewExample from "./WebViewExample";
 import AccordionExample from "./AccordionExample";
@@ -87,6 +88,7 @@ const ROUTES = {
   Switch: SwitchExample,
   Stepper: StepperExample,
   TextField: TextFieldExample,
+  TextInput: TextInputExample,
   WebView: WebViewExample,
 };
 

--- a/example/src/CheckboxExample.js
+++ b/example/src/CheckboxExample.js
@@ -21,6 +21,7 @@ const SingleCheckboxWrapper = ({ label, children }) => (
 
 const CheckboxExample = ({ theme }) => {
   const [checked, setChecked] = React.useState(true);
+  const [checked2, setChecked2] = React.useState(true);
   const [selectedValues, setSelectedValues] = React.useState([]);
 
   const handleValueSelected = (value, selected) => {
@@ -33,7 +34,7 @@ const CheckboxExample = ({ theme }) => {
     }
   };
 
-  const handlePress = () => setChecked((prevState) => !prevState);
+  const handlePress = (value) => setChecked(() => value);
 
   return (
     <ScreenContainer hasSafeArea={false} scrollable={true}>
@@ -72,6 +73,13 @@ const CheckboxExample = ({ theme }) => {
               status={checked ? "checked" : "unchecked"}
               onPress={handlePress}
               size={72}
+            />
+          </SingleCheckboxWrapper>
+          <SingleCheckboxWrapper label="Initial value">
+            <Checkbox
+              status={checked2 ? "checked" : "unchecked"}
+              onPress={(checked) => setChecked2(checked)}
+              initialValue={false}
             />
           </SingleCheckboxWrapper>
         </Row>

--- a/example/src/CheckboxExample.js
+++ b/example/src/CheckboxExample.js
@@ -34,7 +34,7 @@ const CheckboxExample = ({ theme }) => {
     }
   };
 
-  const handlePress = (value) => setChecked(() => value);
+  const handlePress = (value) => setChecked(value);
 
   return (
     <ScreenContainer hasSafeArea={false} scrollable={true}>

--- a/example/src/DatePickerExample.js
+++ b/example/src/DatePickerExample.js
@@ -2,8 +2,12 @@ import * as React from "react";
 import { DatePicker, withTheme } from "@draftbit/ui";
 import Section, { Container } from "./Section";
 
+const FOUR_YEARS_AGO = new Date();
+FOUR_YEARS_AGO.setFullYear(FOUR_YEARS_AGO.getFullYear() - 4);
+
 function DatePickerExample({ theme }) {
   const [date, setDate] = React.useState(new Date());
+  const [date2, setDate2] = React.useState(new Date());
   const handleChange = (d) => setDate(d);
 
   return (
@@ -84,6 +88,15 @@ function DatePickerExample({ theme }) {
           type="solid"
           date={date}
           onDateChange={handleChange}
+        />
+
+        <DatePicker
+          label="Date with initial value"
+          placeholder="Select a date..."
+          type="solid"
+          date={date2}
+          onDateChange={(date) => setDate2(date)}
+          initialValue={FOUR_YEARS_AGO}
         />
       </Section>
     </Container>

--- a/example/src/DatePickerExample.js
+++ b/example/src/DatePickerExample.js
@@ -95,7 +95,7 @@ function DatePickerExample({ theme }) {
           placeholder="Select a date..."
           type="solid"
           date={date2}
-          onDateChange={(date) => setDate2(date)}
+          onDateChange={(d) => setDate2(d)}
           initialValue={FOUR_YEARS_AGO}
         />
       </Section>

--- a/example/src/FieldSearchBarFullExample.js
+++ b/example/src/FieldSearchBarFullExample.js
@@ -5,6 +5,7 @@ import Section, { Container } from "./Section";
 
 function FieldSearchBarFullExample({ theme }) {
   const [searchBarValue, setSearchBarValue] = React.useState(undefined);
+  const [searchBarValue2, setSearchBarValue2] = React.useState(undefined);
   return (
     <Container style={{ backgroundColor: theme.colors.background }}>
       <Section title="FieldSearchBarFull">
@@ -14,6 +15,13 @@ function FieldSearchBarFullExample({ theme }) {
           onChange={(value) => setSearchBarValue(value)}
         />
         <Text>Value: {searchBarValue}</Text>
+
+        <FieldSearchBarFull
+          placeholder="Example with initial value"
+          value={searchBarValue2}
+          onChange={(value) => setSearchBarValue2(value)}
+          initialValue="Replace this with your search"
+        />
       </Section>
     </Container>
   );

--- a/example/src/PickerExample.js
+++ b/example/src/PickerExample.js
@@ -4,6 +4,7 @@ import Section, { Container } from "./Section";
 
 function PickerExample({ theme }) {
   const [value, setValue] = React.useState("Audi");
+  const [value2, setValue2] = React.useState("Audi");
   const handleChange = (v) => setValue(v);
 
   return (
@@ -72,6 +73,22 @@ function PickerExample({ theme }) {
             backgroundColor: "red",
             padding: 16,
           }}
+        />
+      </Section>
+
+      <Section title="Picker - Underline with initial value">
+        <Picker
+          label="Make"
+          placeholder="Select a make..."
+          options={[
+            { value: "Audi", label: "Audi" },
+            { value: "BMW", label: "BMW" },
+            { value: "Cadillac", label: "Cadillac" },
+            { value: "Dodge", label: "Dodge" },
+          ]}
+          value={value2}
+          onValueChange={(v) => setValue2(v)}
+          initialValue="Dodge"
         />
       </Section>
 

--- a/example/src/RadioButtonExample.js
+++ b/example/src/RadioButtonExample.js
@@ -22,6 +22,7 @@ const SingleRadioButtonWrapper = ({ label, children }) => (
 
 const RadioButtonGroupExample = ({ theme }) => {
   const [selected, onSelect] = React.useState("1");
+  const [selected2, onSelect2] = React.useState("1");
   const handleSelect = (value) => onSelect(value);
   return (
     <ScreenContainer hasSafeArea={false} scrollable={true}>
@@ -141,6 +142,28 @@ const RadioButtonGroupExample = ({ theme }) => {
           <RadioButtonRow size={35} label="Second" value="2" />
           <RadioButtonRow size={35} label="Third" value="3" />
         </RadioButtonFieldGroup>
+      </Section>
+
+      <Section title="Single Radio Buttons with initial value">
+        <RadioButtonGroup
+          direction="horizontal"
+          onValueChange={(v) => onSelect2(v)}
+          value={selected2}
+          initialValue="2"
+        >
+          <SingleRadioButtonWrapper>
+            <RadioButton value="1" />
+          </SingleRadioButtonWrapper>
+          <SingleRadioButtonWrapper>
+            <RadioButton value="2" />
+          </SingleRadioButtonWrapper>
+          <SingleRadioButtonWrapper label="Disabled">
+            <RadioButton value="3" disabled />
+          </SingleRadioButtonWrapper>
+          <SingleRadioButtonWrapper label="Custom color">
+            <RadioButton value="4" color={theme.colors.error} />
+          </SingleRadioButtonWrapper>
+        </RadioButtonGroup>
       </Section>
     </ScreenContainer>
   );

--- a/example/src/SliderExample.js
+++ b/example/src/SliderExample.js
@@ -5,6 +5,7 @@ import Section, { Container } from "./Section";
 
 function SliderExample({ theme }) {
   const [value, setValue] = React.useState(4);
+  const [value2, setValue2] = React.useState(4);
   const handleChange = (v) => setValue(v);
 
   return (
@@ -26,6 +27,22 @@ function SliderExample({ theme }) {
           style={{ width: 200 }}
         />
         <Text style={{ fontSize: 24, marginTop: 24 }}>Value: {value}</Text>
+      </Section>
+
+      <Section title="Controlled with initial value">
+        <Slider
+          step={10}
+          maximumTrackTintColor={theme.colors.light}
+          minimumTrackTintColor={theme.colors.primary}
+          thumbTintColor={theme.colors.primary}
+          value={value2}
+          minimumValue={0}
+          maximumValue={100}
+          onValueChange={(v) => setValue2(v)}
+          initialValue={90}
+          style={{ width: 200 }}
+        />
+        <Text style={{ fontSize: 24, marginTop: 24 }}>Value: {value2}</Text>
       </Section>
     </Container>
   );

--- a/example/src/StepperExample.js
+++ b/example/src/StepperExample.js
@@ -4,6 +4,7 @@ import Section, { Container } from "./Section";
 
 function StepperExample({ theme }) {
   const [value, setValue] = React.useState(0);
+  const [value2, setValue2] = React.useState(0);
   const handleChange = (v) => setValue(v);
 
   return (
@@ -18,6 +19,14 @@ function StepperExample({ theme }) {
 
       <Section title="No Value">
         <Stepper />
+      </Section>
+
+      <Section title="With State and initialValue">
+        <Stepper
+          value={value2}
+          onChange={(v) => setValue2(v)}
+          initialValue={100}
+        />
       </Section>
     </Container>
   );

--- a/example/src/SwitchExample.js
+++ b/example/src/SwitchExample.js
@@ -4,6 +4,7 @@ import Section, { Container } from "./Section";
 
 function SwitchExample({ theme }) {
   const [value, toggle] = React.useState(false);
+  const [value2, setValue2] = React.useState(false);
   const handleChange = (v) => toggle(v);
 
   return (
@@ -22,6 +23,14 @@ function SwitchExample({ theme }) {
             fontSize: 24,
             fontWeight: "bold",
           }}
+        />
+      </Section>
+      <Section title="Enabled with initialValue">
+        <Switch
+          value={value2}
+          disabled={false}
+          initialValue={true}
+          onValueChange={(v) => setValue2(v)}
         />
       </Section>
     </Container>

--- a/example/src/TextFieldExample.js
+++ b/example/src/TextFieldExample.js
@@ -5,6 +5,8 @@ import Section, { Container } from "./Section";
 
 export default function TextFieldExample() {
   const [value, setText] = React.useState("Change me!");
+  const [value2, setText2] = React.useState("Change me!");
+  const [value3, setText3] = React.useState("Change me!");
   const handleChange = (text) => setText(text);
 
   return (
@@ -79,6 +81,13 @@ export default function TextFieldExample() {
               backgroundColor: "green",
             }}
           />
+          <TextField
+            type="solid"
+            label="Solid input with initial value"
+            value={value2}
+            onChangeText={(text) => setText2(text)}
+            initialValue="Hello world!!!!!"
+          />
         </Section>
 
         <Section title="Underline">
@@ -150,6 +159,13 @@ export default function TextFieldExample() {
               borderWidth: 2,
               backgroundColor: "green",
             }}
+          />
+          <TextField
+            type="underline"
+            label="Underline input with initial value"
+            value={value3}
+            onChangeText={(text) => setText3(text)}
+            initialValue="Hello world!!!!!"
           />
         </Section>
       </Container>

--- a/example/src/TextInputExample.js
+++ b/example/src/TextInputExample.js
@@ -1,0 +1,36 @@
+import * as React from "react";
+import { KeyboardAvoidingView } from "react-native";
+import { TextInput } from "@draftbit/ui";
+import Section, { Container } from "./Section";
+
+export default function TextInputExample() {
+  const [value, setText] = React.useState("Change me!");
+  const [value2, setText2] = React.useState("Change me!");
+  const handleChange = (text) => setText(text);
+
+  return (
+    <KeyboardAvoidingView behavior="padding" keyboardVerticalOffset={80}>
+      <Container>
+        <Section title="Text Input">
+          <TextInput
+            placeholder="Standard input"
+            value={value}
+            onChangeText={handleChange}
+          />
+          <TextInput
+            placeholder="Disabled input"
+            disabled={true}
+            value={value}
+            onChangeText={handleChange}
+          />
+          <TextInput
+            placeholder="Input with initial value"
+            value={value2}
+            onChangeText={(text) => setText2(text)}
+            initialValue="I'm an initial value!"
+          />
+        </Section>
+      </Container>
+    </KeyboardAvoidingView>
+  );
+}

--- a/example/src/ToggleButtonExample.js
+++ b/example/src/ToggleButtonExample.js
@@ -1,11 +1,13 @@
 import * as React from "react";
+import { Text } from "react-native";
 import { ToggleButton } from "@draftbit/ui";
 import Section, { Container, styles } from "./Section";
 
 export default function ToggleButtonExample() {
   const [toggled, setToggled] = React.useState(false);
-  const toggle = () => {
-    setToggled(!toggled);
+  const [toggled2, setToggled2] = React.useState(false);
+  const toggle = (toggled) => {
+    setToggled(toggled);
   };
   return (
     <Container>
@@ -23,6 +25,16 @@ export default function ToggleButtonExample() {
           height={70}
           toggled={toggled}
           onPress={toggle}
+        />
+        <Text>with initial value</Text>
+        <ToggleButton
+          style={{ margin: 5 }}
+          icon="file-download"
+          width={70}
+          height={70}
+          toggled={toggled2}
+          onPress={(toggled) => setToggled2(toggled)}
+          initialValue={true}
         />
       </Section>
     </Container>

--- a/packages/core/src/components/Checkbox/Checkbox.tsx
+++ b/packages/core/src/components/Checkbox/Checkbox.tsx
@@ -29,13 +29,14 @@ export enum CheckboxStatus {
 export interface CheckboxProps {
   status?: CheckboxStatus;
   disabled?: boolean;
-  onPress?: () => void;
+  onPress?: (checked: boolean) => void;
   color?: string;
   uncheckedColor?: string;
   indeterminateColor?: string;
   checkedIcon?: string;
   uncheckedIcon?: string;
   indeterminateIcon?: string;
+  initialValue?: boolean;
   size?: number;
   style?: StyleProp<ViewStyle>;
 }
@@ -49,6 +50,7 @@ const Checkbox: React.FC<CheckboxProps & TouchableHighlightProps & IconSlot> =
     color,
     uncheckedColor,
     indeterminateColor,
+    initialValue,
     checkedIcon = "MaterialCommunityIcons/checkbox-marked",
     uncheckedIcon = "MaterialCommunityIcons/checkbox-blank-outline",
     indeterminateIcon = "AntDesign/minussquareo",
@@ -56,6 +58,11 @@ const Checkbox: React.FC<CheckboxProps & TouchableHighlightProps & IconSlot> =
     style,
     ...rest
   }) => {
+    React.useEffect(() => {
+      if (initialValue != null) {
+        onPress(initialValue);
+      }
+    }, [initialValue]); // eslint-disable-line react-hooks/exhaustive-deps
     const { colors } = useTheme();
 
     const colorsMap = {
@@ -75,7 +82,7 @@ const Checkbox: React.FC<CheckboxProps & TouchableHighlightProps & IconSlot> =
     return (
       <Touchable
         {...rest}
-        onPress={onPress}
+        onPress={() => onPress(status === "unchecked" ? true : false)}
         disabled={disabled}
         accessibilityState={{ disabled }}
         accessibilityRole="button"

--- a/packages/core/src/components/Checkbox/Checkbox.tsx
+++ b/packages/core/src/components/Checkbox/Checkbox.tsx
@@ -19,6 +19,7 @@ import { useTheme } from "../../theming";
 import type { IconSlot } from "../../interfaces/Icon";
 
 import Touchable from "../Touchable";
+import { usePrevious } from "../../hooks";
 
 export enum CheckboxStatus {
   Checked = "checked",
@@ -58,11 +59,12 @@ const Checkbox: React.FC<CheckboxProps & TouchableHighlightProps & IconSlot> =
     style,
     ...rest
   }) => {
+    const previousInitialValue = usePrevious(initialValue);
     React.useEffect(() => {
-      if (initialValue != null) {
+      if (initialValue !== previousInitialValue) {
         onPress(initialValue);
       }
-    }, [initialValue]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [initialValue, previousInitialValue, onPress]);
     const { colors } = useTheme();
 
     const colorsMap = {

--- a/packages/core/src/components/DatePicker/DatePicker.tsx
+++ b/packages/core/src/components/DatePicker/DatePicker.tsx
@@ -25,6 +25,7 @@ import DateTimePicker from "./DatePickerComponent";
 
 import type { Theme } from "../../styles/DefaultTheme";
 import type { IconSlot } from "../../interfaces/Icon";
+import { usePrevious } from "../../hooks";
 
 const AnimatedText = Animated.createAnimatedComponent(Text);
 
@@ -101,12 +102,13 @@ const DatePicker: React.FC<Props> = ({
     width: number;
   }>({ measured: false, width: 0 });
 
+  const previousInitialValue = usePrevious(initialValue);
   React.useEffect(() => {
-    if (initialValue != null) {
+    if (initialValue !== previousInitialValue) {
       setValue(initialValue);
       onDateChange(initialValue);
     }
-  }, [initialValue]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [initialValue, previousInitialValue, setValue, onDateChange]);
 
   const getValidDate = (): Date => {
     if (!value) {

--- a/packages/core/src/components/DatePicker/DatePicker.tsx
+++ b/packages/core/src/components/DatePicker/DatePicker.tsx
@@ -43,7 +43,8 @@ type Props = {
   // type?: string;
   date?: Date;
   format?: string;
-  onDateChange?: (data?: any) => void;
+  onDateChange?: (data?: Date) => void;
+  initialValue?: Date;
   disabled?: boolean;
   mode?: "date" | "time" | "datetime";
   type?: "solid" | "underline";
@@ -76,6 +77,7 @@ const DatePicker: React.FC<Props> = ({
   theme: { colors, typography, roundness, disabledOpacity },
   date,
   onDateChange = () => {},
+  initialValue,
   disabled = false,
   mode = "date",
   format,
@@ -98,6 +100,13 @@ const DatePicker: React.FC<Props> = ({
     measured: Boolean;
     width: number;
   }>({ measured: false, width: 0 });
+
+  React.useEffect(() => {
+    if (initialValue != null) {
+      setValue(initialValue);
+      onDateChange(initialValue);
+    }
+  }, [initialValue]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const getValidDate = (): Date => {
     if (!value) {

--- a/packages/core/src/components/FieldSearchBarFull.tsx
+++ b/packages/core/src/components/FieldSearchBarFull.tsx
@@ -28,6 +28,7 @@ type Props = {
   onChange: (text: string) => void;
   onSubmit?: (e: NativeSyntheticEvent<TextInputSubmitEditingEventData>) => void;
   value: string;
+  initialValue?: string;
 } & IconSlot;
 
 const FieldSearchBarFull: React.FC<Props> = ({
@@ -39,6 +40,7 @@ const FieldSearchBarFull: React.FC<Props> = ({
   onChange: changeOverride,
   onSubmit: submitOverride,
   value,
+  initialValue,
 }) => {
   const [focused, setIsFocused] = React.useState(false);
 
@@ -49,6 +51,12 @@ const FieldSearchBarFull: React.FC<Props> = ({
   const onChange = (text: string) => {
     changeOverride && changeOverride(text);
   };
+
+  React.useEffect(() => {
+    if (initialValue != null) {
+      onChange(initialValue);
+    }
+  }, [initialValue]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const onFocus = () => {
     setIsFocused(true);

--- a/packages/core/src/components/FieldSearchBarFull.tsx
+++ b/packages/core/src/components/FieldSearchBarFull.tsx
@@ -19,6 +19,7 @@ import {
 import type { Theme } from "../styles/DefaultTheme";
 import type { IconSlot } from "../interfaces/Icon";
 import Config from "./Config";
+import { usePrevious } from "../hooks";
 
 type Props = {
   icon?: string;
@@ -48,15 +49,19 @@ const FieldSearchBarFull: React.FC<Props> = ({
     setIsFocused(false);
   };
 
-  const onChange = (text: string) => {
-    changeOverride && changeOverride(text);
-  };
+  const onChange = React.useCallback(
+    (text: string) => {
+      changeOverride && changeOverride(text);
+    },
+    [changeOverride]
+  );
 
+  const previousInitialValue = usePrevious(initialValue);
   React.useEffect(() => {
-    if (initialValue != null) {
+    if (initialValue !== previousInitialValue) {
       onChange(initialValue);
     }
-  }, [initialValue]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [initialValue, previousInitialValue, onChange]);
 
   const onFocus = () => {
     setIsFocused(true);

--- a/packages/core/src/components/Picker/Picker.tsx
+++ b/packages/core/src/components/Picker/Picker.tsx
@@ -22,6 +22,7 @@ const Picker: React.FC<Props> = ({
   placeholder,
   onValueChange: onValueChangeOverride,
   value,
+  initialValue,
   ...props
 }) => {
   const onValueChange = (itemValue: string, itemIndex: number) => {
@@ -30,6 +31,18 @@ const Picker: React.FC<Props> = ({
     }
     onValueChangeOverride && onValueChangeOverride(itemValue, itemIndex);
   };
+
+  React.useEffect(() => {
+    if (initialValue != null) {
+      const index = options.findIndex((opt) => opt.value === initialValue);
+
+      if (index == null) {
+        return;
+      }
+
+      onValueChange(initialValue, index);
+    }
+  }, [initialValue]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const pickerOptions = placeholder
     ? [{ value: placeholder, label: placeholder }, ...options]

--- a/packages/core/src/components/Picker/Picker.tsx
+++ b/packages/core/src/components/Picker/Picker.tsx
@@ -11,6 +11,7 @@ import {
   PROP_TYPES,
   FIELD_NAME,
 } from "@draftbit/types";
+import { usePrevious } from "../../hooks";
 
 type Props = PickerComponentProps & {
   placeholder?: string;
@@ -47,16 +48,21 @@ const Picker: React.FC<Props> = ({
   initialValue,
   ...props
 }) => {
-  const onValueChange = (itemValue: string, itemIndex: number) => {
-    if (placeholder && itemIndex === 0) {
-      return;
-    }
-    onValueChangeOverride && onValueChangeOverride(itemValue, itemIndex);
-  };
+  const onValueChange = React.useCallback(
+    (itemValue: string, itemIndex: number) => {
+      if (placeholder && itemIndex === 0) {
+        return;
+      }
+      onValueChangeOverride && onValueChangeOverride(itemValue, itemIndex);
+    },
+    [placeholder, onValueChangeOverride]
+  );
 
   const normalizedOptions = normalizeOptions(options);
+
+  const previousInitialValue = usePrevious(initialValue);
   React.useEffect(() => {
-    if (initialValue != null) {
+    if (initialValue !== previousInitialValue) {
       const index = normalizedOptions.findIndex(
         (opt) => opt.value === initialValue
       );
@@ -67,7 +73,7 @@ const Picker: React.FC<Props> = ({
 
       onValueChange(initialValue, index);
     }
-  }, [initialValue]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [initialValue, previousInitialValue, normalizedOptions, onValueChange]);
 
   const pickerOptions = placeholder
     ? [{ value: placeholder, label: placeholder }, ...normalizedOptions]

--- a/packages/core/src/components/Picker/PickerTypes.ts
+++ b/packages/core/src/components/Picker/PickerTypes.ts
@@ -14,4 +14,5 @@ export interface PickerComponentProps extends TextFieldProps {
   selectedValue: string;
   disabled?: boolean;
   onValueChange: (value: string, index: number) => void;
+  initialValue?: string;
 }

--- a/packages/core/src/components/RadioButton/RadioButtonGroup.tsx
+++ b/packages/core/src/components/RadioButton/RadioButtonGroup.tsx
@@ -7,6 +7,7 @@ import {
 } from "@draftbit/types";
 import type { Theme } from "../../styles/DefaultTheme";
 import { radioButtonGroupContext, Direction } from "./context";
+import { usePrevious } from "../../hooks";
 export interface RadioButtonGroupProps {
   direction?: Direction;
   style?: StyleProp<ViewStyle>;
@@ -28,11 +29,12 @@ const RadioButtonGroup: React.FC<RadioButtonGroupProps> = ({
   children,
   ...rest
 }) => {
+  const previousInitialValue = usePrevious(initialValue);
   React.useEffect(() => {
-    if (initialValue != null) {
+    if (initialValue !== previousInitialValue) {
       onValueChange(initialValue);
     }
-  }, [initialValue]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [initialValue, previousInitialValue, onValueChange]);
 
   const _containerStyle: StyleProp<ViewStyle> = [
     {

--- a/packages/core/src/components/RadioButton/RadioButtonGroup.tsx
+++ b/packages/core/src/components/RadioButton/RadioButtonGroup.tsx
@@ -12,6 +12,7 @@ export interface RadioButtonGroupProps {
   style?: StyleProp<ViewStyle>;
   value: string;
   onValueChange: (value: string) => void;
+  initialValue?: string;
   theme: Theme;
   children: React.ReactNode;
 }
@@ -22,10 +23,17 @@ const RadioButtonGroup: React.FC<RadioButtonGroupProps> = ({
   direction = Direction.Vertical,
   value,
   onValueChange = () => {},
+  initialValue,
   style,
   children,
   ...rest
 }) => {
+  React.useEffect(() => {
+    if (initialValue != null) {
+      onValueChange(initialValue);
+    }
+  }, [initialValue]); // eslint-disable-line react-hooks/exhaustive-deps
+
   const _containerStyle: StyleProp<ViewStyle> = [
     {
       flexDirection: direction === Direction.Horizontal ? "row" : "column",

--- a/packages/core/src/components/Slider.tsx
+++ b/packages/core/src/components/Slider.tsx
@@ -19,6 +19,7 @@ import type { IconSlot } from "../interfaces/Icon";
 export type Props = {
   style?: StyleProp<ViewStyle>;
   value?: number;
+  initialValue?: number;
   minimumTrackTintColor: string;
   maximumTrackTintColor: string;
   leftIcon?: string;
@@ -62,6 +63,7 @@ function Slider({
   leftIconColor,
   rightIconColor,
   value,
+  initialValue,
   minimumTrackTintColor,
   maximumTrackTintColor,
   thumbTintColor,
@@ -74,6 +76,12 @@ function Slider({
   theme,
   ...rest
 }: Props) {
+  React.useEffect(() => {
+    if (initialValue != null) {
+      onValueChange(initialValue);
+    }
+  }, [initialValue]); // eslint-disable-line react-hooks/exhaustive-deps
+
   const minTrackColor = minimumTrackTintColor || theme.colors.primary;
   const maxTrackColor = maximumTrackTintColor || theme.colors.light;
   const thumbColor = thumbTintColor || theme.colors.primary;

--- a/packages/core/src/components/Slider.tsx
+++ b/packages/core/src/components/Slider.tsx
@@ -15,6 +15,7 @@ import {
 import { withTheme } from "../theming";
 import type { Theme } from "../styles/DefaultTheme";
 import type { IconSlot } from "../interfaces/Icon";
+import { usePrevious } from "../hooks";
 
 export type Props = {
   style?: StyleProp<ViewStyle>;
@@ -76,11 +77,12 @@ function Slider({
   theme,
   ...rest
 }: Props) {
+  const previousInitialValue = usePrevious(initialValue);
   React.useEffect(() => {
-    if (initialValue != null) {
+    if (initialValue !== previousInitialValue) {
       onValueChange(initialValue);
     }
-  }, [initialValue]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [initialValue, previousInitialValue, onValueChange]);
 
   const minTrackColor = minimumTrackTintColor || theme.colors.primary;
   const maxTrackColor = maximumTrackTintColor || theme.colors.light;

--- a/packages/core/src/components/Stepper.tsx
+++ b/packages/core/src/components/Stepper.tsx
@@ -11,6 +11,7 @@ import type { Theme } from "../styles/DefaultTheme";
 import type { IconSlot } from "../interfaces/Icon";
 
 import IconButton from "./IconButton";
+import { usePrevious } from "../hooks";
 
 type Props = {
   value?: number;
@@ -38,12 +39,13 @@ const Stepper: React.FC<Props> = ({
 }) => {
   const [stateValue, setStateValue] = React.useState(value);
 
+  const previousInitialValue = usePrevious(initialValue);
   React.useEffect(() => {
-    if (initialValue != null) {
+    if (initialValue !== previousInitialValue) {
       setStateValue(initialValue);
       onChange && onChange(initialValue);
     }
-  }, [initialValue]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [initialValue, previousInitialValue, onChange, setStateValue]);
 
   const handleMinus = () => {
     if (value || value === 0) {

--- a/packages/core/src/components/Stepper.tsx
+++ b/packages/core/src/components/Stepper.tsx
@@ -115,7 +115,7 @@ export const SEED_DATA = [
       fieldName: createFieldNameProp({
         defaultValue: "stepperValue",
         handlerPropName: "onChange",
-        valuePropName: "stepperValue",
+        valuePropName: "value",
       }),
       iconSize: createIconSizeProp({ defaultValue: 24 }),
       iconColor: createColorProp({ defaultValue: "strong" }),

--- a/packages/core/src/components/Stepper.tsx
+++ b/packages/core/src/components/Stepper.tsx
@@ -17,6 +17,7 @@ type Props = {
   theme: Theme;
   style?: StyleProp<ViewStyle>;
   onChange?: (value: number) => void;
+  initialValue?: number;
   iconSize?: number;
   iconColor?: string;
   borderRadius?: number;
@@ -28,6 +29,7 @@ const Stepper: React.FC<Props> = ({
   value = 0,
   style,
   onChange,
+  initialValue,
   theme: { colors, typography, roundness },
   iconSize = 24,
   iconColor = colors.strong,
@@ -35,6 +37,13 @@ const Stepper: React.FC<Props> = ({
   typeStyle,
 }) => {
   const [stateValue, setStateValue] = React.useState(value);
+
+  React.useEffect(() => {
+    if (initialValue != null) {
+      setStateValue(initialValue);
+      onChange && onChange(initialValue);
+    }
+  }, [initialValue]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleMinus = () => {
     if (value || value === 0) {

--- a/packages/core/src/components/Switch.tsx
+++ b/packages/core/src/components/Switch.tsx
@@ -18,6 +18,7 @@ import {
   RowDirection,
 } from "@draftbit/types";
 import type { Theme } from "../styles/DefaultTheme";
+import { usePrevious } from "../hooks";
 
 type Props = {
   value: boolean;
@@ -57,12 +58,13 @@ function Switch({
     }
   }, [value, checked]);
 
+  const previousInitialValue = usePrevious(initialValue);
   React.useEffect(() => {
-    if (initialValue != null) {
+    if (initialValue !== previousInitialValue) {
       setChecked(initialValue);
       onValueChange && onValueChange(initialValue);
     }
-  }, [initialValue]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [initialValue, previousInitialValue, setChecked, onValueChange]);
 
   return (
     <NativeSwitch

--- a/packages/core/src/components/Switch.tsx
+++ b/packages/core/src/components/Switch.tsx
@@ -23,6 +23,7 @@ type Props = {
   value: boolean;
   disabled?: boolean;
   onValueChange?: (value: boolean) => void;
+  initialValue?: boolean;
   theme: Theme;
   activeTrackColor: string;
   inactiveTrackColor: string;
@@ -32,6 +33,7 @@ type Props = {
 
 function Switch({
   value = false,
+  initialValue,
   disabled,
   onValueChange,
   activeTrackColor,
@@ -54,6 +56,13 @@ function Switch({
       setChecked(value);
     }
   }, [value, checked]);
+
+  React.useEffect(() => {
+    if (initialValue != null) {
+      setChecked(initialValue);
+      onValueChange && onValueChange(initialValue);
+    }
+  }, [initialValue]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <NativeSwitch

--- a/packages/core/src/components/TextField.tsx
+++ b/packages/core/src/components/TextField.tsx
@@ -35,11 +35,15 @@ const ICON_SIZE = 24;
 
 export type Props = {
   type?: "solid" | "underline";
+  initialValue?: string;
   disabled?: boolean;
   label?: string;
   error?: boolean;
   leftIconName?: string;
   leftIconMode?: "inset" | "outset";
+  onChangeText: (
+    text: string | NativeSyntheticEvent<TextInputChangeEventData>
+  ) => void;
   rightIconName?: string;
   assistiveText?: string;
   multiline?: boolean;
@@ -55,7 +59,6 @@ interface State {
   labeled: Animated.Value;
   focused?: boolean;
   placeholder?: string | undefined;
-  defaultValue?: string | undefined;
   labelLayout: {
     measured: boolean;
     width: number;
@@ -63,7 +66,7 @@ interface State {
   value?: string;
 }
 
-class TextField extends React.Component<Props> {
+class TextField extends React.Component<Props, State> {
   static getDerivedStateFromProps(nextProps: Props, prevState: State) {
     return {
       value:
@@ -77,7 +80,6 @@ class TextField extends React.Component<Props> {
     labeled: new Animated.Value(this.props.value || this.props.error ? 0 : 1),
     focused: false,
     placeholder: this.props.error ? this.props.placeholder : "",
-    defaultValue: this.props.value,
     labelLayout: {
       measured: false,
       width: 0,
@@ -85,6 +87,10 @@ class TextField extends React.Component<Props> {
   };
 
   componentDidMount() {
+    if (this.props.initialValue) {
+      this._handleChangeText(this.props.initialValue);
+    }
+
     if (this.props.placeholder) {
       this._minmizeLabel();
     }
@@ -180,14 +186,14 @@ class TextField extends React.Component<Props> {
   };
 
   _handleChangeText = (
-    value: NativeSyntheticEvent<TextInputChangeEventData>
+    value: NativeSyntheticEvent<TextInputChangeEventData> | string
   ) => {
     if (this.props.disabled) {
       return;
     }
 
-    this.setState({ value });
-    this.props.onChange && this.props.onChange(value);
+    // this.setState({ value });
+    this.props.onChangeText && this.props.onChangeText(value);
   };
 
   toggleFocus() {
@@ -542,6 +548,7 @@ class TextField extends React.Component<Props> {
             underlineColorAndroid: "transparent",
             style: inputStyles,
             ...rest,
+            value: this.state.value,
           })}
         </View>
         {rightIconName ? (

--- a/packages/core/src/components/TextField.tsx
+++ b/packages/core/src/components/TextField.tsx
@@ -192,7 +192,7 @@ class TextField extends React.Component<Props, State> {
       return;
     }
 
-    // this.setState({ value });
+    this.setState({ value: value as string });
     this.props.onChangeText && this.props.onChangeText(value);
   };
 

--- a/packages/core/src/components/TextInput.tsx
+++ b/packages/core/src/components/TextInput.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { TextInput as NativeTextInput } from "react-native";
+import { usePrevious } from "../hooks";
 
 interface Props {
   initialValue?: string;
@@ -11,7 +12,12 @@ const TextInput: React.FC<Props> = ({
   onChangeText,
   ...props
 }) => {
-  React.useEffect(() => onChangeText(initialValue), [initialValue]); // eslint-disable-line react-hooks/exhaustive-deps
+  const previousInitialValue = usePrevious(initialValue);
+  React.useEffect(() => {
+    if (initialValue !== previousInitialValue) {
+      onChangeText(initialValue);
+    }
+  }, [initialValue, previousInitialValue, onChangeText]);
 
   return <NativeTextInput onChangeText={onChangeText} {...props} />;
 };

--- a/packages/core/src/components/TextInput.tsx
+++ b/packages/core/src/components/TextInput.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { TextInput as NativeTextInput } from "react-native";
+
+interface Props {
+  initialValue?: string;
+  onChangeText: (value?: string) => void;
+}
+
+const TextInput: React.FC<Props> = ({
+  initialValue,
+  onChangeText,
+  ...props
+}) => {
+  React.useEffect(() => onChangeText(initialValue), [initialValue]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return <NativeTextInput onChangeText={onChangeText} {...props} />;
+};
+
+export default TextInput;

--- a/packages/core/src/components/ToggleButton.tsx
+++ b/packages/core/src/components/ToggleButton.tsx
@@ -15,11 +15,13 @@ import {
 } from "@draftbit/types";
 import type { Theme } from "../styles/DefaultTheme";
 import type { IconSlot } from "../interfaces/Icon";
+import { usePrevious } from "../hooks";
 
 type Props = {
   icon: string;
   toggled?: boolean;
-  onPress?: () => void;
+  onPress?: (toggled: boolean) => void;
+  initialValue?: boolean;
   disabled?: boolean;
   color?: colorTypes;
   colorSecondary?: colorTypes;
@@ -36,6 +38,7 @@ const ToggleButton: React.FC<Props> = ({
   icon,
   toggled = false,
   onPress = () => {},
+  initialValue,
   disabled = false,
   color = "primary",
   colorSecondary = "surface",
@@ -47,13 +50,20 @@ const ToggleButton: React.FC<Props> = ({
   style,
   ...rest
 }) => {
+  const previousInitialValue = usePrevious(initialValue);
+  React.useEffect(() => {
+    if (initialValue !== previousInitialValue) {
+      onPress(initialValue);
+    }
+  }, [initialValue, previousInitialValue, onPress]);
+
   return (
     <IconButton
       Icon={Icon}
       icon={icon}
       size={iconSize}
       color={toggled ? colors[color] : colors[colorSecondary]}
-      onPress={onPress}
+      onPress={() => onPress(!toggled)}
       disabled={disabled}
       style={[
         styles.mainContainer,

--- a/packages/core/src/hooks.ts
+++ b/packages/core/src/hooks.ts
@@ -1,0 +1,15 @@
+import React from "react";
+
+export function usePrevious(value: any) {
+  // The ref object is a generic container whose current property is mutable
+  // and can hold any value, similar to an instance property on a class
+  const ref = React.useRef();
+
+  // Store current value in ref
+  React.useEffect(() => {
+    ref.current = value;
+  }, [value]);
+
+  // Return previous value (happens before update in useEffect above)
+  return ref.current;
+}

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -21,6 +21,7 @@ export { default as StarRating } from "./components/StarRating";
 export { default as Surface } from "./components/Surface";
 export { default as Switch, SwitchRow } from "./components/Switch";
 export { default as TextField } from "./components/TextField";
+export { default as TextInput } from "./components/TextInput";
 export { default as ToggleButton } from "./components/ToggleButton";
 export { default as Touchable } from "./components/Touchable";
 export { AccordionGroup, AccordionItem } from "./components/Accordion";

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -21,6 +21,7 @@ export {
   Surface,
   Switch,
   SwitchRow,
+  TextInput,
   ThemeProvider,
   Touchable,
   withTheme,


### PR DESCRIPTION
This is a prop that can be used to set the initial value of the component. This is useful because sometimes components are loaded in Draftbit within a render prop or FlatList, where a useEffect can not be utilized within the parent component.