### PR TITLE
correctly pass in either defaultValue or value

### DIFF
--- a/example/src/TextInputExample.js
+++ b/example/src/TextInputExample.js
@@ -31,18 +31,12 @@ export default function TextInputExample() {
             defaultValue="I'm an initial value!"
           />
           <NumberInput
-            placeholder="Number input with initial value"
+            placeholder="Number input using value"
             value={number}
             onChangeText={(num) => setNumber(num)}
           />
           <NumberInput
             placeholder="Number input using defaultValue"
-            value={number === 0 ? undefined : number}
-            onChangeText={(num) => setNumber(num)}
-            defaultValue={1}
-          />
-          <NumberInput
-            placeholder="Number input using defaultValue, no value"
             onChangeText={(num) => setNumber(num)}
             defaultValue={1}
           />

--- a/example/src/TextInputExample.js
+++ b/example/src/TextInputExample.js
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { TextInput, KeyboardAvoidingView } from "react-native";
-import { NumberInput } from "@draftbit/ui";
-import Section, { Container } from "./Section";
+import { NumberInput, ButtonSolid } from "@draftbit/ui";
+import Section, { Container, styles } from "./Section";
 
 export default function TextInputExample() {
   const [value, setText] = React.useState("Change me!");
@@ -34,7 +34,22 @@ export default function TextInputExample() {
             placeholder="Number input with initial value"
             value={number}
             onChangeText={(num) => setNumber(num)}
-            defaultValue="1"
+          />
+          <NumberInput
+            placeholder="Number input using defaultValue"
+            value={number === 0 ? undefined : number}
+            onChangeText={(num) => setNumber(num)}
+            defaultValue={1}
+          />
+          <NumberInput
+            placeholder="Number input using defaultValue, no value"
+            onChangeText={(num) => setNumber(num)}
+            defaultValue={1}
+          />
+          <ButtonSolid
+            style={[styles.button]}
+            title="Reset Number"
+            onPress={(_) => setNumber(0)}
           />
         </Section>
       </Container>

--- a/example/src/TextInputExample.js
+++ b/example/src/TextInputExample.js
@@ -36,6 +36,11 @@ export default function TextInputExample() {
             onChangeText={(num) => setNumber(num)}
           />
           <NumberInput
+            placeholder="Number input using value (2)"
+            value={number}
+            onChangeText={(num) => setNumber(num)}
+          />
+          <NumberInput
             placeholder="Number input using defaultValue"
             onChangeText={(num) => setNumber(num)}
             defaultValue={1}

--- a/package.json
+++ b/package.json
@@ -109,6 +109,6 @@
     "*.{js,ts,tsx,json,mcss,md}": "prettier --write"
   },
   "engines": {
-    "node": "16.13"
+    "node": "16.x"
   }
 }

--- a/packages/core/src/components/NumberInput.tsx
+++ b/packages/core/src/components/NumberInput.tsx
@@ -7,29 +7,20 @@ interface Props {
   onChangeText: (value?: number) => void;
 }
 
-const getValue = (
-  valueFromProp: number | undefined,
-  defaultValue: number | undefined
-) => {
-  let value = valueFromProp ?? defaultValue;
-  if (typeof value !== "number" || Number.isNaN(value)) {
-    value = 0;
-  }
-  return value;
-};
-
 const NumberInput: React.FC<Props> = ({
   onChangeText,
-  value: valueFromProp,
+  value,
   defaultValue,
   ...props
 }) => {
-  const value = getValue(valueFromProp, defaultValue);
-  const [isDecimal, setIsDecimal] = React.useState(!Number.isInteger(value));
+  const [isDecimal, setIsDecimal] = React.useState(
+    value && !Number.isInteger(value)
+  );
   React.useEffect(() => {
-    const newValue = getValue(valueFromProp, defaultValue);
-    setIsDecimal(newValue.toString().includes("."));
-  }, [valueFromProp, defaultValue]);
+    if (value) {
+      setIsDecimal(value.toString().includes("."));
+    }
+  }, [value]);
 
   const handleChangeText = (newValue: string) => {
     if (onChangeText) {
@@ -40,17 +31,20 @@ const NumberInput: React.FC<Props> = ({
     }
   };
 
-  let strValue: string = value.toString();
-  if (isDecimal && !strValue.includes(".")) {
-    strValue = `${strValue}.`;
+  let strValue;
+  if (value != undefined) {
+    strValue = value.toString();
+    if (isDecimal && !strValue.includes(".")) {
+      strValue = `${strValue}.`;
+    }
   }
 
   return (
     <TextInput
       keyboardType="numeric"
       {...props}
-      value={valueFromProp !== undefined ? strValue : undefined}
-      defaultValue={defaultValue !== undefined ? strValue : undefined}
+      value={strValue}
+      defaultValue={defaultValue?.toString()}
       onChangeText={handleChangeText}
     />
   );

--- a/packages/core/src/components/NumberInput.tsx
+++ b/packages/core/src/components/NumberInput.tsx
@@ -1,44 +1,59 @@
 import React from "react";
-import { TextInput as NativeNumberInput } from "react-native";
+import { TextInput } from "react-native";
 
 interface Props {
-  defaultValue?: string;
+  value?: number;
+  defaultValue?: number;
   onChangeText: (value?: number) => void;
 }
 
+const getValue = (
+  valueFromProp: number | undefined,
+  defaultValue: number | undefined
+) => {
+  let value = valueFromProp ?? defaultValue;
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    value = 0;
+  }
+  return value;
+};
+
 const NumberInput: React.FC<Props> = ({
-  defaultValue,
   onChangeText,
+  value: valueFromProp,
+  defaultValue,
   ...props
 }) => {
-  const [internalValue, setInternalValue] = React.useState(defaultValue);
-
+  const value = getValue(valueFromProp, defaultValue);
+  const [isDecimal, setIsDecimal] = React.useState(!Number.isInteger(value));
   React.useEffect(() => {
-    if (defaultValue != null) {
-      setInternalValue(defaultValue);
-    }
-  }, [defaultValue]);
+    const newValue = getValue(valueFromProp, defaultValue);
+    setIsDecimal(newValue.toString().includes("."));
+  }, [valueFromProp, defaultValue]);
 
-  const handleChangeText = (value: string) => {
-    setInternalValue(value);
+  const handleChangeText = (newValue: string) => {
     if (onChangeText) {
-      onChangeText(stringToInteger(value));
+      const parsedNumber = parseFloat(newValue);
+      const number = isNaN(parsedNumber) ? 0 : parsedNumber;
+      setIsDecimal(newValue.includes("."));
+      onChangeText(number);
     }
   };
 
+  let strValue: string = value.toString();
+  if (isDecimal && !strValue.includes(".")) {
+    strValue = `${strValue}.`;
+  }
+
   return (
-    <NativeNumberInput
+    <TextInput
       keyboardType="numeric"
-      onChangeText={handleChangeText}
       {...props}
-      value={internalValue}
+      value={valueFromProp !== undefined ? strValue : undefined}
+      defaultValue={defaultValue !== undefined ? strValue : undefined}
+      onChangeText={handleChangeText}
     />
   );
-};
-
-const stringToInteger = (str: string | undefined): number => {
-  const number = parseFloat(str as string);
-  return isNaN(number) ? 0 : number;
 };
 
 export default NumberInput;


### PR DESCRIPTION
This might be a little overcomplicated given that we don't need to watch `defaultValue` for changes, but at least it works:

* Supports integers
* Supports floats (typing in decimals)
* Shows correct `value` and updates it when it changes
* Supports `value` and `defaultValue` following the same rules as react-native TextInput