### PR TITLE
Add keyboardShouldPersistTaps to KASV mapping

### DIFF
--- a/packages/core/src/mappings/KeyboardAwareScrollView.ts
+++ b/packages/core/src/mappings/KeyboardAwareScrollView.ts
@@ -2,6 +2,7 @@ import {
   COMPONENT_TYPES,
   createStaticBoolProp,
   createStaticNumberProp,
+  createTextEnumProp,
 } from "@draftbit/types";
 
 export const SEED_DATA = {
@@ -48,6 +49,13 @@ export const SEED_DATA = {
       label: "Shows Vertical Scroll Indicator",
       description: "Show or hide the vertical scroll indicator",
       defaultValue: true,
+    }),
+    keyboardShouldPersistTaps: createTextEnumProp({
+      label: "Allow Touch Events With Open Keyboard",
+      description:
+        "Allows touch events on visible components to be processed while the keyboard is open",
+      defaultValue: "never",
+      options: ["never", "always"],
     }),
   },
 };


### PR DESCRIPTION
So a user can register a button press (or any other event) when the KASV shows the keyboard.