### PR TITLE
Support for data-driven Map Markers and Swiper Items

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -41,6 +41,7 @@ import FieldSearchBarFullExample from "./FieldSearchBarFullExample";
 import LayoutExample from "./LayoutExample";
 
 import MapViewExample from "./MapViewExample";
+import MapViewDataDrivenExample from "./MapViewDataDrivenExample";
 
 import PickerExample from "./PickerExample";
 
@@ -90,6 +91,7 @@ const ROUTES = {
   FieldSearchBarFull: FieldSearchBarFullExample,
   LinearGradient: LinearGradientExample,
   MapView: MapViewExample,
+  MapViewDataDriven: MapViewDataDrivenExample,
   // TODO fix Header (spacing problem, textOverflow ellipses doesn't work on web)
   // Header: HeaderExample,
   Picker: PickerExample,

--- a/example/src/MapViewDataDrivenExample.js
+++ b/example/src/MapViewDataDrivenExample.js
@@ -29,7 +29,7 @@ const MapViewDataDrivenExample = ({ theme }) => {
         longitude={-116.524}
         zoom={12}
         apiKey={"AIzaSyC53v7BvSuA1yv7Hwf1rC_9kpHMmmYJJhU"}
-        data={data}
+        markersData={data}
         keyExtractor={(item) => item.id}
         renderItem={({ item }) => (
           <MapMarker

--- a/example/src/MapViewDataDrivenExample.js
+++ b/example/src/MapViewDataDrivenExample.js
@@ -1,0 +1,62 @@
+import React from "react";
+import { MapView, MapMarker, MapCallout } from "@draftbit/maps";
+import { withTheme } from "@draftbit/ui";
+import { StyleSheet, Text, View } from "react-native";
+
+const MapViewDataDrivenExample = ({ theme }) => {
+  const mapRef = React.createRef();
+  const [data, setData] = React.useState();
+
+  React.useEffect(() => {
+    fetch("https://example-data.draftbit.com/properties?_limit=10")
+      .then((res) => res.json())
+      .then((res) => {
+        setData(res);
+      });
+  }, []);
+
+  if (!data) {
+    return <Text>"Loading..."</Text>;
+  }
+
+  return (
+    <View style={styles.container}>
+      <MapView
+        ref={mapRef}
+        showsCompass={true}
+        style={styles.map}
+        latitude={33.8303}
+        longitude={-116.524}
+        zoom={12}
+        apiKey={"AIzaSyC53v7BvSuA1yv7Hwf1rC_9kpHMmmYJJhU"}
+        data={data}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <MapMarker
+            latitude={item.latitude}
+            longitude={item.longitude}
+            pinColor={theme.colors.secondary}
+          >
+            <MapCallout showTooltip>
+              <Text>With Callout</Text>
+            </MapCallout>
+          </MapMarker>
+        )}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "column",
+    justifyContent: "center",
+    height: "100%",
+  },
+  map: {
+    width: "100%",
+    height: "90%",
+  },
+});
+
+export default withTheme(MapViewDataDrivenExample);

--- a/example/src/SwiperExample.js
+++ b/example/src/SwiperExample.js
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { View, Text, StyleSheet } from "react-native";
+import { Image, Text, StyleSheet, View } from "react-native";
 import { Swiper, SwiperItem } from "@draftbit/ui";
 import Section, { Container } from "./Section";
 
@@ -11,9 +11,23 @@ const style = StyleSheet.create({
 });
 
 function SwiperExample({ theme }) {
+  const [data, setData] = React.useState();
+
+  React.useEffect(() => {
+    fetch("https://example-data.draftbit.com/properties?_limit=10")
+      .then((res) => res.json())
+      .then((res) => {
+        setData(res);
+      });
+  }, []);
+
+  if (!data) {
+    return <Text>"Loading..."</Text>;
+  }
+
   return (
     <Container>
-      <Section title="Swiper Example">
+      <Section title="Horizontal Example">
         <Swiper
           vertical={false}
           loop={true}
@@ -34,7 +48,7 @@ function SwiperExample({ theme }) {
           </SwiperItem>
         </Swiper>
       </Section>
-      <Section title="Swiper Example">
+      <Section title="Vertical Example">
         <Swiper
           vertical={true}
           style={{ width: "100%", height: 300 }}
@@ -51,6 +65,33 @@ function SwiperExample({ theme }) {
             <Text>Test Slide 2</Text>
           </SwiperItem>
         </Swiper>
+      </Section>
+      <Section title="Data-Driven Example">
+        <Swiper
+          vertical={false}
+          loop={true}
+          prevTitle="Previous"
+          nextTitle="Next"
+          prevTitleColor="white"
+          nextTitleColor="white"
+          dotColor="white"
+          dotActiveColor="black"
+          style={{ width: "100%", height: 300 }}
+          data={data}
+          keyExtractor={(item) => item.id}
+          renderItem={({ item }) => (
+            <SwiperItem style={[style.item, { backgroundColor: "#fdd3d3" }]}>
+              <View style={{ alignItems: "center", justifyContent: "center" }}>
+                <Image
+                  source={{ uri: item.image_url }}
+                  resizeMode="cover"
+                  style={{ position: "absolute", width: "100%", height: 300 }}
+                />
+                <Text style={{ color: "white" }}>{item.name}</Text>
+              </View>
+            </SwiperItem>
+          )}
+        />
       </Section>
     </Container>
   );

--- a/packages/core/src/components/Swiper/Swiper.tsx
+++ b/packages/core/src/components/Swiper/Swiper.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { View, StyleProp, ViewStyle } from "react-native";
 import SwiperComponent from "react-native-web-swiper";
 
-export interface SwiperProps {
+export interface SwiperProps<T> {
   vertical?: boolean;
   loop?: boolean;
   from?: number;
@@ -15,6 +15,9 @@ export interface SwiperProps {
   dotColor?: string;
   dotActiveColor?: string;
   children: React.ReactNode;
+  data?: Array<T>;
+  keyExtractor: (item: T, index: number) => string;
+  renderItem?: ({ item, index }: { item: T; index: number }) => JSX.Element;
   style?: StyleProp<ViewStyle>;
 }
 
@@ -30,9 +33,12 @@ const Swiper = ({
   dotsTouchable = true,
   dotColor,
   dotActiveColor,
+  data,
+  keyExtractor,
+  renderItem,
   children,
   style,
-}: SwiperProps) => (
+}: SwiperProps<any>) => (
   <View style={style}>
     <SwiperComponent
       from={from}
@@ -53,7 +59,13 @@ const Swiper = ({
           : {}),
       }}
     >
-      {children}
+      {data && renderItem
+        ? data.map((item, index) =>
+            React.cloneElement(renderItem({ item, index }), {
+              key: keyExtractor ? keyExtractor(item, index) : index,
+            })
+          )
+        : children}
     </SwiperComponent>
   </View>
 );

--- a/packages/maps/src/components/MapView.tsx
+++ b/packages/maps/src/components/MapView.tsx
@@ -17,15 +17,15 @@ function zoomToAltitude(zoom: number) {
   return C * Math.pow((A - D) / (zoom - D) - 1, 1 / B);
 }
 
-class MapView extends React.Component<MapViewProps> {
+class MapView extends React.Component<MapViewProps<any>> {
   private mapRef: React.RefObject<any>;
-  constructor(props: MapViewProps) {
+  constructor(props: MapViewProps<any>) {
     super(props);
     this.state = {};
     this.mapRef = React.createRef();
   }
 
-  componentDidUpdate(prevProps: MapViewProps) {
+  componentDidUpdate(prevProps: MapViewProps<any>) {
     if (
       prevProps.latitude != null &&
       prevProps.longitude != null &&
@@ -88,6 +88,9 @@ class MapView extends React.Component<MapViewProps> {
       followsUserLocation,
       showsPointsOfInterest,
       style,
+      data,
+      renderItem,
+      keyExtractor,
       children,
     } = this.props;
 
@@ -124,7 +127,13 @@ class MapView extends React.Component<MapViewProps> {
         loadingIndicatorColor={loadingIndicatorColor}
         style={style}
       >
-        {children}
+        {data && renderItem
+          ? data.map((item, index) =>
+              React.cloneElement(renderItem({ item, index }), {
+                key: keyExtractor ? keyExtractor(item, index) : index,
+              })
+            )
+          : children}
       </NativeMapView>
     );
   }

--- a/packages/maps/src/components/MapView.tsx
+++ b/packages/maps/src/components/MapView.tsx
@@ -88,7 +88,7 @@ class MapView extends React.Component<MapViewProps<any>> {
       followsUserLocation,
       showsPointsOfInterest,
       style,
-      data,
+      markersData,
       renderItem,
       keyExtractor,
       children,
@@ -127,8 +127,8 @@ class MapView extends React.Component<MapViewProps<any>> {
         loadingIndicatorColor={loadingIndicatorColor}
         style={style}
       >
-        {data && renderItem
-          ? data.map((item, index) =>
+        {markersData && renderItem
+          ? markersData.map((item, index) =>
               React.cloneElement(renderItem({ item, index }), {
                 key: keyExtractor ? keyExtractor(item, index) : index,
               })

--- a/packages/types/src/mapTypes.tsx
+++ b/packages/types/src/mapTypes.tsx
@@ -18,7 +18,7 @@ export interface MapMarkerProps {
   style?: StyleProp<ViewStyle>;
 }
 
-export interface MapViewProps {
+export interface MapViewProps<TMarkerData> {
   apiKey: string;
   provider?: "google" | null;
   latitudeDelta?: number;
@@ -38,6 +38,15 @@ export interface MapViewProps {
   followsUserLocation?: boolean;
   showsPointsOfInterest?: boolean;
   style?: StyleProp<ViewStyle>;
+  data?: Array<TMarkerData>;
+  keyExtractor: (item: TMarkerData, index: number) => string;
+  renderItem?: ({
+    item,
+    index,
+  }: {
+    item: TMarkerData;
+    index: number;
+  }) => JSX.Element;
 }
 
 export interface MapCalloutProps {

--- a/packages/types/src/mapTypes.tsx
+++ b/packages/types/src/mapTypes.tsx
@@ -38,7 +38,7 @@ export interface MapViewProps<TMarkerData> {
   followsUserLocation?: boolean;
   showsPointsOfInterest?: boolean;
   style?: StyleProp<ViewStyle>;
-  data?: Array<TMarkerData>;
+  markersData?: Array<TMarkerData>;
   keyExtractor: (item: TMarkerData, index: number) => string;
   renderItem?: ({
     item,

--- a/packages/web-maps/src/components/MapView.tsx
+++ b/packages/web-maps/src/components/MapView.tsx
@@ -19,8 +19,8 @@ type State = {
   };
 };
 
-class MapView extends React.Component<MapViewProps, State> {
-  constructor(props: MapViewProps) {
+class MapView extends React.Component<MapViewProps<any>, State> {
+  constructor(props: MapViewProps<any>) {
     super(props);
     this.state = {
       lat: props.latitude || 0,
@@ -49,7 +49,7 @@ class MapView extends React.Component<MapViewProps, State> {
     })();
   }
 
-  componentDidUpdate(prevProps: MapViewProps) {
+  componentDidUpdate(prevProps: MapViewProps<any>) {
     if (
       prevProps.latitude != null &&
       prevProps.longitude != null &&
@@ -95,6 +95,9 @@ class MapView extends React.Component<MapViewProps, State> {
       scrollEnabled = true,
       mapType = "standard",
       style,
+      data,
+      renderItem,
+      keyExtractor,
       children,
     } = this.props;
 
@@ -140,7 +143,13 @@ class MapView extends React.Component<MapViewProps, State> {
               }}
             />
           ) : null}
-          {children}
+          {data && renderItem
+            ? data.map((item, index) =>
+                React.cloneElement(renderItem({ item, index }), {
+                  key: keyExtractor ? keyExtractor(item, index) : index,
+                })
+              )
+            : children}
         </GoogleMap>
       </LoadScript>
     );

--- a/packages/web-maps/src/components/MapView.tsx
+++ b/packages/web-maps/src/components/MapView.tsx
@@ -95,7 +95,7 @@ class MapView extends React.Component<MapViewProps<any>, State> {
       scrollEnabled = true,
       mapType = "standard",
       style,
-      data,
+      markersData,
       renderItem,
       keyExtractor,
       children,
@@ -143,8 +143,8 @@ class MapView extends React.Component<MapViewProps<any>, State> {
               }}
             />
           ) : null}
-          {data && renderItem
-            ? data.map((item, index) =>
+          {markersData && renderItem
+            ? markersData.map((item, index) =>
                 React.cloneElement(renderItem({ item, index }), {
                   key: keyExtractor ? keyExtractor(item, index) : index,
                 })


### PR DESCRIPTION
Adds a `data`, `renderItem`, and `keyExtractor` API for `MapView` and `Swiper` to allow for making their children data-driven, since `FlatList` is not compatible.

![IMG_4483](https://user-images.githubusercontent.com/2578537/167045578-ade73ae3-f9be-4294-baba-fced8e8c851a.PNG)

![IMG_4482](https://user-images.githubusercontent.com/2578537/167045543-e002a0b5-71ac-438a-8a4e-3c6c0088a80f.PNG)
