### PR TITLE
sdk46 with core 44

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draftbit/core",
-  "version": "46.0.1",
+  "version": "44.2.2-rc",
   "description": "Core (non-native) Components",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -43,7 +43,7 @@
   },
   "homepage": "https://github.com/draftbit/react-native-jigsaw#readme",
   "dependencies": {
-    "@draftbit/core": "^46.0.1",
+    "@draftbit/core": "^44.2.2",
     "@draftbit/native": "^46.0.1"
   },
   "react-native-builder-bob": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -43,7 +43,7 @@
   },
   "homepage": "https://github.com/draftbit/react-native-jigsaw#readme",
   "dependencies": {
-    "@draftbit/core": "^44.2.2",
+    "@draftbit/core": "44.2.2-rc",
     "@draftbit/native": "^46.0.1"
   },
   "react-native-builder-bob": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1162,28 +1162,6 @@
   dependencies:
     "@date-io/core" "^1.3.13"
 
-"@draftbit/core@^44.2.2":
-  version "44.2.2"
-  resolved "https://registry.yarnpkg.com/@draftbit/core/-/core-44.2.2.tgz#8494891b0fc5738887bc9ff8b1fcfe776e98ccba"
-  integrity sha512-t14skweSysODaa41Ar0glguRqAzMHp9mi1j1HTZlV78DPYxEmbXEATa3DfsSUZeBe6NIMKbmlTyrXPm4HXZyIw==
-  dependencies:
-    "@date-io/date-fns" "^1.3.13"
-    "@draftbit/react-theme-provider" "^2.1.1"
-    "@draftbit/types" "^44.1.12"
-    "@material-ui/core" "^4.11.0"
-    "@material-ui/pickers" "^3.2.10"
-    "@react-native-community/slider" "4.1.12"
-    "@react-native-picker/picker" "2.4.1"
-    color "^3.1.2"
-    date-fns "^2.16.1"
-    dateformat "^3.0.3"
-    lodash.isnumber "^3.0.3"
-    lodash.omit "^4.5.0"
-    lodash.tonumber "^4.0.3"
-    react-native-modal-datetime-picker "^13.0.0"
-    react-native-typography "^1.4.1"
-    react-native-web-swiper "^2.2.3"
-
 "@draftbit/react-theme-provider@^2.1.1":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@draftbit/react-theme-provider/-/react-theme-provider-2.1.1.tgz#8ae9d097d1d3c8a08fe04c583d4f020764e24f72"
@@ -1191,11 +1169,6 @@
   dependencies:
     deepmerge "^3.2.0"
     hoist-non-react-statics "^3.3.0"
-
-"@draftbit/types@^44.1.12":
-  version "44.1.12"
-  resolved "https://registry.yarnpkg.com/@draftbit/types/-/types-44.1.12.tgz#8041ca52350f04f0f57c0d3918d48aee65cca162"
-  integrity sha512-VsmE04lEGMVgL/z3hqt1fQfb3hR0sXlwlLEb789RcDi7ZBloxzJWC3+uQUt3qCHrvqqyL/fKUoSSfHO+G9CdxQ==
 
 "@egjs/hammerjs@^2.0.17":
   version "2.0.17"
@@ -3069,20 +3042,10 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/eslint-plugin/-/eslint-plugin-1.2.0.tgz#7d6d789ae8edf73dc9bed1246cd48277edea8066"
   integrity sha512-o6aam+0Ug1xGK3ABYmBm0B1YuEKfM/5kaoZO0eHbZwSpw9UzDX4G5y4Nx/K20FHqUmJHkZmLvOUFYwN4N+HqKA==
 
-"@react-native-community/slider@4.1.12":
-  version "4.1.12"
-  resolved "https://registry.yarnpkg.com/@react-native-community/slider/-/slider-4.1.12.tgz#279ff7bbe487af92ad95ec758a029a54569e2a62"
-  integrity sha512-CiuLZ2orueBiWHYxfaJF57jQY6HY2Q3z5pdAE4MKH8EqIImr/jgDJrJ/UxOVZHK1Ng9P+XlGIKfVIcuWZ6guuA==
-
 "@react-native-community/slider@4.2.3":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/@react-native-community/slider/-/slider-4.2.3.tgz#7ed4f00ca2c50c666c47a59205b3df031d2588eb"
   integrity sha512-qPkrAy883tSPoRWgGZjqL5tYnd4AmNLYNtjvtD9G6JMYtImxK4ITa/W8zOEgR8UOrPde/t+VN0MMxL63HZZK1Q==
