### PR TITLE
Fix ScrollView double-spacing issue

### DIFF
--- a/packages/core/src/components/ScreenContainer.tsx
+++ b/packages/core/src/components/ScreenContainer.tsx
@@ -56,15 +56,15 @@ function ScreenContainer({
       {scrollable ? (
         <ScrollView
           contentContainerStyle={[
+            styles.scrollViewContainer,
             { backgroundColor },
             style,
-            styles.scrollViewContainer,
           ]}
         >
           {children}
         </ScrollView>
       ) : (
-        <View style={[{ backgroundColor }, style, styles.container]}>
+        <View style={[styles.container, { backgroundColor }, style]}>
           {children}
         </View>
       )}

--- a/packages/core/src/components/ScreenContainer.tsx
+++ b/packages/core/src/components/ScreenContainer.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {
   StyleSheet,
-  ScrollView as NativeScrollView,
+  ScrollView,
   StyleProp,
   ViewStyle,
   View,
@@ -10,27 +10,6 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import type { Edge } from "react-native-safe-area-context";
 import { withTheme } from "../theming";
 import type { Theme } from "../styles/DefaultTheme";
-
-function ScrollView({
-  children,
-  style,
-}: {
-  children: React.ReactNode;
-  style?: StyleProp<ViewStyle>;
-}) {
-  return (
-    <NativeScrollView
-      contentContainerStyle={[
-        {
-          flexGrow: 1,
-        },
-        style,
-      ]}
-    >
-      {children}
-    </NativeScrollView>
-  );
-}
 
 type Props = {
   hasSafeArea: boolean;
@@ -74,13 +53,21 @@ function ScreenContainer({
       ]}
       {...rest}
     >
-      <View style={[styles.container, { backgroundColor }, style]}>
-        {scrollable ? (
-          <ScrollView style={style}>{children}</ScrollView>
-        ) : (
-          children
-        )}
-      </View>
+      {scrollable ? (
+        <ScrollView
+          contentContainerStyle={[
+            { backgroundColor },
+            style,
+            styles.scrollViewContainer,
+          ]}
+        >
+          {children}
+        </ScrollView>
+      ) : (
+        <View style={[{ backgroundColor }, style, styles.container]}>
+          {children}
+        </View>
+      )}
     </SafeAreaView>
   );
 }
@@ -88,6 +75,10 @@ function ScreenContainer({
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+  },
+  scrollViewContainer: {
+    flexGrow: 1,
+    flex: undefined,
   },
 });
 


### PR DESCRIPTION
Per [P-2742](https://linear.app/draftbit/issue/P-2742/container-scrollview-adds-padding-or-margins), there was an issue where margin / padding and other props were being doubled when using a `ScrollView` via the `scrollable` prop.

I've refactored `ScreenContainer` and slotted it's style prop in a different order to solve this.  To test go to:

`example/src/App.tsx`

And replace the `export default function App()` on line 170 with this code and play with all the props...

```javascript
export default function App() {
  const [loaded] = Font.useFonts(customFonts);

  if (!loaded) {
    return <AppLoading />;
  }

  return (
    <Provider theme={DefaultTheme}>
      <SafeAreaProvider initialMetrics={initialWindowMetrics}>
        <ScreenContainer
          hasSafeArea={false} /* required */
          scrollable={true} /* required */
          hasBottomSafeArea={undefined}
          hasTopSafeArea={true}
          theme={{}} /* required */
          style={{
            paddingHorizontal: 20,
            borderColor: "red",
            borderWidth: 1,
            flex: 1,
          }}
        >
          {[...Array(100)].map((_) => (
            <Text>All work and no play makes Jack a dull boy.</Text>
          ))}
        </ScreenContainer>
      </SafeAreaProvider>
    </Provider>
  );
}
```