### PR TITLE
Fix bug when using TextField component on web without value prop

### DIFF
--- a/packages/core/src/components/TextField.tsx
+++ b/packages/core/src/components/TextField.tsx
@@ -187,8 +187,14 @@ class TextField extends React.Component<Props, State> {
       return;
     }
 
-    this.setState({ value: value as string });
-    this.props.onChangeText && this.props.onChangeText(value);
+    if (typeof value === "string") {
+      this.setState({ value });
+      this.props.onChangeText && this.props.onChangeText(value);
+    } else {
+      this.setState({ value: value.nativeEvent.text });
+      this.props.onChangeText &&
+        this.props.onChangeText(value.nativeEvent.text);
+    }
   };
 
   toggleFocus() {


### PR DESCRIPTION
Stops casting the event type to a string and properly handles the non-string case