### PR TITLE
Allow radioButton(Row/Group) zero & number values

### DIFF
--- a/example/src/RadioButtonExample.js
+++ b/example/src/RadioButtonExample.js
@@ -54,9 +54,9 @@ const RadioButtonGroupExample = ({ theme }) => {
           value={selected}
         >
           <RadioButtonRow label="Zero" value={0} />
-          <RadioButtonRow label="1st" value={1} />
+          <RadioButtonRow label="1st" value={"1"} />
           <RadioButtonRow label="2nd" value={2} />
-          <RadioButtonRow label="3rd" value={3} />
+          <RadioButtonRow label="3rd" value={"3"} />
         </RadioButtonGroup>
       </Section>
 

--- a/example/src/RadioButtonExample.js
+++ b/example/src/RadioButtonExample.js
@@ -21,7 +21,7 @@ const SingleRadioButtonWrapper = ({ label, children }) => (
 );
 
 const RadioButtonGroupExample = ({ theme }) => {
-  const [selected, onSelect] = React.useState("1");
+  const [selected, onSelect] = React.useState("0");
   const [selected2, onSelect2] = React.useState("1");
   const handleSelect = (value) => onSelect(value);
   return (

--- a/example/src/RadioButtonExample.js
+++ b/example/src/RadioButtonExample.js
@@ -53,9 +53,10 @@ const RadioButtonGroupExample = ({ theme }) => {
           onValueChange={handleSelect}
           value={selected}
         >
-          <RadioButtonRow label="First" value="1" />
-          <RadioButtonRow label="Second" value="2" />
-          <RadioButtonRow label="Third" value="3" />
+          <RadioButtonRow label="Zero" value={0} />
+          <RadioButtonRow label="1st" value={1} />
+          <RadioButtonRow label="2nd" value={2} />
+          <RadioButtonRow label="3rd" value={3} />
         </RadioButtonGroup>
       </Section>
 

--- a/packages/core/src/components/RadioButton/RadioButton.tsx
+++ b/packages/core/src/components/RadioButton/RadioButton.tsx
@@ -27,7 +27,7 @@ const RadioButton: React.FC<RadioButtonProps> = ({
   value,
   selected,
   unselectedColor,
-  onPress = () => {},
+  onPress,
   size = Config.radioButtonSize,
   selectedIcon = "MaterialIcons/radio-button-checked",
   unselectedIcon = "MaterialIcons/radio-button-unchecked",
@@ -36,16 +36,16 @@ const RadioButton: React.FC<RadioButtonProps> = ({
 }) => {
   const { value: contextValue, onValueChange } = useRadioButtonGroupContext();
 
-  const handlePress = () => {
-    onPress && onPress();
+  // @ts-expect-error
+  const valueExists = value === 0 || value;
 
-    if (onValueChange && value) {
-      onValueChange(value);
-    }
+  const handlePress = () => {
+    onPress?.();
+    valueExists && onValueChange(value);
   };
 
   const isSelected =
-    selected || (contextValue != null && contextValue === value);
+    selected || (contextValue !== null && contextValue === value);
 
   return (
     <IconButton

--- a/packages/core/src/components/RadioButton/RadioButton.tsx
+++ b/packages/core/src/components/RadioButton/RadioButton.tsx
@@ -12,7 +12,7 @@ export type RadioButtonProps = {
   selected?: boolean;
   disabled?: boolean;
   color?: string;
-  value?: string | number;
+  value: string | number;
   unselectedColor?: string;
   onPress?: (value: string) => void;
   style?: StyleProp<ViewStyle>;
@@ -25,7 +25,7 @@ const RadioButton: React.FC<RadioButtonProps> = ({
   Icon,
   disabled = false,
   color,
-  value,
+  value = "",
   selected,
   unselectedColor,
   onPress,
@@ -39,15 +39,11 @@ const RadioButton: React.FC<RadioButtonProps> = ({
 
   const realValue = getValueForRadioButton(value);
   const realContextValue = getValueForRadioButton(contextValue);
-  const isSelected =
-    selected ??
-    (realContextValue && realValue && realContextValue === realValue);
+  const isSelected = selected ?? realContextValue === realValue;
 
   const handlePress = () => {
-    if (realValue) {
-      onPress?.(realValue);
-      onValueChange?.(realValue);
-    }
+    onPress?.(realValue);
+    onValueChange?.(realValue);
   };
 
   return (

--- a/packages/core/src/components/RadioButton/RadioButton.tsx
+++ b/packages/core/src/components/RadioButton/RadioButton.tsx
@@ -12,9 +12,9 @@ export type RadioButtonProps = {
   selected?: boolean;
   disabled?: boolean;
   color?: string;
-  value: string | number;
+  value?: string | number;
   unselectedColor?: string;
-  onPress?: (value: string) => void;
+  onPress?: (value?: string) => void;
   style?: StyleProp<ViewStyle>;
   size?: number;
   selectedIcon?: string;

--- a/packages/core/src/components/RadioButton/RadioButton.tsx
+++ b/packages/core/src/components/RadioButton/RadioButton.tsx
@@ -3,6 +3,7 @@ import { StyleProp, ViewStyle } from "react-native";
 
 import Config from "../Config";
 import IconButton from "../IconButton";
+import { getRealValue } from "../../utilities";
 import { useRadioButtonGroupContext } from "./context";
 
 import type { IconSlot } from "../../interfaces/Icon";
@@ -13,7 +14,7 @@ export type RadioButtonProps = {
   color?: string;
   value?: string;
   unselectedColor?: string;
-  onPress?: () => void;
+  onPress?: (value: string) => void;
   style?: StyleProp<ViewStyle>;
   size?: number;
   selectedIcon?: string;
@@ -36,16 +37,22 @@ const RadioButton: React.FC<RadioButtonProps> = ({
 }) => {
   const { value: contextValue, onValueChange } = useRadioButtonGroupContext();
 
-  // @ts-expect-error
-  const valueExists = value === 0 || value;
+  const realValue = getRealValue(value);
+  const realContextValue = getRealValue(contextValue);
+  const isSelected =
+    selected ??
+    (realContextValue && realValue && realContextValue === realValue);
+
+  console.log({ realValue, realContextValue, isSelected });
 
   const handlePress = () => {
-    onPress?.();
-    valueExists && onValueChange(value);
-  };
+    console.log("RadioButton:realValue", realValue);
 
-  const isSelected =
-    selected || (contextValue !== null && contextValue === value);
+    if (realValue) {
+      onPress?.(realValue);
+      onValueChange?.(realValue);
+    }
+  };
 
   return (
     <IconButton

--- a/packages/core/src/components/RadioButton/RadioButton.tsx
+++ b/packages/core/src/components/RadioButton/RadioButton.tsx
@@ -3,7 +3,7 @@ import { StyleProp, ViewStyle } from "react-native";
 
 import Config from "../Config";
 import IconButton from "../IconButton";
-import { getRealValue } from "../../utilities";
+import { getValueForRadioButton } from "../../utilities";
 import { useRadioButtonGroupContext } from "./context";
 
 import type { IconSlot } from "../../interfaces/Icon";
@@ -12,7 +12,7 @@ export type RadioButtonProps = {
   selected?: boolean;
   disabled?: boolean;
   color?: string;
-  value?: string;
+  value?: string | number;
   unselectedColor?: string;
   onPress?: (value: string) => void;
   style?: StyleProp<ViewStyle>;
@@ -37,8 +37,8 @@ const RadioButton: React.FC<RadioButtonProps> = ({
 }) => {
   const { value: contextValue, onValueChange } = useRadioButtonGroupContext();
 
-  const realValue = getRealValue(value);
-  const realContextValue = getRealValue(contextValue);
+  const realValue = getValueForRadioButton(value);
+  const realContextValue = getValueForRadioButton(contextValue);
   const isSelected =
     selected ??
     (realContextValue && realValue && realContextValue === realValue);

--- a/packages/core/src/components/RadioButton/RadioButton.tsx
+++ b/packages/core/src/components/RadioButton/RadioButton.tsx
@@ -43,11 +43,7 @@ const RadioButton: React.FC<RadioButtonProps> = ({
     selected ??
     (realContextValue && realValue && realContextValue === realValue);
 
-  console.log({ realValue, realContextValue, isSelected });
-
   const handlePress = () => {
-    console.log("RadioButton:realValue", realValue);
-
     if (realValue) {
       onPress?.(realValue);
       onValueChange?.(realValue);

--- a/packages/core/src/components/RadioButton/RadioButtonGroup.tsx
+++ b/packages/core/src/components/RadioButton/RadioButtonGroup.tsx
@@ -1,13 +1,14 @@
 import * as React from "react";
 import { View, StyleProp, ViewStyle } from "react-native";
 import type { Theme } from "../../styles/DefaultTheme";
+import { getRealValue } from "../../utilities";
 import { radioButtonGroupContext, Direction } from "./context";
 export interface RadioButtonGroupProps {
   direction?: Direction;
   style?: StyleProp<ViewStyle>;
   value?: string;
-  onValueChange?: (value: string | number) => void;
-  defaultValue?: string;
+  onValueChange?: (value: string) => void;
+  defaultValue?: string | number;
   theme: Theme;
   children: React.ReactNode;
 }
@@ -23,25 +24,35 @@ const RadioButtonGroup: React.FC<RadioButtonGroupProps> = ({
   children,
   ...rest
 }) => {
-  const [internalValue, setInternalValue] = React.useState<string | undefined>(
-    value || defaultValue
-  );
+  const [internalValue, setInternalValue] = React.useState<
+    string | undefined
+  >();
 
   React.useEffect(() => {
-    if (value !== null) {
-      setInternalValue(value);
+    const realValue = getRealValue(value);
+
+    if (realValue) {
+      setInternalValue(realValue);
     }
   }, [value]);
 
   React.useEffect(() => {
-    if (defaultValue !== null) {
-      setInternalValue(defaultValue);
+    const realDefaultValue = getRealValue(defaultValue);
+
+    if (realDefaultValue) {
+      setInternalValue(realDefaultValue);
     }
   }, [defaultValue]);
 
-  const handleValueChange = (newValue: string) => {
-    setInternalValue(newValue);
-    onValueChange(newValue);
+  const handleValueChange = (newValue: any) => {
+    const realNewValue = getRealValue(newValue);
+
+    if (realNewValue) {
+      console.log("RadioButtonGroup:realValue", realNewValue);
+
+      setInternalValue(newValue);
+      onValueChange?.(newValue);
+    }
   };
 
   const _containerStyle: StyleProp<ViewStyle> = [
@@ -60,8 +71,7 @@ const RadioButtonGroup: React.FC<RadioButtonGroupProps> = ({
     <View style={[{ minHeight: 40 }, style]} {...rest}>
       <Provider
         value={{
-          // @ts-ignore
-          value: internalValue === 0 ? 0 : internalValue || "",
+          value: internalValue || "",
           onValueChange: handleValueChange,
           direction,
         }}

--- a/packages/core/src/components/RadioButton/RadioButtonGroup.tsx
+++ b/packages/core/src/components/RadioButton/RadioButtonGroup.tsx
@@ -6,7 +6,7 @@ import { radioButtonGroupContext, Direction } from "./context";
 export interface RadioButtonGroupProps {
   direction?: Direction;
   style?: StyleProp<ViewStyle>;
-  value?: string;
+  value: string;
   onValueChange?: (value: string) => void;
   defaultValue?: string | number;
   theme: Theme;
@@ -17,40 +17,32 @@ const { Provider } = radioButtonGroupContext;
 
 const RadioButtonGroup: React.FC<RadioButtonGroupProps> = ({
   direction = Direction.Vertical,
-  value,
+  value = "",
   onValueChange,
-  defaultValue,
+  defaultValue = "",
   style,
   children,
   ...rest
 }) => {
-  const [internalValue, setInternalValue] = React.useState<
-    string | undefined
-  >();
+  const [internalValue, setInternalValue] = React.useState<string>("");
 
   React.useEffect(() => {
     const realValue = getValueForRadioButton(value);
 
-    if (realValue) {
-      setInternalValue(realValue);
-    }
+    setInternalValue(realValue);
   }, [value]);
 
   React.useEffect(() => {
     const realDefaultValue = getValueForRadioButton(defaultValue);
 
-    if (realDefaultValue) {
-      setInternalValue(realDefaultValue);
-    }
+    setInternalValue(realDefaultValue);
   }, [defaultValue]);
 
-  const handleValueChange = (newValue?: string | number) => {
+  const handleValueChange = (newValue: string | number) => {
     const realNewValue = getValueForRadioButton(newValue);
 
-    if (realNewValue) {
-      setInternalValue(realNewValue);
-      onValueChange?.(realNewValue);
-    }
+    setInternalValue(realNewValue);
+    onValueChange?.(realNewValue);
   };
 
   const _containerStyle: StyleProp<ViewStyle> = [
@@ -69,7 +61,7 @@ const RadioButtonGroup: React.FC<RadioButtonGroupProps> = ({
     <View style={[{ minHeight: 40 }, style]} {...rest}>
       <Provider
         value={{
-          value: internalValue || "",
+          value: internalValue ?? "",
           onValueChange: handleValueChange,
           direction,
         }}

--- a/packages/core/src/components/RadioButton/RadioButtonGroup.tsx
+++ b/packages/core/src/components/RadioButton/RadioButtonGroup.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { View, StyleProp, ViewStyle } from "react-native";
 import type { Theme } from "../../styles/DefaultTheme";
-import { getRealValue } from "../../utilities";
+import { getValueForRadioButton } from "../../utilities";
 import { radioButtonGroupContext, Direction } from "./context";
 export interface RadioButtonGroupProps {
   direction?: Direction;
@@ -29,7 +29,7 @@ const RadioButtonGroup: React.FC<RadioButtonGroupProps> = ({
   >();
 
   React.useEffect(() => {
-    const realValue = getRealValue(value);
+    const realValue = getValueForRadioButton(value);
 
     if (realValue) {
       setInternalValue(realValue);
@@ -37,19 +37,19 @@ const RadioButtonGroup: React.FC<RadioButtonGroupProps> = ({
   }, [value]);
 
   React.useEffect(() => {
-    const realDefaultValue = getRealValue(defaultValue);
+    const realDefaultValue = getValueForRadioButton(defaultValue);
 
     if (realDefaultValue) {
       setInternalValue(realDefaultValue);
     }
   }, [defaultValue]);
 
-  const handleValueChange = (newValue: any) => {
-    const realNewValue = getRealValue(newValue);
+  const handleValueChange = (newValue?: string | number) => {
+    const realNewValue = getValueForRadioButton(newValue);
 
     if (realNewValue) {
-      setInternalValue(newValue);
-      onValueChange?.(newValue);
+      setInternalValue(realNewValue);
+      onValueChange?.(realNewValue);
     }
   };
 

--- a/packages/core/src/components/RadioButton/RadioButtonGroup.tsx
+++ b/packages/core/src/components/RadioButton/RadioButtonGroup.tsx
@@ -18,7 +18,7 @@ const { Provider } = radioButtonGroupContext;
 const RadioButtonGroup: React.FC<RadioButtonGroupProps> = ({
   direction = Direction.Vertical,
   value,
-  onValueChange = () => {},
+  onValueChange,
   defaultValue,
   style,
   children,
@@ -48,8 +48,6 @@ const RadioButtonGroup: React.FC<RadioButtonGroupProps> = ({
     const realNewValue = getRealValue(newValue);
 
     if (realNewValue) {
-      console.log("RadioButtonGroup:realValue", realNewValue);
-
       setInternalValue(newValue);
       onValueChange?.(newValue);
     }

--- a/packages/core/src/components/RadioButton/RadioButtonGroup.tsx
+++ b/packages/core/src/components/RadioButton/RadioButtonGroup.tsx
@@ -61,7 +61,7 @@ const RadioButtonGroup: React.FC<RadioButtonGroupProps> = ({
     <View style={[{ minHeight: 40 }, style]} {...rest}>
       <Provider
         value={{
-          value: internalValue ?? "",
+          value: internalValue || "",
           onValueChange: handleValueChange,
           direction,
         }}

--- a/packages/core/src/components/RadioButton/RadioButtonGroup.tsx
+++ b/packages/core/src/components/RadioButton/RadioButtonGroup.tsx
@@ -6,7 +6,7 @@ export interface RadioButtonGroupProps {
   direction?: Direction;
   style?: StyleProp<ViewStyle>;
   value?: string;
-  onValueChange?: (value: string) => void;
+  onValueChange?: (value: string | number) => void;
   defaultValue?: string;
   theme: Theme;
   children: React.ReactNode;
@@ -28,13 +28,13 @@ const RadioButtonGroup: React.FC<RadioButtonGroupProps> = ({
   );
 
   React.useEffect(() => {
-    if (value != null) {
+    if (value !== null) {
       setInternalValue(value);
     }
   }, [value]);
 
   React.useEffect(() => {
-    if (defaultValue != null) {
+    if (defaultValue !== null) {
       setInternalValue(defaultValue);
     }
   }, [defaultValue]);
@@ -60,7 +60,8 @@ const RadioButtonGroup: React.FC<RadioButtonGroupProps> = ({
     <View style={[{ minHeight: 40 }, style]} {...rest}>
       <Provider
         value={{
-          value: internalValue || "",
+          // @ts-ignore
+          value: internalValue === 0 ? 0 : internalValue || "",
           onValueChange: handleValueChange,
           direction,
         }}

--- a/packages/core/src/components/RadioButton/RadioButtonRow.tsx
+++ b/packages/core/src/components/RadioButton/RadioButtonRow.tsx
@@ -22,7 +22,7 @@ export enum Direction {
 
 export interface RadioButtonRowProps extends Omit<RadioButtonProps, "onPress"> {
   label: string | React.ReactNode;
-  value?: string; // A string (or JS number to be parsed to String) that this radio button row represents when selected
+  value: string; // A string (or number that will be parsed String(number)) that this radio button row represents when selected
   color?: string;
   unselectedColor?: string;
   labelContainerStyle: StyleProp<ViewStyle>;
@@ -51,11 +51,7 @@ const renderLabel = (
   textStyle: StyleProp<TextStyle>
 ) => {
   if (typeof label === "string") {
-    return (
-      <Text style={[labelStyle, textStyle] /* NOTE order right? */}>
-        {label}
-      </Text>
-    );
+    return <Text style={[labelStyle, textStyle]}>{label}</Text>;
   } else {
     return <>{label}</>;
   }
@@ -101,11 +97,7 @@ const RadioButtonRow: React.FC<RadioButtonRowProps & IconSlot> = ({
   return (
     <Touchable
       onPress={handlePress}
-      style={[
-        styles.mainParent,
-        { flexDirection: direction },
-        viewStyles /* NOTE order right? */,
-      ]}
+      style={[styles.mainParent, { flexDirection: direction }, viewStyles]}
       disabled={disabled}
       {...rest}
     >

--- a/packages/core/src/components/RadioButton/RadioButtonRow.tsx
+++ b/packages/core/src/components/RadioButton/RadioButtonRow.tsx
@@ -13,7 +13,7 @@ import { useRadioButtonGroupContext } from "./context";
 import type { IconSlot } from "../../interfaces/Icon";
 import { Direction as GroupDirection } from "./context";
 import Touchable from "../Touchable";
-import { extractStyles } from "../../utilities";
+import { extractStyles, getRealValue } from "../../utilities";
 
 export enum Direction {
   Row = "row",
@@ -22,7 +22,7 @@ export enum Direction {
 
 export interface RadioButtonRowProps extends Omit<RadioButtonProps, "onPress"> {
   label: string | React.ReactNode;
-  value: string; // A string that this radio button row represents when selected
+  value?: string; // A string (or JS number to be parsed to String) that this radio button row represents when selected
   color?: string;
   unselectedColor?: string;
   labelContainerStyle: StyleProp<ViewStyle>;
@@ -46,14 +46,16 @@ const getRadioButtonAlignment = (
 };
 
 const renderLabel = (
-  value: string | React.ReactNode,
+  label: string | React.ReactNode,
   labelStyle: StyleProp<TextStyle>,
   textStyle: StyleProp<TextStyle>
 ) => {
-  if (typeof value === "string") {
-    return <Text style={[labelStyle, textStyle]}>{value}</Text>;
+  console.log({ label, labelStyle, textStyle });
+
+  if (typeof label === "string") {
+    return <Text style={[textStyle, labelStyle]}>{label}</Text>;
   } else {
-    return <>{value}</>;
+    return <>{label}</>;
   }
 };
 
@@ -63,7 +65,7 @@ const RadioButtonRow: React.FC<RadioButtonRowProps & IconSlot> = ({
   value,
   color,
   unselectedColor,
-  onPress = () => {},
+  onPress,
   labelContainerStyle,
   labelStyle,
   radioButtonStyle,
@@ -79,9 +81,19 @@ const RadioButtonRow: React.FC<RadioButtonRowProps & IconSlot> = ({
     direction: parentDirection,
   } = useRadioButtonGroupContext();
 
+  const realValue = getRealValue(value);
+  const realContextValue = getRealValue(contextValue);
+  const isSelected =
+    selected ??
+    (realContextValue && realValue && realContextValue === realValue);
+
   const handlePress = () => {
-    onPress(value);
-    onValueChange && onValueChange(value);
+    console.log("RadioButtonRow:realValue", realValue);
+
+    if (realValue) {
+      onPress?.(realValue);
+      onValueChange?.(realValue);
+    }
   };
 
   const { textStyles, viewStyles } = extractStyles(style);
@@ -112,12 +124,10 @@ const RadioButtonRow: React.FC<RadioButtonRowProps & IconSlot> = ({
       >
         <RadioButton
           Icon={Icon}
-          selected={
-            selected || (contextValue != null && contextValue === value)
-          }
+          selected={isSelected ? true : false}
+          value={realValue}
           color={color}
           unselectedColor={unselectedColor}
-          onPress={handlePress}
           style={radioButtonStyle}
         />
       </View>

--- a/packages/core/src/components/RadioButton/RadioButtonRow.tsx
+++ b/packages/core/src/components/RadioButton/RadioButtonRow.tsx
@@ -46,14 +46,14 @@ const getRadioButtonAlignment = (
 };
 
 const renderLabel = (
-  label: string | React.ReactNode,
+  value: string | React.ReactNode,
   labelStyle: StyleProp<TextStyle>,
   textStyle: StyleProp<TextStyle>
 ) => {
-  if (typeof label === "string") {
-    return <Text style={[labelStyle, textStyle]}>{label}</Text>;
+  if (typeof value === "string") {
+    return <Text style={[labelStyle, textStyle]}>{value}</Text>;
   } else {
-    return <>{label}</>;
+    return <>{value}</>;
   }
 };
 
@@ -116,7 +116,7 @@ const RadioButtonRow: React.FC<RadioButtonRowProps & IconSlot> = ({
       >
         <RadioButton
           Icon={Icon}
-          selected={isSelected ? true : false}
+          selected={isSelected}
           value={realValue}
           color={color}
           unselectedColor={unselectedColor}

--- a/packages/core/src/components/RadioButton/RadioButtonRow.tsx
+++ b/packages/core/src/components/RadioButton/RadioButtonRow.tsx
@@ -50,10 +50,12 @@ const renderLabel = (
   labelStyle: StyleProp<TextStyle>,
   textStyle: StyleProp<TextStyle>
 ) => {
-  console.log({ label, labelStyle, textStyle });
-
   if (typeof label === "string") {
-    return <Text style={[textStyle, labelStyle]}>{label}</Text>;
+    return (
+      <Text style={[labelStyle, textStyle] /* NOTE order right? */}>
+        {label}
+      </Text>
+    );
   } else {
     return <>{label}</>;
   }
@@ -88,8 +90,6 @@ const RadioButtonRow: React.FC<RadioButtonRowProps & IconSlot> = ({
     (realContextValue && realValue && realContextValue === realValue);
 
   const handlePress = () => {
-    console.log("RadioButtonRow:realValue", realValue);
-
     if (realValue) {
       onPress?.(realValue);
       onValueChange?.(realValue);
@@ -101,7 +101,11 @@ const RadioButtonRow: React.FC<RadioButtonRowProps & IconSlot> = ({
   return (
     <Touchable
       onPress={handlePress}
-      style={[styles.mainParent, { flexDirection: direction }, viewStyles]}
+      style={[
+        styles.mainParent,
+        { flexDirection: direction },
+        viewStyles /* NOTE order right? */,
+      ]}
       disabled={disabled}
       {...rest}
     >

--- a/packages/core/src/components/RadioButton/RadioButtonRow.tsx
+++ b/packages/core/src/components/RadioButton/RadioButtonRow.tsx
@@ -60,7 +60,7 @@ const renderLabel = (
 const RadioButtonRow: React.FC<RadioButtonRowProps & IconSlot> = ({
   Icon,
   label,
-  value,
+  value = "",
   color,
   unselectedColor,
   onPress,
@@ -81,15 +81,11 @@ const RadioButtonRow: React.FC<RadioButtonRowProps & IconSlot> = ({
 
   const realValue = getValueForRadioButton(value);
   const realContextValue = getValueForRadioButton(contextValue);
-  const isSelected =
-    selected ??
-    (realContextValue && realValue && realContextValue === realValue);
+  const isSelected = selected ?? realContextValue === realValue;
 
   const handlePress = () => {
-    if (realValue) {
-      onPress?.(realValue);
-      onValueChange?.(realValue);
-    }
+    onPress?.(realValue);
+    onValueChange?.(realValue);
   };
 
   const { textStyles, viewStyles } = extractStyles(style);

--- a/packages/core/src/components/RadioButton/RadioButtonRow.tsx
+++ b/packages/core/src/components/RadioButton/RadioButtonRow.tsx
@@ -13,7 +13,7 @@ import { useRadioButtonGroupContext } from "./context";
 import type { IconSlot } from "../../interfaces/Icon";
 import { Direction as GroupDirection } from "./context";
 import Touchable from "../Touchable";
-import { extractStyles, getRealValue } from "../../utilities";
+import { extractStyles, getValueForRadioButton } from "../../utilities";
 
 export enum Direction {
   Row = "row",
@@ -22,7 +22,7 @@ export enum Direction {
 
 export interface RadioButtonRowProps extends Omit<RadioButtonProps, "onPress"> {
   label: string | React.ReactNode;
-  value: string; // A string (or number that will be parsed String(number)) that this radio button row represents when selected
+  value: string | number; // A string (or number that will be parsed String(number)) that this radio button row represents when selected
   color?: string;
   unselectedColor?: string;
   labelContainerStyle: StyleProp<ViewStyle>;
@@ -79,8 +79,8 @@ const RadioButtonRow: React.FC<RadioButtonRowProps & IconSlot> = ({
     direction: parentDirection,
   } = useRadioButtonGroupContext();
 
-  const realValue = getRealValue(value);
-  const realContextValue = getRealValue(contextValue);
+  const realValue = getValueForRadioButton(value);
+  const realContextValue = getValueForRadioButton(contextValue);
   const isSelected =
     selected ??
     (realContextValue && realValue && realContextValue === realValue);

--- a/packages/core/src/utilities.ts
+++ b/packages/core/src/utilities.ts
@@ -1,4 +1,5 @@
 import { StyleSheet, StyleProp, TextStyle } from "react-native";
+import { isString, isNumber } from "lodash";
 
 export function extractStyles(style: StyleProp<any>) {
   const {
@@ -64,15 +65,9 @@ export function applyStyles(
   return flattenedStyles;
 }
 
-export function getRealValue(value: any) {
-  // console.log("getRealValue typeof", typeof value);
-  // console.log("getRealValue value", value);
-  switch (typeof value) {
-    case "string":
-      return value;
-    case "number":
-      return String(value);
-    default:
-      return undefined;
-  }
+export function getRealValue(value: string | number | undefined) {
+  if (isString(value)) return value;
+  else if (isNumber(value)) return String(value);
+  else if (!value) return undefined;
+  else throw new Error(`Invalid value: ${value}`);
 }

--- a/packages/core/src/utilities.ts
+++ b/packages/core/src/utilities.ts
@@ -65,13 +65,11 @@ export function applyStyles(
   return flattenedStyles;
 }
 
-export function getValueForRadioButton(value?: string | number) {
+export function getValueForRadioButton(value: string | number) {
   if (isString(value)) {
     return value;
   } else if (isNumber(value)) {
     return String(value);
-  } else if (value === undefined) {
-    return undefined;
   } else {
     throw new Error(`Invalid value: ${value}`);
   }

--- a/packages/core/src/utilities.ts
+++ b/packages/core/src/utilities.ts
@@ -63,3 +63,15 @@ export function applyStyles(
 
   return flattenedStyles;
 }
+
+export function getRealValue(value: any) {
+  console.log("getRealValue", value);
+  switch (typeof value) {
+    case "string":
+      return value;
+    case "number":
+      return String(value);
+    default:
+      return undefined;
+  }
+}

--- a/packages/core/src/utilities.ts
+++ b/packages/core/src/utilities.ts
@@ -65,7 +65,8 @@ export function applyStyles(
 }
 
 export function getRealValue(value: any) {
-  console.log("getRealValue", value);
+  // console.log("getRealValue typeof", typeof value);
+  // console.log("getRealValue value", value);
   switch (typeof value) {
     case "string":
       return value;

--- a/packages/core/src/utilities.ts
+++ b/packages/core/src/utilities.ts
@@ -65,9 +65,14 @@ export function applyStyles(
   return flattenedStyles;
 }
 
-export function getRealValue(value: string | number | undefined) {
-  if (isString(value)) return value;
-  else if (isNumber(value)) return String(value);
-  else if (!value) return undefined;
-  else throw new Error(`Invalid value: ${value}`);
+export function getValueForRadioButton(value?: string | number) {
+  if (isString(value)) {
+    return value;
+  } else if (isNumber(value)) {
+    return String(value);
+  } else if (value === undefined) {
+    return undefined;
+  } else {
+    throw new Error(`Invalid value: ${value}`);
+  }
 }


### PR DESCRIPTION
Per [P-2714](https://linear.app/draftbit/issue/P-2714/cant-select-radio-button-when-value-is-set-to-0-zero), assigning a value of 0 (not a sting "0") is not supported with any of the RadioButton components.

Although they are typed for String(s), when strictly using JS, they will allow a user to initialize / use number props and work -- even though real forms do not use numbers as values.  However, 0 being a falsely value is not recognized and is rejected when you enter it in as a prop.

Hence, the solution to parse all numbers to strings and so that they if they are provided in a JS (non-TS) context, they will work as expected -- including the number 0.