### PR TITLE
 Set full width as default for WebView

### DIFF
--- a/packages/native/src/components/WebView.tsx
+++ b/packages/native/src/components/WebView.tsx
@@ -90,6 +90,16 @@ const NativeWebView: React.FC<WebViewProps> = ({
     );
   };
 
+  const getFinalWidth = () => {
+    if (typeof style?.width === "number") {
+      return style.width;
+    } else if (typeof style?.width === "string" && style.width.includes("%")) {
+      return width * (Number(style.width.replace("%", "")) / 100);
+    } else {
+      return width;
+    }
+  };
+
   const selectComponent = () => {
     if (
       !optimizeVideoChat ||
@@ -98,7 +108,7 @@ const NativeWebView: React.FC<WebViewProps> = ({
       return (
         <WebView
           source={source}
-          style={[{ width: optimizeVideoChat ? width : undefined }, style]}
+          style={{ ...style, width: getFinalWidth() }}
           injectedJavaScript={injectFirst}
           onMessage={onMessage}
           {...videoChatProps}

--- a/packages/native/src/components/WebView.tsx
+++ b/packages/native/src/components/WebView.tsx
@@ -37,8 +37,6 @@ const NativeWebView: React.FC<WebViewProps> = ({
 }) => {
   const [height, setHeight] = useState(0);
 
-  const { width } = Dimensions.get("window");
-
   const [cameraPermissions, setCameraPermissions] =
     useState<null | PermissionResponse>(null);
 
@@ -91,6 +89,8 @@ const NativeWebView: React.FC<WebViewProps> = ({
   };
 
   const getFinalWidth = () => {
+    const { width } = Dimensions.get("window");
+
     if (typeof style?.width === "number") {
       return style.width;
     } else if (typeof style?.width === "string" && style.width.includes("%")) {


### PR DESCRIPTION
Per [P-2843](https://linear.app/draftbit/issue/P-2843/webview-doesnt-show-on-mobile-previews), the WebView should always display full width when added to a screen.  It should also respond to height and width % and px settings.

NOTE ... unlike other width's we have to start with the window.width and base our settings from there with WebView.