### PR TITLE
Upgrade react-native-maps to 0.29.4 and add props

### DIFF
--- a/example/babel.config.js
+++ b/example/babel.config.js
@@ -2,5 +2,6 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ["babel-preset-expo"],
+    plugins: ["react-native-reanimated/plugin"],
   };
 };

--- a/example/package.json
+++ b/example/package.json
@@ -25,7 +25,6 @@
     "expo": "^44.0.0",
     "expo-app-loading": "~1.3.0",
     "expo-font": "~10.0.4",
-    "expo-location": "~14.0.2",
     "expo-status-bar": "~1.2.0",
     "react": "17.0.1",
     "react-dom": "17.0.1",

--- a/packages/core/src/mappings/MapView.ts
+++ b/packages/core/src/mappings/MapView.ts
@@ -120,19 +120,26 @@ export const SEED_DATA = {
       label: "Loading BG Color",
       description: "Color of the background to show while the map is loading",
     }),
-    showUserLocation: createBoolProp({
-      label: "Show User Location",
-      description: "Whether to request and show the user's location on the map",
+    showsUserLocation: createBoolProp({
+      label: "Shows User Location",
+      description: "Whether to show the user's location on the map",
       required: false,
       defaultValue: null,
       group: GROUPS.basic,
     }),
-    moveMapToUser: createBoolProp({
-      label: "Move Map to User",
+    followsUserLocation: createBoolProp({
+      label: "Follows User Location (iOS only)",
       description:
-        "Whether to set the map region to the user's location. Overrides latitude and longitude.",
+        "Whether to set the map region to follow the user's location",
       required: false,
       defaultValue: null,
+      group: GROUPS.basic,
+    }),
+    showPointsOfInterest: createBoolProp({
+      label: "Show Points of Interest",
+      description: "Whether to show points of interest on the map.",
+      required: false,
+      defaultValue: true,
       group: GROUPS.basic,
     }),
     apiKey: createTextProp({

--- a/packages/maps/package.json
+++ b/packages/maps/package.json
@@ -41,10 +41,7 @@
   "dependencies": {
     "@draftbit/types": "^44.0.3",
     "@draftbit/web-maps": "^44.0.4",
-    "react-native-maps": "0.28.0"
-  },
-  "peerDependencies": {
-    "expo-location": "~13.0.4"
+    "react-native-maps": "0.29.4"
   },
   "react-native-builder-bob": {
     "source": "src",

--- a/packages/maps/src/components/MapView.tsx
+++ b/packages/maps/src/components/MapView.tsx
@@ -1,6 +1,4 @@
 import * as React from "react";
-import * as Location from "expo-location";
-import Svg, { Ellipse } from "react-native-svg";
 import NativeMapView, { Marker } from "./ReactNativeMaps";
 import { MapViewProps } from "@draftbit/types";
 
@@ -19,40 +17,12 @@ function zoomToAltitude(zoom: number) {
   return C * Math.pow((A - D) / (zoom - D) - 1, 1 / B);
 }
 
-type State = {
-  userLocation?: {
-    latitude: number;
-    longitude: number;
-    altitude: number | null;
-    accuracy: number | null;
-    altitudeAccuracy: number | null;
-    heading: number | null;
-    speed: number | null;
-  };
-};
-
-class MapView extends React.Component<MapViewProps, State> {
+class MapView extends React.Component<MapViewProps> {
   private mapRef: React.RefObject<any>;
   constructor(props: MapViewProps) {
     super(props);
     this.state = {};
     this.mapRef = React.createRef();
-  }
-
-  componentDidMount() {
-    (async () => {
-      if (!this.props.showUserLocation) {
-        return;
-      }
-
-      const { status } = await Location.requestForegroundPermissionsAsync();
-      if (status !== "granted") {
-        return;
-      }
-
-      const { coords } = await Location.getCurrentPositionAsync({});
-      this.setState({ userLocation: coords });
-    })();
   }
 
   componentDidUpdate(prevProps: MapViewProps) {
@@ -114,12 +84,12 @@ class MapView extends React.Component<MapViewProps, State> {
       loadingBackgroundColor,
       loadingIndicatorColor,
       mapType = "standard",
-      moveMapToUser,
+      showsUserLocation,
+      followsUserLocation,
+      showsPointsOfInterest,
       style,
       children,
     } = this.props;
-
-    const { userLocation } = this.state;
 
     if (!NativeMapView || !Marker) {
       return null;
@@ -130,16 +100,10 @@ class MapView extends React.Component<MapViewProps, State> {
       heading: 0,
       pitch: 0,
       zoom,
-      center:
-        userLocation && moveMapToUser
-          ? {
-              latitude: userLocation.latitude,
-              longitude: userLocation.longitude,
-            }
-          : {
-              latitude,
-              longitude,
-            },
+      center: {
+        latitude,
+        longitude,
+      },
     };
 
     return (
@@ -153,31 +117,13 @@ class MapView extends React.Component<MapViewProps, State> {
         camera={camera}
         loadingEnabled={loadingEnabled}
         scrollEnabled={scrollEnabled}
+        showsUserLocation={showsUserLocation}
+        followsUserLocation={followsUserLocation}
+        showsPointsOfInterest={showsPointsOfInterest}
         loadingBackgroundColor={loadingBackgroundColor}
         loadingIndicatorColor={loadingIndicatorColor}
         style={style}
       >
-        {userLocation ? (
-          <Marker
-            title="Your Location"
-            coordinate={{
-              latitude: userLocation.latitude,
-              longitude: userLocation.longitude,
-            }}
-          >
-            <Svg height={40} width={40}>
-              <Ellipse
-                cx="20"
-                cy="20"
-                rx="8"
-                ry="8"
-                fill="#387af4"
-                stroke="#fff"
-                strokeWidth="2"
-              />
-            </Svg>
-          </Marker>
-        ) : null}
         {children}
       </NativeMapView>
     );

--- a/packages/types/src/mapTypes.tsx
+++ b/packages/types/src/mapTypes.tsx
@@ -34,8 +34,9 @@ export interface MapViewProps {
   loadingEnabled?: boolean;
   loadingBackgroundColor?: string;
   loadingIndicatorColor?: string;
-  showUserLocation?: boolean;
-  moveMapToUser?: boolean;
+  showsUserLocation?: boolean;
+  followsUserLocation?: boolean;
+  showsPointsOfInterest?: boolean;
   style?: StyleProp<ViewStyle>;
 }
 

--- a/packages/web-maps/src/components/MapView.tsx
+++ b/packages/web-maps/src/components/MapView.tsx
@@ -31,7 +31,7 @@ class MapView extends React.Component<MapViewProps, State> {
 
   componentDidMount() {
     (async () => {
-      if (!this.props.showUserLocation) {
+      if (!this.props.showsUserLocation) {
         return;
       }
 
@@ -41,7 +41,7 @@ class MapView extends React.Component<MapViewProps, State> {
 
           this.setState({ userLocation: coords });
 
-          if (this.props.moveMapToUser) {
+          if (this.props.followsUserLocation) {
             this.setState({ lat: coords.latitude, lng: coords.longitude });
           }
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6852,14 +6852,6 @@ expo-linear-gradient@^9.2.0:
   resolved "https://registry.yarnpkg.com/expo-linear-gradient/-/expo-linear-gradient-9.2.0.tgz#5ae16fcb8f141b1c51dc36bd4493dfd6566a9511"
   integrity sha512-LnW2u9OT6GeyC6T8qEGjFYfNSk4KIBAwU0aRSjM4Y8hckWqhtKngGDz46DqGmJBzvZMSKuZZvj5xKn794r54ag==
 
-expo-location@~14.0.2:
-  version "14.0.2"
-  resolved "https://registry.yarnpkg.com/expo-location/-/expo-location-14.0.2.tgz#933276b36558f546964753f107493b37953068b7"
-  integrity sha512-xFlj03NM0g9LZfWyIyL8q6AIXDhXskctX96806QGqZKv9C+JI2osEiTiyFxG8ei1MeTJojHfx+E07ORuByWiMw==
-  dependencies:
-    "@expo/config-plugins" "^4.0.2"
-    unimodules-task-manager-interface "~7.1.0"
-
 expo-modules-autolinking@0.5.5, expo-modules-autolinking@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/expo-modules-autolinking/-/expo-modules-autolinking-0.5.5.tgz#6bcc42072dcbdfca79d207b7f549f1fdb54a2b74"
@@ -12878,10 +12870,10 @@ react-native-iphone-x-helper@^1.3.0:
   resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz#20c603e9a0e765fd6f97396638bdeb0e5a60b010"
   integrity sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg==
 
-react-native-maps@0.28.0:
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/react-native-maps/-/react-native-maps-0.28.0.tgz#1913dd4977652ddfc317d39c7cb7d78a8e513784"
-  integrity sha512-F+k5ZT9hhl+iXR1H+5ZcoHOEB5lPu9gCIwtA4lI/LoI9nfa9xFvr1vMiLIv44jzeGNzbE3+/R81IpcNDMJ5uDg==
+react-native-maps@0.29.4:
+  version "0.29.4"
+  resolved "https://registry.yarnpkg.com/react-native-maps/-/react-native-maps-0.29.4.tgz#eb4a446104ed2aca5361422d06712f26d4c0d562"
+  integrity sha512-Td2KE8+KODcHOxfB1GBNnzFo4/89rlLiC7yTvqQZh0tGVrEzIcgSleUZRrjtq/WvSWSR4rql4AS+0VsBgDkYrw==
   dependencies:
     "@types/geojson" "^7946.0.7"
 
@@ -15055,11 +15047,6 @@ unicode-property-aliases-ecmascript@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.0.0.tgz#0a36cb9a585c4f6abd51ad1deddb285c165297c8"
   integrity sha512-5Zfuy9q/DFr4tfO7ZPeVXb1aPoeQSdeFMLpYuFebehDAhbuevLs5yxSZmIFN1tP5F9Wl4IpJrYojg85/zgyZHQ==
-
-unimodules-task-manager-interface@~7.1.0:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/unimodules-task-manager-interface/-/unimodules-task-manager-interface-7.1.1.tgz#1d48585012018971a0f0b62bc5ac53508a7addb4"
-  integrity sha512-vvtxJO3O6fJXvSc9qvgB2FS9xJk2nWG4NOvwCMmTmfblmvzGPFcTheOKzV7Z1dvjlqTZZ+TDqd5XOGa+0+NXVA==
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
- Upgrades `react-native-maps` to v0.29.4
- Modifies `showUserLocation` to `showsUserLocation` and uses underlying `react-native-maps` functionality rather than custom icon
- Modifies `moveMapToUser` to `followsUserLocation` and uses underling `react-native-maps` functionality
- Adds `showPointsOfInterest` prop (iOS only)
