### PR TITLE
Fix App Breaking Link Issue

### DIFF
--- a/packages/core/src/components/Text.tsx
+++ b/packages/core/src/components/Text.tsx
@@ -45,7 +45,7 @@ export const BaseLink = ({
   return (
     <Text
       hitSlop={8}
-      style={[{ color: theme.colors.primary, alignSelf: "baseline" }, style]}
+      style={[{ color: theme.colors.primary, alignSelf: "flex-start" }, style]}
       theme={theme}
       {...props}
     >


### PR DESCRIPTION
Per [P-2655](https://linear.app/draftbit/issue/P-2655/issue-with-link-jigsaw-issue) and [p-2632](https://linear.app/draftbit/issue/P-2632/expo-go-app-crashing-on-ios-because-of-link-component), an issue occurs when...

1. A parent `View` has set `flexDirection: 'row'`
2. There are a minimum of 2 specific children -- 1 `Icon` and 1 `Link` from `@draftbit/ui`

...then on only iOS the app crashes.  There is a CSS conflict "somewhere" in the Yoga Layout engine whereby if either of these elements is commented out, everything lays out fine in iOS

-- OR --

if the `alignSelf` style of the `Link` ([BaseLink](https://github.com/draftbit/react-native-jigsaw/blob/05dba13ad16746015b0139cd0065bc00a49b8d5c/packages/core/src/components/Text.tsx#L38-L39)) is swapped from `"baseline"` to `"flex-start"` this resolves the issue.

Considering, a user will not mix fonts on a `Link` element,  I've elected to go with the latter option ... more especially because most users will not want choose between having a row with either an Icon or a Link or a broken app.