### PR TITLE
Parse non-string title and descriptions for map markers to avoid crash

### DIFF
--- a/packages/maps/src/components/MapMarker.tsx
+++ b/packages/maps/src/components/MapMarker.tsx
@@ -22,8 +22,8 @@ const MapMarker: React.FC<MapMarkerProps> = ({
         latitude,
         longitude,
       }}
-      title={title}
-      description={description}
+      title={title != null ? String(title) : undefined}
+      description={description != null ? String(description) : undefined}
       flat={flat}
       pinColor={pinColor}
       style={style}


### PR DESCRIPTION
Stringifies Map Marker title and description to avoid crash on native platforms
