### PR TITLE
Fix default title value for Link component

### DIFF
--- a/packages/core/src/components/Text.tsx
+++ b/packages/core/src/components/Text.tsx
@@ -45,7 +45,7 @@ export const BaseLink = ({
   return (
     <Text
       hitSlop={8}
-      style={[{ color: theme.colors.primary, alignSelf: "flex-start" }, style]}
+      style={[{ color: theme.colors.primary }, style]}
       theme={theme}
       {...props}
     >

--- a/packages/core/src/mappings/Text.ts
+++ b/packages/core/src/mappings/Text.ts
@@ -5,19 +5,10 @@ import {
   PROP_TYPES,
   Triggers,
   createActionProp,
+  createTextProp,
 } from "@draftbit/types";
 
 const SEED_DATA_PROPS = {
-  children: {
-    group: GROUPS.data,
-    label: "Text",
-    description: "Text",
-    editable: true,
-    required: true,
-    formType: FORM_TYPES.string,
-    propType: PROP_TYPES.STRING,
-    defaultValue: "Double click me to edit 👀",
-  },
   accessibilityLabel: {
     group: GROUPS.accessibility,
     name: "accessibilityLabel",
@@ -232,6 +223,16 @@ export const SEED_DATA = [
     },
     props: {
       ...SEED_DATA_PROPS,
+      children: {
+        group: GROUPS.data,
+        label: "Text",
+        description: "Text",
+        editable: true,
+        required: true,
+        formType: FORM_TYPES.string,
+        propType: PROP_TYPES.STRING,
+        defaultValue: "Double click me to edit 👀",
+      },
     },
   },
   {
@@ -245,6 +246,11 @@ export const SEED_DATA = [
     props: {
       ...SEED_DATA_PROPS,
       onPress: createActionProp(),
+      title: createTextProp({
+        label: "Title",
+        description: "Link title",
+        defaultValue: "Get Started",
+      }),
     },
   },
 ];


### PR DESCRIPTION
* We were initializing the Link component with a `children` prop, when it really needs a `title` prop.
* Fixes unexpected flex alignment behavior
