### PR TITLE
Simplify Surface component

### DIFF
--- a/packages/core/src/components/Surface.tsx
+++ b/packages/core/src/components/Surface.tsx
@@ -6,9 +6,8 @@ import {
   ViewProps,
   StyleProp,
   ViewStyle,
-  View,
-  Platform,
 } from "react-native";
+
 import shadow from "../styles/shadow";
 import overlay from "../styles/overlay";
 import { withTheme } from "../theming";
@@ -30,10 +29,7 @@ const Surface: React.FC<Props> = ({
   const {
     elevation: styleElevation = 3,
     backgroundColor,
-    borderRadius,
-    overflow,
-    height,
-    width,
+    ...restStyle
   } = (StyleSheet.flatten(style) || {}) as ViewStyle;
 
   const { dark: isDarkTheme, mode, colors } = theme;
@@ -56,30 +52,15 @@ const Surface: React.FC<Props> = ({
     <Animated.View
       {...rest}
       style={[
-        style,
         {
           backgroundColor: getBackgroundColor(),
-          overflow:
-            Platform.OS === "web" && overflow === "hidden"
-              ? "hidden"
-              : "visible",
           elevation,
           ...evalationStyles,
+          ...restStyle,
         },
       ]}
     >
-      <View
-        style={[
-          {
-            overflow,
-            borderRadius,
-            height,
-            width,
-          },
-        ]}
-      >
-        {children}
-      </View>
+      {children}
     </Animated.View>
   );
 };


### PR DESCRIPTION
This is a simpler (almost reversion) of Surface.

NOTE: it will NOT respect using `overflow: hidden` + `borderRadius: X` on mobile to round `Image` & `ImageBackground` corners.

We are adding these controls into the Builder for styling in an additional PR which will allow for this functionality...

```
borderTopLeftRadius
borderTopRightRadius
borderBottomLeftRadius
borderBottomRightRadius
```