### PR TITLE
Added Deck Swiper component + example in example app

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -71,6 +71,8 @@ import LinearGradientExample from "./LinearGradientExample";
 
 import SurfaceExample from "./SurfaceExample";
 
+import DeckSwiperExample from "./DeckSwiperExample";
+
 const ROUTES = {
   AudioPlayer: AudioPlayerExample,
   Layout: LayoutExample,
@@ -115,6 +117,7 @@ const ROUTES = {
   TextInput: TextInputExample,
   NumberInput: NumberInputExample,
   WebView: WebViewExample,
+  DeckSwiper: DeckSwiperExample,
 };
 
 let customFonts = {

--- a/example/src/DeckSwiperExample.tsx
+++ b/example/src/DeckSwiperExample.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { Image, Text } from "react-native";
+import Section, { Container } from "./Section";
+import { DeckSwiper, DeckSwiperCard } from "@draftbit/core";
+
+const DeckSwiperExample: React.FC = () => {
+  return (
+    <Container style={{}}>
+      <Section title="Simple swiper with text" style={{ paddingBottom: 30 }}>
+        <DeckSwiper visibleCardCount={3}>
+          <DeckSwiperCard>
+            <Text>Card 1</Text>
+          </DeckSwiperCard>
+          <DeckSwiperCard>
+            <Text>Card 2</Text>
+          </DeckSwiperCard>
+          <DeckSwiperCard>
+            <Text>Card 3</Text>
+          </DeckSwiperCard>
+          <DeckSwiperCard>
+            <Text>Card 4</Text>
+          </DeckSwiperCard>
+        </DeckSwiper>
+      </Section>
+
+      <Section title="Infinite swiper with images" style={{}}>
+        <DeckSwiper infiniteSwiping visibleCardCount={2}>
+          <DeckSwiperCard>
+            <Image
+              style={{ width: "100%", height: 300 }}
+              source={{ uri: "https://picsum.photos/id/141/1125" }}
+            />
+          </DeckSwiperCard>
+          <DeckSwiperCard>
+            <Image
+              style={{ width: "100%", height: 300 }}
+              source={{ uri: "https://picsum.photos/id/141/1125" }}
+            />
+          </DeckSwiperCard>
+          <DeckSwiperCard>
+            <Image
+              style={{ width: "100%", height: 300 }}
+              source={{ uri: "https://picsum.photos/id/141/1125" }}
+            />
+          </DeckSwiperCard>
+        </DeckSwiper>
+      </Section>
+    </Container>
+  );
+};
+
+export default DeckSwiperExample;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,6 +53,7 @@
     "lodash.isnumber": "^3.0.3",
     "lodash.omit": "^4.5.0",
     "lodash.tonumber": "^4.0.3",
+    "react-native-deck-swiper": "^2.0.12",
     "react-native-modal-datetime-picker": "^13.0.0",
     "react-native-svg": "12.3.0",
     "react-native-typography": "^1.4.1",

--- a/packages/core/src/components/DeckSwiper/DeckSwiper.tsx
+++ b/packages/core/src/components/DeckSwiper/DeckSwiper.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { StyleProp, ViewStyle, StyleSheet, View } from "react-native";
+import DeckSwiperComponent from "react-native-deck-swiper";
+
+export interface DeckSwiperProps {
+  onIndexChanged?: (index: number) => void;
+  onEndReached?: () => void;
+  startCardIndex?: number;
+  infiniteSwiping?: boolean;
+  verticalEnabled?: boolean;
+  horizontalEnabled?: boolean;
+  visibleCardCount?: number;
+  style?: StyleProp<ViewStyle>;
+}
+
+const DeckSwiper: React.FC<React.PropsWithChildren<DeckSwiperProps>> = ({
+  onIndexChanged,
+  onEndReached,
+  startCardIndex = 0,
+  infiniteSwiping = false,
+  verticalEnabled = true,
+  horizontalEnabled = true,
+  visibleCardCount = 1,
+  style,
+  children,
+}) => {
+  const childrenArray = React.useMemo(
+    () => React.Children.toArray(children),
+    [children]
+  );
+
+  // an array of indices based on children count
+  const cardsFillerData = React.useMemo(
+    () => Array.from(Array(childrenArray.length).keys()),
+    [childrenArray]
+  );
+
+  /**
+   * By default react-native-deck-swiper positions everything with absolute position
+   * To overcome this, it is wrapped in a View to be able to add the component in any layout structure
+   *
+   * Since all children of that View are absolutley positioned, the View does not have a height and still looks and behaves weird
+   * To fix/mitage this without setting a static height, the first card is rendered in invisible state to take up space.
+   * This effectivley makes the default height of the container be the height of the first card
+   */
+
+  return (
+    <View>
+      <View style={styles.containerHeightFiller}>
+        {childrenArray.length && childrenArray[0]}
+      </View>
+      <DeckSwiperComponent
+        cards={cardsFillerData}
+        renderCard={(_, i) => <>{childrenArray[i]}</>}
+        keyExtractor={(card) => card?.toString()}
+        containerStyle={
+          StyleSheet.flatten([styles.cardsContainer, style]) as
+            | object
+            | undefined
+        }
+        cardStyle={styles.card as object | undefined}
+        onSwiped={onIndexChanged}
+        onSwipedAll={onEndReached}
+        cardIndex={startCardIndex}
+        infinite={infiniteSwiping}
+        verticalSwipe={verticalEnabled}
+        horizontalSwipe={horizontalEnabled}
+        showSecondCard={visibleCardCount > 1}
+        stackSize={visibleCardCount}
+        backgroundColor="transparent"
+        cardVerticalMargin={0}
+        cardHorizontalMargin={0}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  cardsContainer: {
+    width: "100%",
+  },
+  card: {
+    left: 0,
+    right: 0,
+    width: "auto",
+    height: "auto",
+  },
+  containerHeightFiller: {
+    opacity: 0.0,
+  },
+});
+
+export default DeckSwiper;

--- a/packages/core/src/components/DeckSwiper/DeckSwiper.tsx
+++ b/packages/core/src/components/DeckSwiper/DeckSwiper.tsx
@@ -36,12 +36,13 @@ const DeckSwiper: React.FC<React.PropsWithChildren<DeckSwiperProps>> = ({
   );
 
   /**
-   * By default react-native-deck-swiper positions everything with absolute position
-   * To overcome this, it is wrapped in a View to be able to add the component in any layout structure
+   * By default react-native-deck-swiper positions everything with absolute position.
+   * To overcome this, it is wrapped in a View to be able to add the component in any layout structure.
    *
-   * Since all children of that View are absolutley positioned, the View does not have a height and still looks and behaves weird
-   * To fix/mitage this without setting a static height, the first card is rendered in invisible state to take up space
-   * This effectivley makes the default height of the container be the height of the first card
+   *
+   * Since all children of that View are absolutley positioned, the View does not have a height and still looks and behaves weird.
+   * To fix/mitage this without setting a static height, the first card is rendered in invisible state to take up space.
+   * This effectivley makes the default height of the container be the height of the first card.
    */
 
   return (

--- a/packages/core/src/components/DeckSwiper/DeckSwiper.tsx
+++ b/packages/core/src/components/DeckSwiper/DeckSwiper.tsx
@@ -40,7 +40,7 @@ const DeckSwiper: React.FC<React.PropsWithChildren<DeckSwiperProps>> = ({
    * To overcome this, it is wrapped in a View to be able to add the component in any layout structure
    *
    * Since all children of that View are absolutley positioned, the View does not have a height and still looks and behaves weird
-   * To fix/mitage this without setting a static height, the first card is rendered in invisible state to take up space.
+   * To fix/mitage this without setting a static height, the first card is rendered in invisible state to take up space
    * This effectivley makes the default height of the container be the height of the first card
    */
 

--- a/packages/core/src/components/DeckSwiper/DeckSwiperCard.tsx
+++ b/packages/core/src/components/DeckSwiper/DeckSwiperCard.tsx
@@ -19,7 +19,6 @@ const DeckSwiperCard: React.FC<DeckSwiperCardProps> = ({
       styles.card,
       {
         backgroundColor: theme.colors.background,
-        borderRadius: theme.borderRadius?.global,
         borderColor: theme.colors.divider,
       },
       style,

--- a/packages/core/src/components/DeckSwiper/DeckSwiperCard.tsx
+++ b/packages/core/src/components/DeckSwiper/DeckSwiperCard.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { View, StyleSheet, StyleProp, ViewStyle } from "react-native";
+import type { Theme } from "../../styles/DefaultTheme";
+import { withTheme } from "../../theming";
+
+export interface DeckSwiperCardProps {
+  style?: StyleProp<ViewStyle>;
+  children: React.ReactNode;
+  theme: Theme;
+}
+
+const DeckSwiperCard: React.FC<DeckSwiperCardProps> = ({
+  style,
+  children,
+  theme,
+}) => (
+  <View
+    style={[
+      styles.card,
+      {
+        backgroundColor: theme.colors.background,
+        borderRadius: theme.borderRadius.global,
+        borderColor: theme.colors.divider,
+      },
+      style,
+    ]}
+  >
+    {children}
+  </View>
+);
+
+const styles = StyleSheet.create({
+  card: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 20,
+    borderWidth: 2,
+  },
+});
+
+export default withTheme(DeckSwiperCard);

--- a/packages/core/src/components/DeckSwiper/DeckSwiperCard.tsx
+++ b/packages/core/src/components/DeckSwiper/DeckSwiperCard.tsx
@@ -19,7 +19,7 @@ const DeckSwiperCard: React.FC<DeckSwiperCardProps> = ({
       styles.card,
       {
         backgroundColor: theme.colors.background,
-        borderRadius: theme.borderRadius.global,
+        borderRadius: theme.borderRadius?.global,
         borderColor: theme.colors.divider,
       },
       style,

--- a/packages/core/src/components/DeckSwiper/index.tsx
+++ b/packages/core/src/components/DeckSwiper/index.tsx
@@ -1,0 +1,2 @@
+export { default as DeckSwiper } from "./DeckSwiper";
+export { default as DeckSwiperCard } from "./DeckSwiperCard";

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -51,6 +51,8 @@ export {
   RadioButtonFieldGroup,
 } from "./components/RadioButton/index";
 
+export { DeckSwiper, DeckSwiperCard } from "./components/DeckSwiper";
+
 /* Deprecated: Fix or Delete!  */
 export { default as DatePicker } from "./components/DatePicker/DatePicker";
 export { default as Picker } from "./components/Picker/Picker";

--- a/packages/core/src/mappings/DeckSwiper.ts
+++ b/packages/core/src/mappings/DeckSwiper.ts
@@ -1,0 +1,54 @@
+import {
+  COMPONENT_TYPES,
+  Triggers,
+  createActionProp,
+  createStaticNumberProp,
+  createStaticBoolProp,
+  BLOCK_STYLES_SECTIONS,
+} from "@draftbit/types";
+
+export const SEED_DATA = {
+  name: "Deck Swiper",
+  tag: "DeckSwiper",
+  description: "Deck swiper container",
+  category: COMPONENT_TYPES.swiper,
+  stylesPanelSections: BLOCK_STYLES_SECTIONS,
+  triggers: [Triggers.OnIndexChanged, Triggers.OnEndReached],
+  props: {
+    onIndexChanged: createActionProp({
+      label: "On index changed",
+      description: "Action to execute when swipe to new index",
+    }),
+    onEndReached: createActionProp({
+      label: "On end reached",
+      description: "Action to execute when end of swiping reached",
+    }),
+    startCardIndex: createStaticNumberProp({
+      label: "Start card index",
+      description: "Index of card to start swiping from",
+      defaultValue: 0,
+    }),
+    infiniteSwiping: createStaticBoolProp({
+      label: "Infinite swiping",
+      description: "Whether to infinitley loop through cards or not",
+    }),
+    verticalEnabled: createStaticBoolProp({
+      label: "Vertical swipe enabled",
+      description: "Whether cards should be swipeable vertically or not",
+      defaultValue: true,
+    }),
+    horizontalEnabled: createStaticBoolProp({
+      label: "Horizontal swipe enabled",
+      description: "Whether cards should be swipeable horizontally or not",
+      defaultValue: true,
+    }),
+    visibleCardCount: createStaticNumberProp({
+      label: "Visible card count",
+      description:
+        "Number of cards visible behind (and including) the current card",
+      defaultValue: 1,
+      min: 1,
+      step: 1,
+    }),
+  },
+};

--- a/packages/core/src/mappings/DeckSwiper.ts
+++ b/packages/core/src/mappings/DeckSwiper.ts
@@ -13,6 +13,9 @@ export const SEED_DATA = {
   description: "Deck swiper container",
   category: COMPONENT_TYPES.swiper,
   stylesPanelSections: BLOCK_STYLES_SECTIONS,
+  layout: {
+    width: "100%",
+  },
   triggers: [Triggers.OnIndexChanged, Triggers.OnEndReached],
   props: {
     onIndexChanged: createActionProp({

--- a/packages/core/src/mappings/DeckSwiperCard.ts
+++ b/packages/core/src/mappings/DeckSwiperCard.ts
@@ -1,0 +1,13 @@
+import {
+  COMPONENT_TYPES,
+  CONTAINER_COMPONENT_STYLES_SECTIONS,
+} from "@draftbit/types";
+
+export const SEED_DATA = {
+  name: "Deck Swiper Card",
+  tag: "DeckSwiperCard",
+  description: "Single Deck Swiper Card item to be used in DeckSwiper",
+  category: COMPONENT_TYPES.swiper,
+  stylesPanelSections: CONTAINER_COMPONENT_STYLES_SECTIONS,
+  props: {},
+};

--- a/packages/core/src/mappings/DeckSwiperCard.ts
+++ b/packages/core/src/mappings/DeckSwiperCard.ts
@@ -9,5 +9,12 @@ export const SEED_DATA = {
   description: "Single Deck Swiper Card item to be used in DeckSwiper",
   category: COMPONENT_TYPES.swiper,
   stylesPanelSections: CONTAINER_COMPONENT_STYLES_SECTIONS,
+  layout: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 20,
+    borderWidth: 2,
+  },
   props: {},
 };

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -28,6 +28,8 @@ export {
   Pressable,
   withTheme,
   useAuthState,
+  DeckSwiper,
+  DeckSwiperCard,
   /* Deprecated, needs fixing */
   ProgressBar,
   ProgressCircle,
@@ -37,8 +39,6 @@ export {
   ActionSheetCancel,
   Swiper,
   SwiperItem,
-  DeckSwiper,
-  DeckSwiperCard,
 } from "@draftbit/core";
 
 /**

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -37,6 +37,8 @@ export {
   ActionSheetCancel,
   Swiper,
   SwiperItem,
+  DeckSwiper,
+  DeckSwiperCard,
 } from "@draftbit/core";
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -5970,6 +5970,11 @@ core-js-compat@^3.21.0, core-js-compat@^3.22.1:
     browserslist "^4.21.3"
     semver "7.0.0"
 
+core-js@^1.0.0:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
+  integrity sha512-ZiPp9pZlgxpWRu0M+YWbm6+aQ84XEfH1JRXvfOc/fILWI0VKhLC2LX13X1NYq4fULzLMq7Hfh43CSo2/aIaUPA==
+
 core-util-is@~1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
@@ -6890,7 +6895,7 @@ encodeurl@~1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==
 
-encoding@^0.1.13:
+encoding@^0.1.11, encoding@^0.1.13:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.13.tgz#56574afdd791f54a8e9b2785c0582a2d26210fa9"
   integrity sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==
@@ -7730,6 +7735,19 @@ fbjs-css-vars@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz#216551136ae02fe255932c3ec8775f18e2c078b8"
   integrity sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==
+
+fbjs@^0.8.9:
+  version "0.8.18"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.18.tgz#9835e0addb9aca2eff53295cd79ca1cfc7c9662a"
+  integrity sha512-EQaWFK+fEPSoibjNy8IxUtaFOMXcWsY0JaVrQoZR9zC8N2Ygf9iDITPWjUTVIax95b6I742JFLqASHfsag/vKA==
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.30"
 
 fbjs@^3.0.0, fbjs@^3.0.4:
   version "3.0.4"
@@ -9537,7 +9555,7 @@ is-ssh@^1.4.0:
   dependencies:
     protocols "^2.0.1"
 
-is-stream@^1.1.0:
+is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==
@@ -9652,6 +9670,14 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==
+
+isomorphic-fetch@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
+  integrity sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA==
+  dependencies:
+    node-fetch "^1.0.1"
+    whatwg-fetch ">=0.10.0"
 
 istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
   version "3.2.0"
@@ -11819,6 +11845,14 @@ node-fetch@2.6.7, node-fetch@^2.2.0, node-fetch@^2.6.0, node-fetch@^2.6.1, node-
   dependencies:
     whatwg-url "^5.0.0"
 
+node-fetch@^1.0.1:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
+  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
+
 node-forge@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
@@ -13441,6 +13475,14 @@ prop-types@*, prop-types@15.8.1, prop-types@^15.6.2, prop-types@^15.7.2, prop-ty
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
+prop-types@15.5.10:
+  version "15.5.10"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
+  integrity sha512-vCFzoUFaZkVNeFkhK1KbSq4cn97GDrpfBt9K2qLkGnPAEFhEv3M61Lk5t+B7c0QfMLWo0fPkowk/4SuXerh26Q==
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+
 proto-list@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
@@ -13754,6 +13796,13 @@ react-native-codegen@^0.69.2:
     flow-parser "^0.121.0"
     jscodeshift "^0.13.1"
     nullthrows "^1.1.1"
+
+react-native-deck-swiper@^2.0.12:
+  version "2.0.12"
+  resolved "https://registry.yarnpkg.com/react-native-deck-swiper/-/react-native-deck-swiper-2.0.12.tgz#941ebfdd7e4e0cff316640dbe795a4a13714ddb5"
+  integrity sha512-fphojlLDMkg5ppHqoAh/9ZuDzsdxR/HTKGFhAkEOlNe08r/MRUpyYJHLxKS83CnPQLJvvY7ol9pHvTm9D+DSRg==
+  dependencies:
+    prop-types "15.5.10"
 
 react-native-gesture-handler@~2.5.0:
   version "2.5.0"
@@ -16546,7 +16595,7 @@ whatwg-encoding@^1.0.5:
   dependencies:
     iconv-lite "0.4.24"
 
-whatwg-fetch@^3.0.0:
+whatwg-fetch@>=0.10.0, whatwg-fetch@^3.0.0:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
   integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==


### PR DESCRIPTION
Added deck swiper component based on https://github.com/webraptor/react-native-deck-swiper

Also added an example to the example app:
![Screenshot_1675766346](https://user-images.githubusercontent.com/58384527/217288163-26979449-7712-4d6f-8436-27df2ea1e87a.png)

Closes EXT-25
https://linear.app/draftbit/issue/EXT-25/add-swiperdeck-components
