### PR TITLE
Fix height issue with TextField & Picker Text for left Icons

### DIFF
--- a/example/src/PickerExample.js
+++ b/example/src/PickerExample.js
@@ -24,6 +24,8 @@ function PickerExample({ theme }) {
           value={value}
           onValueChange={setValue}
           rightIconName={"AntDesign/caretright"}
+          leftIconName={"AntDesign/caretleft"}
+          leftIconMode="outset"
         />
       </Section>
 
@@ -93,6 +95,8 @@ function PickerExample({ theme }) {
           options={OPTIONS}
           value={value}
           onValueChange={setValue}
+          leftIconName={"AntDesign/caretleft"}
+          leftIconMode="outset"
         />
       </Section>
 
@@ -153,6 +157,7 @@ function PickerExample({ theme }) {
             color: "red",
             fontFamily: "Courier New",
           }}
+          leftIconName={"AntDesign/caretleft"}
         />
       </Section>
 

--- a/packages/core/src/components/TextField.tsx
+++ b/packages/core/src/components/TextField.tsx
@@ -359,6 +359,7 @@ class TextField extends React.Component<Props, State> {
           : leftIconMode === "outset"
           ? 16
           : 0,
+      marginLeft: leftIconMode === "inset" && type === "solid" ? 16 : 0,
     };
 
     const labelStyle = {
@@ -536,13 +537,13 @@ class TextField extends React.Component<Props, State> {
           ) : null}
 
           {leftIconName && leftIconMode === "inset" ? (
-            <Icon
-              {...leftIconProps}
+            <View
               style={{
-                ...leftIconStyle,
-                marginLeft: type === "solid" ? 16 : 0,
+                justifyContent: type === "solid" ? "center" : undefined,
               }}
-            />
+            >
+              <Icon {...leftIconProps} style={leftIconStyle} />
+            </View>
           ) : null}
 
           {render({


### PR DESCRIPTION
Currently, if you add a left icon using

```
leftIconName="AntDesign/caretleft"
leftIconMode="outset" / "inset"
```

inside of either `TextiField` or `Picker`, you get mixed height results on all platforms.

This looks to unify that behavior -- especially when the `type=solid ` prop is passed in `TextField` which is always the case with `Picker`.

KNOWN ISSUES: there are still many issues with text and positioning with this "hack" fix ... it only solves this one issue and does not fix the other layout issues or state issues for this component.