### PR TITLE
ensure that GOOGLE_MAPS_API_KEY is set when uploading to staging or prod

### DIFF
--- a/scripts/collector.js
+++ b/scripts/collector.js
@@ -15,6 +15,12 @@ const IGNORED_FILES = [
 const ERROR_FILES = [];
 const COMPLETED_FILES = [];
 
+if (process.env.target && !process.env.GOOGLE_MAPS_API_KEY) {
+  throw new Error(
+    "GOOGLE_MAPS_API_KEY environment variable must be set when not uploading locally. See mappings/MapView.ts"
+  );
+}
+
 async function main(list = []) {
   console.log("Running on", getUrl());
 


### PR DESCRIPTION
This prevents an invalid/blank value from being uploaded to the "magic" `apiKey` prop of the MapView component.

https://linear.app/draftbit/issue/P-3192/fix-google-maps-api-key-for-web