### PR TITLE
Fixed Picker crash on IOS

### DIFF
--- a/packages/core/src/components/Picker/Picker.tsx
+++ b/packages/core/src/components/Picker/Picker.tsx
@@ -98,7 +98,6 @@ const Picker: React.FC<PickerProps> = ({
   placeholder,
   value,
   disabled = false,
-  theme,
   assistiveText,
   label,
   iconColor = unstyledColor,
@@ -144,8 +143,6 @@ const Picker: React.FC<PickerProps> = ({
   const pickerOptions = placeholder
     ? [{ value: placeholder, label: placeholder }, ...normalizedOptions]
     : normalizedOptions;
-
-  const { colors } = theme;
 
   const { viewStyles, textStyles } = extractStyles(style);
 
@@ -347,15 +344,8 @@ const Picker: React.FC<PickerProps> = ({
       {/* iosPicker */}
       {isIos && pickerVisible ? (
         <Portal>
-          <View
-            style={[
-              styles.iosPicker,
-              {
-                backgroundColor: colors.divider,
-              },
-            ]}
-          >
-            <SafeAreaView style={styles.iosSafeArea}>
+          <SafeAreaView style={styles.iosPicker}>
+            <View style={styles.iosPickerContent}>
               <Button
                 Icon={Icon}
                 type="text"
@@ -378,8 +368,8 @@ const Picker: React.FC<PickerProps> = ({
                   />
                 ))}
               </NativePicker>
-            </SafeAreaView>
-          </View>
+            </View>
+          </SafeAreaView>
         </Portal>
       ) : null}
 
@@ -451,9 +441,9 @@ const styles = StyleSheet.create({
     width: "100%",
     maxWidth: deviceWidth,
     maxHeight: deviceHeight,
-  },
-  iosSafeArea: {
     backgroundColor: "white",
+  },
+  iosPickerContent: {
     flexDirection: "column",
     width: "100%",
     maxWidth: deviceWidth,


### PR DESCRIPTION
The issue was caused by SafeAreaView nested in a View in a Portal component. Moving the SafeAreaView up a level (direct child of Portal) fixed the issue. I am unsure why this happens (or why this fixes it), but possibly because Portal renders outside the regular view tree which could have an impact on how SafeAreaView behaves? 

In any case, the provided test app no longer crashes with this change.