### PR TITLE
Preserve map zoom if animating to location without zoom value

### DIFF
--- a/packages/core/src/mappings/MapView.ts
+++ b/packages/core/src/mappings/MapView.ts
@@ -16,7 +16,7 @@ export const SEED_DATA = {
   description: "A map view",
   category: COMPONENT_TYPES.media,
   layout: {
-    flexGrow: 1,
+    flex: 1,
   },
   props: {
     provider: {

--- a/packages/core/src/mappings/MapView.ts
+++ b/packages/core/src/mappings/MapView.ts
@@ -16,8 +16,7 @@ export const SEED_DATA = {
   description: "A map view",
   category: COMPONENT_TYPES.media,
   layout: {
-    height: "100%",
-    width: "100%",
+    flexGrow: 1,
   },
   props: {
     provider: {

--- a/packages/maps/src/components/MapView.tsx
+++ b/packages/maps/src/components/MapView.tsx
@@ -50,7 +50,11 @@ class MapView extends React.Component<MapViewProps> {
     longitude: number;
     zoom?: number;
   }) {
-    const args: { [key: string]: number | object } = {
+    const args: {
+      center: { latitude: number; longitude: number };
+      altitude?: number;
+      zoom?: number;
+    } = {
       center: {
         latitude,
         longitude,

--- a/packages/maps/src/components/MapView.tsx
+++ b/packages/maps/src/components/MapView.tsx
@@ -50,14 +50,19 @@ class MapView extends React.Component<MapViewProps> {
     longitude: number;
     zoom?: number;
   }) {
-    this.mapRef.current.animateCamera({
-      altitude: zoomToAltitude(zoom || 1),
-      zoom,
+    const args: { [key: string]: number | object } = {
       center: {
         latitude,
         longitude,
       },
-    });
+    };
+
+    if (zoom) {
+      args.altitude = zoomToAltitude(zoom || 1);
+      args.zoom = zoom;
+    }
+
+    this.mapRef.current.animateCamera(args);
   }
 
   render() {

--- a/packages/web-maps/src/components/MapView.tsx
+++ b/packages/web-maps/src/components/MapView.tsx
@@ -46,7 +46,16 @@ class MapView extends React.Component<MapViewProps, State> {
     longitude: number;
     zoom?: number;
   }) {
-    this.setState({ lat: latitude, lng: longitude, zoom });
+    const args: { lat: number; lng: number; zoom?: number } = {
+      lat: latitude,
+      lng: longitude,
+    };
+
+    if (zoom) {
+      args.zoom = zoom;
+    }
+
+    this.setState(args);
   }
 
   render() {


### PR DESCRIPTION
Animating the map to a point takes an optional zoom parameter. If no value is supplied, don't pass zoom to the underlying API so that the current zoom is preserved.
