### PR TITLE
Fix Checkbox(Row, Group, GroupRow) and RadioRow issues

### DIFF
--- a/example/src/CheckboxExample.js
+++ b/example/src/CheckboxExample.js
@@ -1,6 +1,5 @@
 import {
   Checkbox,
-  CheckboxGroup,
   CheckboxRow,
   Switch,
   Row,
@@ -23,17 +22,6 @@ const SingleCheckboxWrapper = ({ label, children }) => (
 const CheckboxExample = ({ theme }) => {
   const [checked, setChecked] = React.useState(true);
   const [airtableChecked, setAirtableChecked] = React.useState(undefined);
-  const [selectedValues, setSelectedValues] = React.useState([]);
-
-  const handleValueSelected = (value, selected) => {
-    if (selected) {
-      setSelectedValues((prevState) => [...prevState, value]);
-    } else {
-      setSelectedValues((prevState) =>
-        prevState.filter((val) => val !== value)
-      );
-    }
-  };
 
   const handlePress = (value) => setChecked(value);
   // An example to simulate how Airtable returns boolean values: `true` or `undefined`
@@ -101,34 +89,26 @@ const CheckboxExample = ({ theme }) => {
         </Row>
       </Section>
 
-      <Section title="Checkbox Group (horizontal)">
-        <CheckboxGroup
-          direction="horizontal"
-          values={selectedValues}
-          onValueChange={handleValueSelected}
-        >
-          <CheckboxRow label="First" value="1" style={{ fontSize: 32 }} />
-          <CheckboxRow label="Second" value="2" />
-          <CheckboxRow label="Third" value="3" />
-        </CheckboxGroup>
-      </Section>
-
-      <Section title="Checkbox Group (vertical)">
-        <CheckboxGroup
-          direction="vertical"
-          values={selectedValues}
-          onValueChange={handleValueSelected}
-        >
-          <CheckboxRow label="First" value="1" />
-          <CheckboxRow label="Second" value="2" />
-          <CheckboxRow
-            direction="row-reverse"
-            label="Third (reversed)"
-            value="3"
-          />
-          <CheckboxRow label="Always selected" value="4" status="checked" />
-          <CheckboxRow label="Disabled" disabled />
-        </CheckboxGroup>
+      <Section title="CheckboxRow">
+        <CheckboxRow
+          label="First"
+          direction="row"
+          style={{ fontSize: 32 }}
+          onPress={setChecked}
+          status={checked}
+          size={72}
+          checkedIcon="Ionicons/notifications"
+          uncheckedIcon="Ionicons/notifications-off"
+          uncheckedColor={"dodgerblue"}
+          color={"hotpink"}
+        />
+        <CheckboxRow
+          label="Second"
+          direction="row-reverse"
+          style={{ fontSize: 32 }}
+          onPress={setChecked}
+          status={checked}
+        />
       </Section>
     </ScreenContainer>
   );

--- a/packages/core/src/components/Checkbox/Checkbox.tsx
+++ b/packages/core/src/components/Checkbox/Checkbox.tsx
@@ -32,7 +32,7 @@ const Checkbox: React.FC<CheckboxProps & TouchableHighlightProps & IconSlot> =
     Icon,
     status,
     disabled = false,
-    onPress = () => {},
+    onPress,
     onCheck,
     onUncheck,
     color,
@@ -59,6 +59,7 @@ const Checkbox: React.FC<CheckboxProps & TouchableHighlightProps & IconSlot> =
     const previousDefaultValue = usePrevious(defaultValue) as
       | boolean
       | undefined;
+
     React.useEffect(() => {
       if (defaultValue !== previousDefaultValue) {
         setInternalValue(Boolean(defaultValue));
@@ -73,15 +74,16 @@ const Checkbox: React.FC<CheckboxProps & TouchableHighlightProps & IconSlot> =
 
     const handlePress = () => {
       const newValue = !internalValue;
-      setInternalValue(newValue);
-      onPress(newValue);
 
-      if (onCheck && newValue) {
-        onCheck();
+      setInternalValue(newValue);
+      onPress?.(newValue);
+
+      if (newValue) {
+        onCheck?.();
       }
 
-      if (onUncheck && !newValue) {
-        onUncheck();
+      if (!newValue) {
+        onUncheck?.();
       }
     };
 

--- a/packages/core/src/components/Checkbox/CheckboxGroupRow.tsx
+++ b/packages/core/src/components/Checkbox/CheckboxGroupRow.tsx
@@ -84,13 +84,8 @@ const CheckboxGroupRow: React.FC<CheckboxGroupRowProps & IconSlot> = ({
 
   const handlePress = () => {
     if (!disabled) {
-      console.log("isChecked BEFORE", isChecked);
-      console.log("value", value);
-
       onPress?.(!isChecked);
       onValueChange?.(value, !isChecked);
-
-      console.log("isChecked AFTER", isChecked);
     }
   };
 

--- a/packages/core/src/components/Checkbox/CheckboxGroupRow.tsx
+++ b/packages/core/src/components/Checkbox/CheckboxGroupRow.tsx
@@ -1,0 +1,157 @@
+import * as React from "react";
+import {
+  StyleProp,
+  ViewStyle,
+  StyleSheet,
+  TextStyle,
+  View,
+  Platform,
+} from "react-native";
+import Checkbox, { CheckboxProps } from "./Checkbox";
+import Text from "../Text";
+import { useCheckboxGroupContext } from "./context";
+import type { IconSlot } from "../../interfaces/Icon";
+import { Direction as GroupDirection } from "./context";
+import Touchable from "../Touchable";
+import { extractStyles } from "../../utilities";
+
+export enum Direction {
+  Row = "row",
+  RowReverse = "row-reverse",
+}
+
+export interface CheckboxGroupRowProps extends Omit<CheckboxProps, "onPress"> {
+  label: string | React.ReactNode;
+  value: string; // A string that this checkbox represents
+  labelContainerStyle: StyleProp<ViewStyle>;
+  checkboxStyle?: StyleProp<ViewStyle>;
+  labelStyle?: StyleProp<TextStyle>;
+  onPress?: (value: boolean) => void;
+  direction?: Direction;
+  color: string;
+  unselectedColor: string;
+}
+
+const getCheckboxAlignment = (
+  parentDirection: GroupDirection | undefined,
+  direction: Direction
+) => {
+  if (parentDirection === GroupDirection.Horizontal) {
+    return direction === Direction.Row ? "flex-start" : "flex-end";
+  } else if (direction === Direction.RowReverse) {
+    return "flex-start";
+  } else {
+    return "flex-end";
+  }
+};
+
+const renderLabel = (
+  value: string | React.ReactNode,
+  labelStyle: StyleProp<TextStyle>,
+  textStyle: StyleProp<TextStyle>
+) => {
+  if (typeof value === "string") {
+    return <Text style={[labelStyle, textStyle]}>{value}</Text>;
+  } else {
+    return <>{value}</>;
+  }
+};
+
+const CheckboxGroupRow: React.FC<CheckboxGroupRowProps & IconSlot> = ({
+  Icon,
+  label = "Label",
+  status,
+  value,
+  onPress,
+  labelContainerStyle,
+  labelStyle,
+  checkboxStyle,
+  direction = Direction.Row,
+  disabled,
+  style,
+  color,
+  uncheckedColor,
+  ...rest
+}) => {
+  const {
+    values: selectedValues,
+    onValueChange,
+    direction: parentDirection,
+  } = useCheckboxGroupContext();
+
+  const values = Array.isArray(selectedValues) ? selectedValues : [];
+  const isChecked = status || values.includes(value);
+
+  const handlePress = () => {
+    if (!disabled) {
+      console.log("isChecked BEFORE", isChecked);
+      console.log("value", value);
+
+      onPress?.(!isChecked);
+      onValueChange?.(value, !isChecked);
+
+      console.log("isChecked AFTER", isChecked);
+    }
+  };
+
+  const { textStyles, viewStyles } = extractStyles(style);
+
+  return (
+    <Touchable
+      onPress={handlePress}
+      style={[styles.mainParent, { flexDirection: direction }, viewStyles]}
+      disabled={disabled}
+      {...rest}
+    >
+      <View
+        style={[
+          styles.label,
+          {
+            alignItems: direction === Direction.Row ? "flex-start" : "flex-end",
+          },
+          labelContainerStyle,
+        ]}
+      >
+        {renderLabel(label, labelStyle, textStyles)}
+      </View>
+      <View
+        style={{
+          flex: 1,
+          alignItems: getCheckboxAlignment(parentDirection, direction),
+        }}
+      >
+        <Checkbox
+          Icon={Icon}
+          status={isChecked}
+          onPress={handlePress}
+          style={checkboxStyle}
+          disabled={disabled}
+          color={color}
+          uncheckedColor={uncheckedColor}
+        />
+      </View>
+    </Touchable>
+  );
+};
+
+const styles = StyleSheet.create({
+  mainParent: {
+    alignItems: "center",
+    justifyContent: "space-around",
+    paddingStart: 20,
+    minHeight: 50,
+    paddingEnd: 20,
+    display: "flex",
+    ...Platform.select({
+      web: {
+        cursor: "pointer",
+        userSelect: "none",
+      },
+    }),
+  },
+  label: {
+    flex: 3,
+  },
+});
+
+export default CheckboxGroupRow;

--- a/packages/core/src/components/Checkbox/CheckboxRow.tsx
+++ b/packages/core/src/components/Checkbox/CheckboxRow.tsx
@@ -136,7 +136,7 @@ const styles = StyleSheet.create({
     paddingStart: 20,
     minHeight: 50,
     paddingEnd: 20,
-    flex: 1,
+    display: "flex",
     ...Platform.select({
       web: {
         cursor: "pointer",

--- a/packages/core/src/components/RadioButton/RadioButtonRow.tsx
+++ b/packages/core/src/components/RadioButton/RadioButtonRow.tsx
@@ -134,7 +134,7 @@ const styles = StyleSheet.create({
     paddingStart: 20,
     minHeight: 50,
     paddingEnd: 20,
-    flex: 1,
+    display: "flex",
     ...Platform.select({
       web: {
         cursor: "pointer",

--- a/packages/core/src/mappings/CheckboxRow.ts
+++ b/packages/core/src/mappings/CheckboxRow.ts
@@ -1,8 +1,11 @@
 import {
+  createBoolProp,
   createTextProp,
   createTextStyle,
   createRowDirectionProp,
   createFieldNameProp,
+  createIconProp,
+  createStaticNumberProp,
   COMPONENT_TYPES,
   Triggers,
   createColorProp,
@@ -15,8 +18,13 @@ export const SEED_DATA = {
   layout: {
     minHeight: 50,
   },
-  triggers: [Triggers.OnPress],
+  triggers: [Triggers.OnPress, Triggers.OnCheck, Triggers.OnUncheck],
   props: {
+    fieldName: createFieldNameProp({
+      defaultValue: "checkboxRowValue",
+      valuePropName: "value",
+      handlerPropName: "onPress",
+    }),
     label: createTextProp({
       label: "Label",
       description: "Label to show with the checkbox",
@@ -30,17 +38,31 @@ export const SEED_DATA = {
       editable: false,
     }),
     direction: createRowDirectionProp(),
-    fieldName: createFieldNameProp({
-      defaultValue: "checkboxRowValue",
-      valuePropName: "value",
-      handlerPropName: "onPress",
-    }),
     color: createColorProp({
       description: "Color for the button (used when the checkbox is checked)",
     }),
     uncheckedColor: createColorProp({
       label: "Unselected Color",
       description: "Color for the button when the checkbox is unchecked",
+    }),
+    disabled: createBoolProp({
+      label: "Disabled",
+      description: "Whether the checkbox is disabled",
+    }),
+    size: createStaticNumberProp({
+      label: "Size",
+      description: "Specifies the size of the icon",
+      defaultValue: null,
+    }),
+    checkedIcon: createIconProp({
+      label: "Checked Icon",
+      description: 'Icon to show when the checkbox status is "checked"',
+      defaultValue: null,
+    }),
+    uncheckedIcon: createIconProp({
+      label: "Unchecked Icon",
+      description: 'Icon to show when the checkbox status is "unchecked"',
+      defaultValue: null,
     }),
   },
 };


### PR DESCRIPTION
Per @bluerssen `CheckboxRow` should function exactly the same as `Checkbox` with the added value of having a row of text horizontally adjacent to it.

This PR...

1. Fixes a flex issue with `RadioButtonRow` & `CheckboxRow`
2. Splits the original `CheckboxRow` 2 different implementations / components: 
  a. `CheckboxRow` which is now functionally the same as `Checkbox` with added props for a label, etc.
  b. `CheckboxGroupRow` which is the original implementation that is designed to work as a child of `CheckboxGroup` 
3. Refactors / all components -- usually just a little -- for clarity
4. Updated mappings for `CheckboxRow`
5. Edits the `CheckboxExample.js` file to reflect the new way to use `CheckboxRow`

Finally...

There is a lot of code duplication between `CheckboxRow` & `Checkbox` now.  They could be merged to a single component LATER :)

And the newly created `CheckboxGroupRow` component ... like `CheckboxGroup` is not being exported or used currently.