-
-"@react-native-picker/picker@2.4.1":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-2.4.1.tgz#92feb7e0672d739624517dae04bf4de1452dfcdc"
-  integrity sha512-1XWy3IQgwr7MWd30KdY1iUh2gQZD+JiotN1ifj/ptFUYKon/0UFwngKQaWCO/CP/FdLl20/huSSLwKedYrdMMA==
 
 "@react-native-picker/picker@2.4.2":
   version "2.4.2"
@@ -13528,7 +13491,7 @@ react-native-maps@0.31.1:
     "@types/geojson" "^7946.0.7"
     deprecated-react-native-prop-types "^2.3.0"
 
-react-native-modal-datetime-picker@^13.0.0, react-native-modal-datetime-picker@^13.1.2:
+react-native-modal-datetime-picker@^13.1.2:
   version "13.1.2"
   resolved "https://registry.yarnpkg.com/react-native-modal-datetime-picker/-/react-native-modal-datetime-picker-13.1.2.tgz#7c8bd3402acb4dcfbca49c926a7f18dd108c69c4"
   integrity sha512-PZDkuY7HayRX1KE2X2dm29CvCLzwj/vn6B6QdPbjZea/GEKvHBMOLGdhFCcA9+gD64Y41+VqfytUh2fdvUvQ1g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1162,6 +1162,28 @@
   dependencies:
     "@date-io/core" "^1.3.13"
 
+"@draftbit/core@^44.2.2":
+  version "44.2.2"
+  resolved "https://registry.yarnpkg.com/@draftbit/core/-/core-44.2.2.tgz#8494891b0fc5738887bc9ff8b1fcfe776e98ccba"
+  integrity sha512-t14skweSysODaa41Ar0glguRqAzMHp9mi1j1HTZlV78DPYxEmbXEATa3DfsSUZeBe6NIMKbmlTyrXPm4HXZyIw==
+  dependencies:
+    "@date-io/date-fns" "^1.3.13"
+    "@draftbit/react-theme-provider" "^2.1.1"
+    "@draftbit/types" "^44.1.12"
+    "@material-ui/core" "^4.11.0"
+    "@material-ui/pickers" "^3.2.10"
+    "@react-native-community/slider" "4.1.12"
+    "@react-native-picker/picker" "2.4.1"
+    color "^3.1.2"
+    date-fns "^2.16.1"
+    dateformat "^3.0.3"
+    lodash.isnumber "^3.0.3"
+    lodash.omit "^4.5.0"
+    lodash.tonumber "^4.0.3"
+    react-native-modal-datetime-picker "^13.0.0"
+    react-native-typography "^1.4.1"
+    react-native-web-swiper "^2.2.3"
+
 "@draftbit/react-theme-provider@^2.1.1":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@draftbit/react-theme-provider/-/react-theme-provider-2.1.1.tgz#8ae9d097d1d3c8a08fe04c583d4f020764e24f72"
@@ -1169,6 +1191,11 @@
   dependencies:
     deepmerge "^3.2.0"
     hoist-non-react-statics "^3.3.0"
+
+"@draftbit/types@^44.1.12":
+  version "44.1.12"
+  resolved "https://registry.yarnpkg.com/@draftbit/types/-/types-44.1.12.tgz#8041ca52350f04f0f57c0d3918d48aee65cca162"
+  integrity sha512-VsmE04lEGMVgL/z3hqt1fQfb3hR0sXlwlLEb789RcDi7ZBloxzJWC3+uQUt3qCHrvqqyL/fKUoSSfHO+G9CdxQ==
 
 "@egjs/hammerjs@^2.0.17":
   version "2.0.17"
@@ -3047,10 +3074,20 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/slider/-/slider-4.1.12.tgz#279ff7bbe487af92ad95ec758a029a54569e2a62"
   integrity sha512-CiuLZ2orueBiWHYxfaJF57jQY6HY2Q3z5pdAE4MKH8EqIImr/jgDJrJ/UxOVZHK1Ng9P+XlGIKfVIcuWZ6guuA==
 
