### PR TITLE
Fix checkboxRow mapping to 'checkboxRowValue'

### DIFF
--- a/packages/core/src/mappings/CheckboxRow.ts
+++ b/packages/core/src/mappings/CheckboxRow.ts
@@ -31,7 +31,7 @@ export const SEED_DATA = {
     }),
     direction: createRowDirectionProp(),
     fieldName: createFieldNameProp({
-      defaultValue: "checkboxValue",
+      defaultValue: "checkboxRowValue",
       valuePropName: "value",
       handlerPropName: "onPress",
     }),


### PR DESCRIPTION
Per [P-2720](https://linear.app/draftbit/issue/P-2720/checkbox-and-checkbox-row-cause-redscreen), this will stop the Builder from breaking when both a CheckBox & CheckBoxRow are on the screen.