### PR TITLE
Fix FAB icon sizing

### DIFF
--- a/example/src/FABExample.js
+++ b/example/src/FABExample.js
@@ -9,10 +9,16 @@ function FABExample({ theme }) {
     <Container
       style={{ flexDirection: "row", backgroundColor: theme.colors.background }}
     >
-      <FAB icon="add" onPress={handlePress} size={32} />
+      <FAB icon="add" onPress={handlePress} size={25} />
       <FAB icon="add" disabled onPress={handlePress} />
       <View style={{ backgroundColor: "yellow" }}>
-        <FAB icon="add" loading onPress={handlePress} style={{ margin: 20 }} />
+        <FAB
+          icon="add"
+          loading
+          onPress={handlePress}
+          style={{ margin: 20 }}
+          size={100}
+        />
       </View>
     </Container>
   );

--- a/packages/core/src/components/FAB.tsx
+++ b/packages/core/src/components/FAB.tsx
@@ -77,9 +77,13 @@ const FAB: React.FC<Props> = ({
       >
         <View>
           {loading ? (
-            <ActivityIndicator size="small" color={color} />
+            <ActivityIndicator
+              style={size > 50 ? { marginTop: 2, marginLeft: 2 } : undefined}
+              size={size <= 50 ? "small" : "large"}
+              color={color}
+            />
           ) : (
-            <Icon name={iconName} size={28} color={color} />
+            <Icon name={iconName} size={size} color={color} />
           )}
         </View>
       </Pressable>


### PR DESCRIPTION
Per [P-2684](https://linear.app/draftbit/issue/P-2684/fab-icon-size-prop-not-working), the `FAB` component sizing prop did not grow the inner `Icon` to match the outer/background `View`.

- Updated `Icon` size prop
- Updated `ActivityIndicator` style & size props
- Updated the example with 3 sizes each doubling -- 25px, 50px (default prop), 100px -- to show how it scales.