### PR TITLE
Fix border top/right/bottom/left width props for Picker/TextField

### DIFF
--- a/example/src/PickerExample.js
+++ b/example/src/PickerExample.js
@@ -167,7 +167,10 @@ function PickerExample({ theme }) {
           onValueChange={handleChange}
           style={{
             backgroundColor: "red",
-            borderWidth: 2,
+            borderTopWidth: 2,
+            borderRightWidth: 2,
+            borderBottomWidth: 2,
+            borderLeftWidth: 2,
             borderColor: "green",
             padding: 16,
           }}

--- a/packages/core/src/components/Picker/PickerComponent.android.tsx
+++ b/packages/core/src/components/Picker/PickerComponent.android.tsx
@@ -21,6 +21,10 @@ const Picker: React.FC<PickerComponentProps> = ({
     viewStyles: {
       borderRadius, // eslint-disable-line @typescript-eslint/no-unused-vars
       borderWidth, // eslint-disable-line @typescript-eslint/no-unused-vars
+      borderTopWidth, // eslint-disable-line @typescript-eslint/no-unused-vars
+      borderRightWidth, // eslint-disable-line @typescript-eslint/no-unused-vars
+      borderBottomWidth, // eslint-disable-line @typescript-eslint/no-unused-vars
+      borderLeftWidth, // eslint-disable-line @typescript-eslint/no-unused-vars
       borderColor, // eslint-disable-line @typescript-eslint/no-unused-vars
       backgroundColor, // eslint-disable-line @typescript-eslint/no-unused-vars
       ...viewStyles

--- a/packages/core/src/components/Picker/PickerComponent.ios.tsx
+++ b/packages/core/src/components/Picker/PickerComponent.ios.tsx
@@ -29,6 +29,10 @@ const Picker: React.FC<PickerComponentProps & IconSlot> = ({
     viewStyles: {
       borderRadius, // eslint-disable-line @typescript-eslint/no-unused-vars
       borderWidth, // eslint-disable-line @typescript-eslint/no-unused-vars
+      borderTopWidth, // eslint-disable-line @typescript-eslint/no-unused-vars
+      borderRightWidth, // eslint-disable-line @typescript-eslint/no-unused-vars
+      borderBottomWidth, // eslint-disable-line @typescript-eslint/no-unused-vars
+      borderLeftWidth, // eslint-disable-line @typescript-eslint/no-unused-vars
       borderColor, // eslint-disable-line @typescript-eslint/no-unused-vars
       backgroundColor, // eslint-disable-line @typescript-eslint/no-unused-vars
       ...viewStyles

--- a/packages/core/src/components/Picker/PickerComponent.web.tsx
+++ b/packages/core/src/components/Picker/PickerComponent.web.tsx
@@ -20,6 +20,10 @@ const Picker: React.FC<PickerComponentProps> = ({
     viewStyles: {
       borderRadius, // eslint-disable-line @typescript-eslint/no-unused-vars
       borderWidth, // eslint-disable-line @typescript-eslint/no-unused-vars
+      borderTopWidth, // eslint-disable-line @typescript-eslint/no-unused-vars
+      borderRightWidth, // eslint-disable-line @typescript-eslint/no-unused-vars
+      borderBottomWidth, // eslint-disable-line @typescript-eslint/no-unused-vars
+      borderLeftWidth, // eslint-disable-line @typescript-eslint/no-unused-vars
       borderColor, // eslint-disable-line @typescript-eslint/no-unused-vars
       backgroundColor, // eslint-disable-line @typescript-eslint/no-unused-vars
       ...viewStyles

--- a/packages/core/src/components/TextField.tsx
+++ b/packages/core/src/components/TextField.tsx
@@ -413,6 +413,10 @@ class TextField extends React.Component<Props, State> {
       paddingRight,
       borderRadius,
       borderWidth,
+      borderTopWidth,
+      borderRightWidth,
+      borderBottomWidth,
+      borderLeftWidth,
       borderColor: borderCol,
       ...styleProp
     } = StyleSheet.flatten(style || {}) as ViewStyle & { height?: number };
@@ -436,6 +440,10 @@ class TextField extends React.Component<Props, State> {
                   ...(paddingRight ? { paddingRight } : {}),
                   ...(borderRadius ? { borderRadius } : {}),
                   ...(borderWidth ? { borderWidth } : {}),
+                  ...(borderTopWidth ? { borderTopWidth } : {}),
+                  ...(borderRightWidth ? { borderRightWidth } : {}),
+                  ...(borderBottomWidth ? { borderBottomWidth } : {}),
+                  ...(borderLeftWidth ? { borderLeftWidth } : {}),
                   ...(borderCol ? { borderColor: borderCol } : {}),
                 }
               : {},


### PR DESCRIPTION
These props were being applied to the wrong part of the component

<img width="134" alt="image" src="https://user-images.githubusercontent.com/2578537/125370622-b259d100-e333-11eb-8b04-cd72e2f57cf0.png">
