### PR TITLE
Bugfix: Allow defaultValue & value prop updates in NumberInput

### DIFF
--- a/packages/core/src/components/NumberInput.tsx
+++ b/packages/core/src/components/NumberInput.tsx
@@ -50,6 +50,8 @@ const NumberInput: FC<Props> = ({
     onChangeText?.(number);
   };
 
+  /* set currentStringNumberValue directly to defaultValue if it exists on load
+  ( no need to use TextInput's defaultValue because its value is always controlled & set ) */
   useEffect(() => {
     const defaultStringNumberValue = formatValueToStringNumber(
       defaultValue,
@@ -62,6 +64,7 @@ const NumberInput: FC<Props> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // set new value if different from current value
   useEffect(() => {
     const nextStringNumberValue = formatValueToStringNumber(
       value,

--- a/packages/core/src/components/NumberInput.tsx
+++ b/packages/core/src/components/NumberInput.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useState } from "react";
+import React, { FC, useEffect, useState } from "react";
 import { TextInput } from "react-native";
 import { isString, isNumber, isNaN } from "lodash";
 
@@ -14,49 +14,72 @@ const NumberInput: FC<Props> = ({
   defaultValue,
   ...props
 }) => {
-  const formatValueToStringNumber = useCallback(
-    (valueToFormat?: number | string, currentStringNumberValue?: string) => {
-      if (valueToFormat != null) {
-        if (isString(valueToFormat) && valueToFormat !== "") {
-          if (/^0[1-9]$/.test(valueToFormat)) {
-            return valueToFormat.slice(1);
-          } else if (/^[+-]?([0-9]+\.?[0-9]*|\.[0-9]+)$/.test(valueToFormat)) {
-            return valueToFormat;
-          } else if (currentStringNumberValue) {
-            return currentStringNumberValue;
-          }
-        } else if (isNumber(valueToFormat) && !isNaN(valueToFormat)) {
-          return valueToFormat.toString();
+  const formatValueToStringNumber = (
+    valueToFormat?: number | string,
+    currentStringNumberValue?: string
+  ) => {
+    if (valueToFormat != null) {
+      if (isString(valueToFormat) && valueToFormat !== "") {
+        if (/^0[1-9]$/.test(valueToFormat)) {
+          return valueToFormat.slice(1);
+        } else if (/^[+-]?([0-9]+\.?[0-9]*|\.[0-9]+)$/.test(valueToFormat)) {
+          return valueToFormat;
+        } else if (currentStringNumberValue) {
+          return currentStringNumberValue;
         }
+      } else if (isNumber(valueToFormat) && !isNaN(valueToFormat)) {
+        return valueToFormat.toString();
       }
+    }
 
-      return "0";
-    },
-    []
-  );
+    return "0";
+  };
 
-  const [stringNumberValue, setStringNumberValue] = useState(
+  const [currentStringNumberValue, setCurrentStringNumberValue] = useState(
     formatValueToStringNumber(value)
   );
 
   const handleChangeText = (newValue: string) => {
     const newStringNumberValue = formatValueToStringNumber(
       newValue,
-      stringNumberValue
+      currentStringNumberValue
     );
     const number = parseFloat(newStringNumberValue);
 
-    setStringNumberValue(newStringNumberValue);
+    setCurrentStringNumberValue(newStringNumberValue);
     onChangeText?.(number);
   };
+
+  useEffect(() => {
+    const defaultStringNumberValue = formatValueToStringNumber(
+      defaultValue,
+      currentStringNumberValue
+    );
+
+    if (currentStringNumberValue !== defaultStringNumberValue) {
+      setCurrentStringNumberValue(defaultStringNumberValue);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const nextStringNumberValue = formatValueToStringNumber(
+      value,
+      currentStringNumberValue
+    );
+
+    if (currentStringNumberValue !== nextStringNumberValue) {
+      handleChangeText(nextStringNumberValue);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value]);
 
   return (
     <TextInput
       keyboardType="numeric"
-      {...props}
-      value={stringNumberValue}
-      defaultValue={formatValueToStringNumber(defaultValue)}
+      value={currentStringNumberValue}
       onChangeText={handleChangeText}
+      {...props}
     />
   );
 };


### PR DESCRIPTION
This is a fix of the oversight when the `NumberInput` was rewritten here...

https://github.com/draftbit/react-native-jigsaw/pull/398/files

...did not test in all cases.  This PR looks to be "the one to rule them all" for `NumberInput`.