### PR TITLE
Optimize video chat in a WebView

### DIFF
--- a/packages/core/src/mappings/WebView.ts
+++ b/packages/core/src/mappings/WebView.ts
@@ -1,4 +1,8 @@
-import { COMPONENT_TYPES, createSourceProp } from "@draftbit/types";
+import {
+  COMPONENT_TYPES,
+  createSourceProp,
+  createStaticBoolProp,
+} from "@draftbit/types";
 
 export const SEED_DATA = {
   name: "Web View",
@@ -9,6 +13,12 @@ export const SEED_DATA = {
   props: {
     source: createSourceProp({
       defaultValue: "https://reactnative.dev",
+    }),
+    optimizeVideoChat: createStaticBoolProp({
+      defaultValue: false,
+      label: "Optimize Video Chat",
+      description:
+        "Allows for a better experience from web hosted video chat services",
     }),
   },
 };


### PR DESCRIPTION
This is to make it easy to use a `WebView` with and external Video Chat Web App such as https://whereby.com/

If the `optimizeVideoChat` is toggled on the Builder, this service (and orthers) will play well in most modes.

There is a CORS error in PWA preview with some services.  There may be a followup PR for this behavior.