### PR TITLE
Allow DatePicker to open/work inside of Modals on mobile

### DIFF
--- a/packages/core/src/components/DatePicker/DatePicker.tsx
+++ b/packages/core/src/components/DatePicker/DatePicker.tsx
@@ -543,7 +543,7 @@ const styles = StyleSheet.create({
     position: "absolute",
     left: 0,
   },
-  pickerContainer: { flexDirection: "column", width: "100%" },
+  pickerContainer: { flexDirection: "column", width: "100%", zIndex: 100 },
   closeButton: {
     alignSelf: "flex-end",
   },


### PR DESCRIPTION
Per [P-2733](https://linear.app/draftbit/issue/P-2733/datepicker-doesnt-work-from-inside-a-modal), users *rarely* need to open a DatePicker inside of a modal.

I've tested this on each platform and it works with no apparent side effects on iOS & Android.  However, it does not work on web because the parent Modal / Portal will always cover children Modal / Portals.

However, the DatePicker is not affected on web if it is not in Modal.  So no side effects there either.