### PR TITLE
Allow Surface to use overflow to control border radius including children...

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -62,6 +62,8 @@ import SwiperExample from "./SwiperExample";
 
 import LinearGradientExample from "./LinearGradientExample";
 
+import SurfaceExample from "./SurfaceExample";
+
 const ROUTES = {
   Layout: LayoutExample,
   Icon: IconExample,
@@ -95,6 +97,7 @@ const ROUTES = {
   Switch: SwitchExample,
   Stepper: StepperExample,
   StarRating: StarRatingExample,
+  Surface: SurfaceExample,
   Swiper: SwiperExample,
   TextField: TextFieldExample,
   TextInput: TextInputExample,

--- a/example/src/SurfaceExample.js
+++ b/example/src/SurfaceExample.js
@@ -1,0 +1,84 @@
+import * as React from "react";
+import { Text, View, ImageBackground } from "react-native";
+import { withTheme, Surface } from "@draftbit/ui";
+import Section, { Container } from "./Section";
+
+function SurfaceExample({ theme }) {
+  return (
+    <Container style={{ backgroundColor: theme.colors.background }}>
+      <Section title="overflow: 'hidden'">
+        <Surface
+          style={{
+            aspectRatio: 2 / 3,
+            height: 300,
+            width: 200,
+            justifyContent: "space-between",
+            margin: 20,
+            borderRadius: 20,
+            overflow: "hidden",
+          }}
+          elevation={10}
+        >
+          <View>
+            <ImageBackground
+              source={require("./assets/images/icon.png")}
+              style={{
+                aspectRatio: 1 / 1,
+                height: 200,
+              }}
+              resizeMode={"cover"}
+            />
+          </View>
+
+          <View
+            style={{
+              flex: 1,
+              justifyContent: "center",
+              width: "100%",
+            }}
+          >
+            <Text style={{ textAlign: "center" }}>Bro</Text>
+          </View>
+        </Surface>
+      </Section>
+
+      <Section title="overflow: 'visible'">
+        <Surface
+          style={{
+            aspectRatio: 2 / 3,
+            height: 300,
+            width: 200,
+            justifyContent: "space-between",
+            margin: 20,
+            borderRadius: 20,
+            overflow: "visible",
+          }}
+          elevation={10}
+        >
+          <View>
+            <ImageBackground
+              source={require("./assets/images/icon.png")}
+              style={{
+                aspectRatio: 1 / 1,
+                height: 200,
+              }}
+              resizeMode={"cover"}
+            />
+          </View>
+
+          <View
+            style={{
+              flex: 1,
+              justifyContent: "center",
+              width: "100%",
+            }}
+          >
+            <Text style={{ textAlign: "center" }}>Bro</Text>
+          </View>
+        </Surface>
+      </Section>
+    </Container>
+  );
+}
+
+export default withTheme(SurfaceExample);

--- a/packages/core/src/components/Surface.tsx
+++ b/packages/core/src/components/Surface.tsx
@@ -15,7 +15,7 @@ import { withTheme } from "../theming";
 import type { Theme } from "../styles/DefaultTheme";
 
 type Props = {
-  elevation: number;
+  elevation?: number;
   style?: StyleProp<ViewStyle>;
   theme: Theme;
 } & ViewProps;

--- a/packages/core/src/components/Surface.tsx
+++ b/packages/core/src/components/Surface.tsx
@@ -6,6 +6,8 @@ import {
   ViewProps,
   StyleProp,
   ViewStyle,
+  View,
+  Platform,
 } from "react-native";
 import shadow from "../styles/shadow";
 import overlay from "../styles/overlay";
@@ -13,40 +15,60 @@ import { withTheme } from "../theming";
 import type { Theme } from "../styles/DefaultTheme";
 
 type Props = {
-  elevation?: number;
+  elevation: number;
   style?: StyleProp<ViewStyle>;
   theme: Theme;
 } & ViewProps;
 
 const Surface: React.FC<Props> = ({
-  elevation,
+  elevation: propElevation,
   style,
   theme,
   children,
   ...rest
 }) => {
-  const { elevation: styleElevation = 3, borderRadius: radius = 0 } =
-    (StyleSheet.flatten(style) || {}) as ViewStyle;
+  const {
+    elevation: styleElevation = 3,
+    borderRadius,
+    overflow,
+    height,
+    width,
+  } = (StyleSheet.flatten(style) || {}) as ViewStyle;
+
   const { dark: isDarkTheme, mode, colors } = theme;
-  const borderRadius = radius;
-  const ele = elevation || styleElevation;
+
+  const elevation = propElevation || styleElevation;
+
+  const evalationStyles = elevation ? shadow(elevation) : {};
 
   return (
     <Animated.View
       {...rest}
       style={[
+        style,
         {
-          borderRadius,
           backgroundColor:
             isDarkTheme && mode === "adaptive"
-              ? overlay(ele, colors.surface)
+              ? overlay(elevation, colors.surface)
               : colors.surface,
+          overflow: Platform.OS === "web" ? "hidden" : "visible",
+          elevation,
+          ...evalationStyles,
         },
-        elevation ? shadow(elevation) : null,
-        style,
       ]}
     >
-      {children}
+      <View
+        style={[
+          {
+            overflow,
+            borderRadius,
+            height,
+            width,
+          },
+        ]}
+      >
+        {children}
+      </View>
     </Animated.View>
   );
 };


### PR DESCRIPTION
Per [P-2762](https://linear.app/draftbit/issue/P-2762/border-radius-doesnt-work-with-surface-component-on-ios), each platform behaves differently regarding elevation & border radius.

Now they all work the same.  See new Surface Example in ExampleApp on all platforms.