### PR TITLE
Edit title and description for Keyboard Aware ScrollView

### DIFF
--- a/packages/core/src/mappings/KeyboardAwareScrollView.ts
+++ b/packages/core/src/mappings/KeyboardAwareScrollView.ts
@@ -36,9 +36,9 @@ export const SEED_DATA = {
         "Lets the user enable or disable automatic resetScrollToCoords",
     }),
     keyboardOpeningTime: createStaticNumberProp({
-      label: "Keyboard Opening Time",
+      label: "Opening Time",
       description:
-        "Sets the delay time before scrolling to new position, default is 250",
+        "Sets the delay time before scrolling to new position after keyboard opening, default is 250",
     }),
     enableOnAndroid: createStaticBoolProp({
       label: "Enable On Android",


### PR DESCRIPTION
Per [P-2831](https://linear.app/draftbit/issue/P-2831/keyboard-opening-time-setting-label-on-keyboard-aware-scroll-view), the label is too long for KASV and the description needs adjustment.