### PR TITLE
Fix bug causing using icon with Picker to cause crash

### DIFF
--- a/example/src/PickerExample.js
+++ b/example/src/PickerExample.js
@@ -23,6 +23,7 @@ function PickerExample({ theme }) {
           options={OPTIONS}
           value={value}
           onValueChange={setValue}
+          rightIconName={"AntDesign/caretright"}
         />
       </Section>
 

--- a/packages/core/src/components/Picker/PickerComponent.ios.tsx
+++ b/packages/core/src/components/Picker/PickerComponent.ios.tsx
@@ -81,6 +81,7 @@ const Picker: React.FC<PickerComponentProps & IconSlot> = ({
           pointerEvents="none"
           // @ts-expect-error
           style={stylesWithoutMargin}
+          Icon={Icon}
         />
       </Touchable>
       {pickerVisible && (


### PR DESCRIPTION
We need to pass the `Icon` component down into `TextField` in order to properly render the icon.﻿
