### PR TITLE
Fix DatePicker for iOS

### DIFF
--- a/packages/core/src/components/DatePicker/DatePicker.tsx
+++ b/packages/core/src/components/DatePicker/DatePicker.tsx
@@ -7,7 +7,6 @@ import {
   StyleProp,
   ViewStyle,
   TextStyle,
-  Platform,
   TextInputProps,
   ImageStyle,
   I18nManager,
@@ -19,7 +18,6 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import dateFormat from "dateformat";
 import { withTheme } from "../../theming";
 import Portal from "../Portal/Portal";
-import Button from "../DeprecatedButton";
 import Touchable from "../Touchable";
 import DateTimePicker from "./DatePickerComponent";
 
@@ -496,24 +494,13 @@ const DatePicker: React.FC<Props> = ({
                 },
               ]}
             >
-              {Platform.OS === "ios" && (
-                <Button
-                  Icon={Icon}
-                  type="text"
-                  onPress={toggleVisibility}
-                  style={styles.closeButton}
-                >
-                  Close
-                </Button>
-              )}
-
               <DateTimePicker
                 value={getValidDate()}
                 mode={mode}
                 isVisible={pickerVisible}
                 toggleVisibility={toggleVisibility}
                 onChange={(_event: any, data: any) => {
-                  Platform.OS === "ios" ? null : toggleVisibility();
+                  toggleVisibility();
                   setValue(data);
                   onDateChange(data);
                 }}


### PR DESCRIPTION
You can now use the built in "Confirm" button to set date.

The trade off is that is does not update/set state in the background (behind the modal) but this is not expected IMHO and it does set the state "for real" once you click "Confirm".