### PR TITLE
Fix Surface backgroundColor prop & unify overflow behavior

### DIFF
--- a/example/src/SurfaceExample.js
+++ b/example/src/SurfaceExample.js
@@ -6,7 +6,7 @@ import Section, { Container } from "./Section";
 function SurfaceExample({ theme }) {
   return (
     <Container style={{ backgroundColor: theme.colors.background }}>
-      <Section title="overflow: 'hidden'">
+      <Section title="overflow: 'hidden', backgroundColor: 'pink'">
         <Surface
           style={{
             aspectRatio: 2 / 3,
@@ -16,6 +16,7 @@ function SurfaceExample({ theme }) {
             margin: 20,
             borderRadius: 20,
             overflow: "hidden",
+            backgroundColor: "pink",
           }}
           elevation={10}
         >

--- a/packages/core/src/components/Surface.tsx
+++ b/packages/core/src/components/Surface.tsx
@@ -29,6 +29,7 @@ const Surface: React.FC<Props> = ({
 }) => {
   const {
     elevation: styleElevation = 3,
+    backgroundColor,
     borderRadius,
     overflow,
     height,
@@ -41,17 +42,27 @@ const Surface: React.FC<Props> = ({
 
   const evalationStyles = elevation ? shadow(elevation) : {};
 
+  const getBackgroundColor = () => {
+    if (backgroundColor) {
+      return backgroundColor;
+    } else if (isDarkTheme && mode === "adaptive") {
+      return overlay(elevation, colors.surface);
+    } else {
+      return colors.surface;
+    }
+  };
+
   return (
     <Animated.View
       {...rest}
       style={[
         style,
         {
-          backgroundColor:
-            isDarkTheme && mode === "adaptive"
-              ? overlay(elevation, colors.surface)
-              : colors.surface,
-          overflow: Platform.OS === "web" ? "hidden" : "visible",
+          backgroundColor: getBackgroundColor(),
+          overflow:
+            Platform.OS === "web" && overflow === "hidden"
+              ? "hidden"
+              : "visible",
           elevation,
           ...evalationStyles,
         },


### PR DESCRIPTION
Per [P-2780](https://linear.app/draftbit/issue/P-2780/surface-no-longer-respects-color-prop), users need to be able to use the backgroundColor prop.  And if overflow should act the same across all platforms. See image below...

<img width="1728" alt="Screen Shot 2022-03-04 at 8 43 12 AM" src="https://user-images.githubusercontent.com/38188005/156775011-31378aaf-2a41-4c0c-976c-d48fee071366.png">