### PR TITLE
Fix Accordion component

### DIFF
--- a/example/src/AccordionExample.js
+++ b/example/src/AccordionExample.js
@@ -34,7 +34,7 @@ function AccordionExample({ theme }) {
           />
         </AccordionGroup>
       </Section>
-      <Section title="Always Expanded Accordion group">
+      <Section title="Expanded Accordion group">
         <AccordionGroup
           openColor={theme.colors.primary}
           closedColor={theme.colors.secondary}
@@ -46,20 +46,27 @@ function AccordionExample({ theme }) {
           expanded={true}
         >
           <AccordionItem
-            label={"I am always visible"}
+            label={"I am visible when you first see this screen"}
             icon={"star"}
             style={{ fontSize: 20, color: theme.colors.primary }}
             iconColor={theme.colors.medium}
           />
         </AccordionGroup>
       </Section>
-      <Section title="Accordion with text inside">
+      <Section title="Accordion with text inside already open">
         <AccordionGroup
           label={"Basic"}
-          caretColor="purple"
+          caretColor="black"
+          openColor="red"
+          closedColor="green"
           style={{ padding: 8 }}
+          expanded={true}
+          icon={"star"}
+          iconSize={50}
+          caretSize={50}
         >
           <Text>Hello!</Text>
+          <Text>Is it me your looking for?</Text>
         </AccordionGroup>
       </Section>
     </Container>

--- a/packages/core/src/components/Accordion/AccordionGroup.tsx
+++ b/packages/core/src/components/Accordion/AccordionGroup.tsx
@@ -12,48 +12,71 @@ import type { IconSlot } from "../../interfaces/Icon";
 import type { Theme } from "../../styles/DefaultTheme";
 import { extractStyles } from "../../utilities";
 
-type Props = {
-  openColor: string;
-  closedColor: string;
-  caretColor: string;
-  icon?: string;
-  iconSize: number;
-  style?: StyleProp<TextStyle>;
-  children: React.ReactNode;
-  label: string;
+//  label: createTextProp({
+//       label: "Label",
+//     }),
+//     expanded: createStaticBoolProp({
+//       label: "Expanded",
+//       description:
+//         "Whether the AccordionGroup should be initaially expanded or not",
+//     }),
+//     openColor: createColorProp({
+//       label: "Open text color",
+//     }),
+//     closedColor: createColorProp({
+//       label: "Closed text color",
+//     }),
+//     caretColor: createColorProp({
+//       label: "Caret color",
+//     }),
+//     caretSize: createNumberProp({
+//       label: "Caret size",
+//       defaultValue: 24,
+//     }),
+//     icon: createIconProp(),
+//     iconSize: createNumberProp({
+//       label: "Icon size",
+//       defaultValue: 24,
+//     }),
+
+type AccordionGroupProps = {
+  label?: string;
   expanded?: boolean;
+  openColor?: string;
+  closedColor?: string;
+  caretColor?: string;
+  caretSize?: number;
+  icon?: string;
+  iconSize?: number;
+  style?: StyleProp<TextStyle>;
+  children?: React.ReactNode;
   theme: Theme;
 } & IconSlot;
 
 const AccordionGroup = ({
-  Icon,
+  label,
+  expanded: expandedProp = false,
   openColor,
   closedColor,
-  caretColor,
+  caretColor: caretColorProp,
+  caretSize = 24,
   icon,
   iconSize = 24,
   style,
-  label,
   children,
-  expanded: expandedProp,
   theme,
-}: Props) => {
-  const [expanded, setExpanded] = React.useState<boolean>(
-    expandedProp || false
-  );
+  Icon,
+}: AccordionGroupProps) => {
+  const [expanded, setExpanded] = React.useState<boolean>(expandedProp);
+  const { textStyles, viewStyles } = extractStyles(style);
+  const expandedColor = openColor || theme.colors.primary;
+  const collapsedColor = closedColor || theme.colors.primary;
+  const labelColor = expanded ? expandedColor : collapsedColor;
+  const caretColor = caretColorProp || labelColor;
 
   const handlePressAction = () => {
     setExpanded(!expanded);
   };
-
-  const expandedInternal = expandedProp !== undefined ? expandedProp : expanded;
-
-  const expandedColor = openColor || theme.colors.primary;
-  const collapsedColor = closedColor || theme.colors.primary;
-
-  const labelColor = expanded ? expandedColor : collapsedColor;
-
-  const { textStyles, viewStyles } = extractStyles(style);
 
   return (
     <>
@@ -90,10 +113,10 @@ const AccordionGroup = ({
               : "MaterialIcons/keyboard-arrow-down"
           }
           color={caretColor}
-          size={24}
+          size={caretSize}
         />
       </Pressable>
-      {expandedInternal ? children : null}
+      {expanded ? children : null}
     </>
   );
 };

--- a/packages/core/src/mappings/Accordion.ts
+++ b/packages/core/src/mappings/Accordion.ts
@@ -20,26 +20,31 @@ export const SEED_DATA = {
     fontSize: 16,
   },
   props: {
-    openColor: createColorProp({
-      label: "Open text color",
-    }),
-    closedColor: createColorProp({
-      label: "Closed text Color",
-    }),
-    caretColor: createColorProp({
-      label: "Caret color",
-    }),
-    iconSize: createNumberProp({
-      label: "Icon size",
-      defaultValue: 24,
-    }),
     label: createTextProp({
       label: "Label",
     }),
     expanded: createStaticBoolProp({
       label: "Expanded",
-      description: "Whether the AccordionGroup should be expanded or not",
+      description:
+        "Whether the AccordionGroup should be initaially expanded or not",
+    }),
+    openColor: createColorProp({
+      label: "Open text color",
+    }),
+    closedColor: createColorProp({
+      label: "Closed text color",
+    }),
+    caretColor: createColorProp({
+      label: "Caret color",
+    }),
+    caretSize: createNumberProp({
+      label: "Caret size",
+      defaultValue: 24,
     }),
     icon: createIconProp(),
+    iconSize: createNumberProp({
+      label: "Icon size",
+      defaultValue: 24,
+    }),
   },
 };


### PR DESCRIPTION
- `expanded` prop now only opens on screen load and is collapsable
- `caretSize` prop added
- added new mappings