+"@react-native-community/slider@4.2.3":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/slider/-/slider-4.2.3.tgz#7ed4f00ca2c50c666c47a59205b3df031d2588eb"
+  integrity sha512-qPkrAy883tSPoRWgGZjqL5tYnd4AmNLYNtjvtD9G6JMYtImxK4ITa/W8zOEgR8UOrPde/t+VN0MMxL63HZZK1Q==
+
 "@react-native-picker/picker@2.4.1":
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-2.4.1.tgz#92feb7e0672d739624517dae04bf4de1452dfcdc"
   integrity sha512-1XWy3IQgwr7MWd30KdY1iUh2gQZD+JiotN1ifj/ptFUYKon/0UFwngKQaWCO/CP/FdLl20/huSSLwKedYrdMMA==
+
+"@react-native-picker/picker@2.4.2":
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-2.4.2.tgz#2925eb8e76ff6b584c80529adc251df963be9141"
+  integrity sha512-0nY8638h1J3wKz6P3IJMpOoxJDdOj7Dk/K2hP/xpqP3KnIY0lmoqYlhyNihuyVPocDGajf6SA7LFFsFepQ56ag==
 
 "@react-native/assets@1.0.0":
   version "1.0.0"
@@ -7139,7 +7176,7 @@ expo-asset@~8.6.1:
     path-browserify "^1.0.0"
     url-parse "^1.5.9"
 
-expo-av@~12.0.3:
+expo-av@~12.0.4:
   version "12.0.4"
   resolved "https://registry.yarnpkg.com/expo-av/-/expo-av-12.0.4.tgz#00cf2da76c0c718a1d316f188247dee85ce512c2"
   integrity sha512-wq3wx6J1aacZEPZce9TK1+o4YTAOWyb5cJ4CqfsgHcXeUdHyO3qbva/5uecigpEYlCxOlWYFhAz2T0dQ7nWSpQ==
@@ -7188,7 +7225,7 @@ expo-keep-awake@~10.2.0:
   resolved "https://registry.yarnpkg.com/expo-keep-awake/-/expo-keep-awake-10.2.0.tgz#46f04740bccd321732bbbed93491e2076d5dbbd7"
   integrity sha512-kIRtO4Hmrvxh4E45IPWG/NiUZsuRe1AQwBT09pq+kx8nm6tUS4B9TeL6+1NFy+qVBLbGKDqoQD5Ez7XYTFtBeQ==
 
-expo-linear-gradient@^11.4.0:
+expo-linear-gradient@~11.4.0:
   version "11.4.0"
   resolved "https://registry.yarnpkg.com/expo-linear-gradient/-/expo-linear-gradient-11.4.0.tgz#20ecad4d11e66e35b31600e5389ec9c4067f7312"
   integrity sha512-qtIfsLs7NOpfxYrFSJL5uLtNHIkBHQFuQ3f7++XpoJTSm4eQVFxjjkCGWiLIrkpVjKzmgp3DLuIVsadsGX21lA==
@@ -13491,7 +13528,7 @@ react-native-maps@0.31.1:
     "@types/geojson" "^7946.0.7"
     deprecated-react-native-prop-types "^2.3.0"
 
-react-native-modal-datetime-picker@^13.0.0:
+react-native-modal-datetime-picker@^13.0.0, react-native-modal-datetime-picker@^13.1.2:
   version "13.1.2"
   resolved "https://registry.yarnpkg.com/react-native-modal-datetime-picker/-/react-native-modal-datetime-picker-13.1.2.tgz#7c8bd3402acb4dcfbca49c926a7f18dd108c69c4"
   integrity sha512-PZDkuY7HayRX1KE2X2dm29CvCLzwj/vn6B6QdPbjZea/GEKvHBMOLGdhFCcA9+gD64Y41+VqfytUh2fdvUvQ1g==


### PR DESCRIPTION
- updatez
- bump datetimepicker
- Upgrade react-native-maps to v0.31.1
- Fix types
- get it working
- fix packages
- updates
- fix lint
- updates packages
- fix build step
- v46.0.1
- expo sdk46 with core 44
