### PR TITLE
Fix NumberInput seed data props fieldName to stop collision with TextInput

### DIFF
--- a/packages/core/src/mappings/TextInput.ts
+++ b/packages/core/src/mappings/TextInput.ts
@@ -7,6 +7,7 @@ import {
   TEXT_INPUT_PROPS,
   NUMBER_INPUT_PROPS,
   Triggers,
+  createFieldNameProp,
 } from "@draftbit/types";
 
 export const SEED_DATA_PROPS = {
@@ -219,8 +220,13 @@ export const SEED_DATA = [
     },
     triggers: [Triggers.OnChangeText],
     props: {
-      ...NUMBER_INPUT_PROPS,
       ...SEED_DATA_PROPS,
+      ...NUMBER_INPUT_PROPS,
+      fieldName: createFieldNameProp({
+        defaultValue: "numberInputValue",
+        valuePropName: "value",
+        handlerPropName: "onChangeText",
+      }),
     },
   },
 ];


### PR DESCRIPTION
Fixed issue with broken screen when an TextInput was also on the screen.

To test, add both a TextInput and NumberInput on the screen and watch  it break ... then reseed with this PR .. voila!