### PR TITLE
Add shadow component (for v46)

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -71,6 +71,8 @@ import LinearGradientExample from "./LinearGradientExample";
 
 import SurfaceExample from "./SurfaceExample";
 
+import ShadowExample from "./ShadowExample";
+
 const ROUTES = {
   AudioPlayer: AudioPlayerExample,
   Layout: LayoutExample,
@@ -115,6 +117,7 @@ const ROUTES = {
   TextInput: TextInputExample,
   NumberInput: NumberInputExample,
   WebView: WebViewExample,
+  Shadow: ShadowExample,
 };
 
 let customFonts = {

--- a/example/src/ShadowExample.tsx
+++ b/example/src/ShadowExample.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { Text, View } from "react-native";
+import Section, { Container } from "./Section";
+import { Shadow } from "@draftbit/ui";
+
+const DeckSwiperExample: React.FC = () => {
+  return (
+    <Container style={{}}>
+      <Section title="Simple shadow" style={{ alignItems: "center" }}>
+        <Shadow>
+          <View style={{ padding: 100, backgroundColor: "white" }}>
+            <Text>Shadow </Text>
+          </View>
+        </Shadow>
+      </Section>
+
+      <Section title="Customized shadow" style={{ alignItems: "center" }}>
+        <Shadow
+          showShadowSideEnd={false}
+          showShadowCornerBottomEnd={false}
+          startColor="rgba(0,0,255,0.5)"
+          endColor="rgba(0,0,255,0.2)"
+        >
+          <View style={{ padding: 100, backgroundColor: "white" }}>
+            <Text>Shadow </Text>
+          </View>
+        </Shadow>
+      </Section>
+    </Container>
+  );
+};
+
+export default DeckSwiperExample;

--- a/example/src/ShadowExample.tsx
+++ b/example/src/ShadowExample.tsx
@@ -3,7 +3,7 @@ import { Text, View } from "react-native";
 import Section, { Container } from "./Section";
 import { Shadow } from "@draftbit/ui";
 
-const DeckSwiperExample: React.FC = () => {
+const ShadowExample: React.FC = () => {
   return (
     <Container style={{}}>
       <Section title="Simple shadow" style={{ alignItems: "center" }}>
@@ -30,4 +30,4 @@ const DeckSwiperExample: React.FC = () => {
   );
 };
 
-export default DeckSwiperExample;
+export default ShadowExample;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,6 +54,7 @@
     "lodash.omit": "^4.5.0",
     "lodash.tonumber": "^4.0.3",
     "react-native-modal-datetime-picker": "^13.0.0",
+    "react-native-shadow-2": "^7.0.6",
     "react-native-svg": "12.3.0",
     "react-native-typography": "^1.4.1",
     "react-native-web-swiper": "^2.2.3"

--- a/packages/core/src/components/Shadow.tsx
+++ b/packages/core/src/components/Shadow.tsx
@@ -3,22 +3,22 @@ import { StyleProp, ViewStyle } from "react-native";
 import { Shadow as ShadowComponent } from "react-native-shadow-2";
 
 interface ShadowProps {
-  disabled: boolean;
-  startColor: string;
-  endColor: string;
-  distance: number;
-  paintInside: boolean;
-  stretch: boolean;
-  offsetX: number;
-  offsetY: number;
-  showShadowSideStart: boolean;
-  showShadowSideEnd: boolean;
-  showShadowSideTop: boolean;
-  showShadowSideBottom: boolean;
-  showShadowCornerTopStart: boolean;
-  showShadowCornerTopEnd: boolean;
-  showShadowCornerBottomStart: boolean;
-  showShadowCornerBottomEnd: boolean;
+  disabled?: boolean;
+  startColor?: string;
+  endColor?: string;
+  distance?: number;
+  paintInside?: boolean;
+  stretch?: boolean;
+  offsetX?: number;
+  offsetY?: number;
+  showShadowSideStart?: boolean;
+  showShadowSideEnd?: boolean;
+  showShadowSideTop?: boolean;
+  showShadowSideBottom?: boolean;
+  showShadowCornerTopStart?: boolean;
+  showShadowCornerTopEnd?: boolean;
+  showShadowCornerBottomStart?: boolean;
+  showShadowCornerBottomEnd?: boolean;
   style?: StyleProp<ViewStyle>;
 }
 

--- a/packages/core/src/components/Shadow.tsx
+++ b/packages/core/src/components/Shadow.tsx
@@ -34,7 +34,6 @@ const Shadow: React.FC<React.PropsWithChildren<ShadowProps>> = ({
   showShadowCornerBottomStart = true,
   showShadowCornerBottomEnd = true,
   paintInside = false,
-  stretch = false,
   style,
   ...rest
 }) => {
@@ -55,7 +54,6 @@ const Shadow: React.FC<React.PropsWithChildren<ShadowProps>> = ({
       }}
       containerStyle={style}
       paintInside={paintInside}
-      stretch={stretch}
       {...rest}
     />
   );

--- a/packages/core/src/components/Shadow.tsx
+++ b/packages/core/src/components/Shadow.tsx
@@ -33,6 +33,7 @@ const Shadow: React.FC<React.PropsWithChildren<ShadowProps>> = ({
   showShadowCornerTopEnd = true,
   showShadowCornerBottomStart = true,
   showShadowCornerBottomEnd = true,
+  paintInside = false,
   style,
   ...rest
 }) => {
@@ -52,6 +53,7 @@ const Shadow: React.FC<React.PropsWithChildren<ShadowProps>> = ({
         bottomEnd: showShadowCornerBottomEnd,
       }}
       containerStyle={style}
+      paintInside={paintInside}
       {...rest}
     />
   );

--- a/packages/core/src/components/Shadow.tsx
+++ b/packages/core/src/components/Shadow.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { StyleProp, ViewStyle } from "react-native";
+import { Shadow as ShadowComponent } from "react-native-shadow-2";
+
+interface ShadowProps {
+  disabled: boolean;
+  startColor: string;
+  endColor: string;
+  distance: number;
+  paintInside: boolean;
+  stretch: boolean;
+  offsetX: number;
+  offsetY: number;
+  showShadowSideStart: boolean;
+  showShadowSideEnd: boolean;
+  showShadowSideTop: boolean;
+  showShadowSideBottom: boolean;
+  showShadowCornerTopStart: boolean;
+  showShadowCornerTopEnd: boolean;
+  showShadowCornerBottomStart: boolean;
+  showShadowCornerBottomEnd: boolean;
+  style?: StyleProp<ViewStyle>;
+}
+
+const Shadow: React.FC<ShadowProps> = ({
+  offsetX = 0,
+  offsetY = 0,
+  showShadowSideStart = true,
+  showShadowSideEnd = true,
+  showShadowSideTop = true,
+  showShadowSideBottom = true,
+  showShadowCornerTopStart = true,
+  showShadowCornerTopEnd = true,
+  showShadowCornerBottomStart = true,
+  showShadowCornerBottomEnd = true,
+  ...rest
+}) => {
+  return (
+    <ShadowComponent
+      offset={[offsetX, offsetY]}
+      sides={{
+        start: showShadowSideStart,
+        end: showShadowSideEnd,
+        top: showShadowSideTop,
+        bottom: showShadowSideBottom,
+      }}
+      corners={{
+        topStart: showShadowCornerTopStart,
+        topEnd: showShadowCornerTopEnd,
+        bottomStart: showShadowCornerBottomStart,
+        bottomEnd: showShadowCornerBottomEnd,
+      }}
+      {...rest}
+    />
+  );
+};
+
+export default Shadow;

--- a/packages/core/src/components/Shadow.tsx
+++ b/packages/core/src/components/Shadow.tsx
@@ -33,6 +33,7 @@ const Shadow: React.FC<React.PropsWithChildren<ShadowProps>> = ({
   showShadowCornerTopEnd = true,
   showShadowCornerBottomStart = true,
   showShadowCornerBottomEnd = true,
+  style,
   ...rest
 }) => {
   return (
@@ -50,6 +51,7 @@ const Shadow: React.FC<React.PropsWithChildren<ShadowProps>> = ({
         bottomStart: showShadowCornerBottomStart,
         bottomEnd: showShadowCornerBottomEnd,
       }}
+      containerStyle={style}
       {...rest}
     />
   );

--- a/packages/core/src/components/Shadow.tsx
+++ b/packages/core/src/components/Shadow.tsx
@@ -34,6 +34,7 @@ const Shadow: React.FC<React.PropsWithChildren<ShadowProps>> = ({
   showShadowCornerBottomStart = true,
   showShadowCornerBottomEnd = true,
   paintInside = false,
+  stretch = false,
   style,
   ...rest
 }) => {
@@ -54,6 +55,7 @@ const Shadow: React.FC<React.PropsWithChildren<ShadowProps>> = ({
       }}
       containerStyle={style}
       paintInside={paintInside}
+      stretch={stretch}
       {...rest}
     />
   );

--- a/packages/core/src/components/Shadow.tsx
+++ b/packages/core/src/components/Shadow.tsx
@@ -22,7 +22,7 @@ interface ShadowProps {
   style?: StyleProp<ViewStyle>;
 }
 
-const Shadow: React.FC<ShadowProps> = ({
+const Shadow: React.FC<React.PropsWithChildren<ShadowProps>> = ({
   offsetX = 0,
   offsetY = 0,
   showShadowSideStart = true,

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -51,6 +51,8 @@ export {
   RadioButtonFieldGroup,
 } from "./components/RadioButton/index";
 
+export { default as Shadow } from "./components/Shadow";
+
 /* Deprecated: Fix or Delete!  */
 export { default as DatePicker } from "./components/DatePicker/DatePicker";
 export { default as Picker } from "./components/Picker/Picker";

--- a/packages/core/src/mappings/Shadow.ts
+++ b/packages/core/src/mappings/Shadow.ts
@@ -39,7 +39,7 @@ export const SEED_DATA = {
     stretch: createStaticBoolProp({
       label: "Stretch",
       description: "Force children to occupy all available horizontal space.",
-      defaultValue: false,
+      defaultValue: null,
     }),
     offsetX: createStaticNumberProp({
       label: "Offset X",

--- a/packages/core/src/mappings/Shadow.ts
+++ b/packages/core/src/mappings/Shadow.ts
@@ -1,0 +1,95 @@
+import {
+  COMPONENT_TYPES,
+  CONTAINER_COMPONENT_STYLES_SECTIONS,
+  createColorProp,
+  createStaticNumberProp,
+  createStaticBoolProp,
+  createDisabledProp,
+} from "@draftbit/types";
+
+export const SEED_DATA = {
+  name: "Shadow",
+  tag: "Shadow View",
+  description: "A cross-platform, universal shadow.",
+  category: COMPONENT_TYPES.view,
+  stylesPanelSections: CONTAINER_COMPONENT_STYLES_SECTIONS,
+  props: {
+    disabled: createDisabledProp({
+      description: "Disables the shadow.",
+    }),
+    startColor: createColorProp({
+      label: "Start Color",
+      description: "The initial gradient color of the shadow.",
+      defaultValue: null,
+    }),
+    endColor: createColorProp({
+      label: "End Color",
+      description: "The final gradient color of the shadow.",
+      defaultValue: null,
+    }),
+    distance: createStaticNumberProp({
+      label: "Distance",
+      description: "The distance of the shadow.",
+    }),
+    paintInside: createStaticBoolProp({
+      label: "Paint Inside",
+      description: "Apply the shadow below/inside the content.",
+      defaultValue: null,
+    }),
+    stretch: createStaticBoolProp({
+      label: "Stretch",
+      description: "Force children to occupy all available horizontal space.",
+      defaultValue: null,
+    }),
+    offsetX: createStaticNumberProp({
+      label: "Offset X",
+      description: "Moved the shadow in the x direction",
+      defeaultValue: 0,
+    }),
+    offsetY: createStaticNumberProp({
+      label: "Offset Y",
+      description: "Moved the shadow in the y direction",
+      defeaultValue: 0,
+    }),
+    showShadowSideStart: createStaticBoolProp({
+      label: "Show Shadow Start",
+      description: "Whether to show shadow on the start side or not",
+      defaultValue: true,
+    }),
+    showShadowSideEnd: createStaticBoolProp({
+      label: "Show Shadow End",
+      description: "Whether to show shadow on the end side or not",
+      defaultValue: true,
+    }),
+    showShadowSideTop: createStaticBoolProp({
+      label: "Show Shadow Top",
+      description: "Whether to show shadow on the top side or not",
+      defaultValue: true,
+    }),
+    showShadowSideBottom: createStaticBoolProp({
+      label: "Show Shadow Bottom",
+      description: "Whether to show shadow on the bottom side or not",
+      defaultValue: true,
+    }),
+    showShadowCornerTopStart: createStaticBoolProp({
+      label: "Show Shadow Top Start Corner",
+      description: "Whether to show shadow on the top start corner or not",
+      defaultValue: true,
+    }),
+    showShadowCornerTopEnd: createStaticBoolProp({
+      label: "Show Shadow Top End Corner",
+      description: "Whether to show shadow on the top end corner or not",
+      defaultValue: true,
+    }),
+    showShadowCornerBottomStart: createStaticBoolProp({
+      label: "Show Shadow Bottom Start Corner",
+      description: "Whether to show shadow on the bottom start corner or not",
+      defaultValue: true,
+    }),
+    showShadowCornerBottomEnd: createStaticBoolProp({
+      label: "Show Shadow Bottom End Corner",
+      description: "Whether to show shadow on the bottom end corner or not",
+      defaultValue: true,
+    }),
+  },
+};

--- a/packages/core/src/mappings/Shadow.ts
+++ b/packages/core/src/mappings/Shadow.ts
@@ -5,6 +5,7 @@ import {
   createStaticNumberProp,
   createStaticBoolProp,
   createDisabledProp,
+  GROUPS,
 } from "@draftbit/types";
 
 export const SEED_DATA = {
@@ -55,41 +56,49 @@ export const SEED_DATA = {
       label: "Show Shadow Start",
       description: "Whether to show shadow on the start side or not",
       defaultValue: true,
+      group: GROUPS.advanced,
     }),
     showShadowSideEnd: createStaticBoolProp({
       label: "Show Shadow End",
       description: "Whether to show shadow on the end side or not",
       defaultValue: true,
+      group: GROUPS.advanced,
     }),
     showShadowSideTop: createStaticBoolProp({
       label: "Show Shadow Top",
       description: "Whether to show shadow on the top side or not",
       defaultValue: true,
+      group: GROUPS.advanced,
     }),
     showShadowSideBottom: createStaticBoolProp({
       label: "Show Shadow Bottom",
       description: "Whether to show shadow on the bottom side or not",
       defaultValue: true,
+      group: GROUPS.advanced,
     }),
     showShadowCornerTopStart: createStaticBoolProp({
       label: "Show Shadow Top Start Corner",
       description: "Whether to show shadow on the top start corner or not",
       defaultValue: true,
+      group: GROUPS.advanced,
     }),
     showShadowCornerTopEnd: createStaticBoolProp({
       label: "Show Shadow Top End Corner",
       description: "Whether to show shadow on the top end corner or not",
       defaultValue: true,
+      group: GROUPS.advanced,
     }),
     showShadowCornerBottomStart: createStaticBoolProp({
       label: "Show Shadow Bottom Start Corner",
       description: "Whether to show shadow on the bottom start corner or not",
       defaultValue: true,
+      group: GROUPS.advanced,
     }),
     showShadowCornerBottomEnd: createStaticBoolProp({
       label: "Show Shadow Bottom End Corner",
       description: "Whether to show shadow on the bottom end corner or not",
       defaultValue: true,
+      group: GROUPS.advanced,
     }),
   },
 };

--- a/packages/core/src/mappings/Shadow.ts
+++ b/packages/core/src/mappings/Shadow.ts
@@ -39,7 +39,7 @@ export const SEED_DATA = {
     stretch: createStaticBoolProp({
       label: "Stretch",
       description: "Force children to occupy all available horizontal space.",
-      defaultValue: null,
+      defaultValue: false,
     }),
     offsetX: createStaticNumberProp({
       label: "Offset X",

--- a/packages/core/src/mappings/Shadow.ts
+++ b/packages/core/src/mappings/Shadow.ts
@@ -34,7 +34,7 @@ export const SEED_DATA = {
     paintInside: createStaticBoolProp({
       label: "Paint Inside",
       description: "Apply the shadow below/inside the content.",
-      defaultValue: null,
+      defaultValue: false,
     }),
     stretch: createStaticBoolProp({
       label: "Stretch",

--- a/packages/core/src/mappings/Shadow.ts
+++ b/packages/core/src/mappings/Shadow.ts
@@ -9,7 +9,7 @@ import {
 
 export const SEED_DATA = {
   name: "Shadow",
-  tag: "Shadow View",
+  tag: "Shadow",
   description: "A cross-platform, universal shadow.",
   category: COMPONENT_TYPES.view,
   stylesPanelSections: CONTAINER_COMPONENT_STYLES_SECTIONS,

--- a/packages/core/src/mappings/Shadow.ts
+++ b/packages/core/src/mappings/Shadow.ts
@@ -43,12 +43,12 @@ export const SEED_DATA = {
     }),
     offsetX: createStaticNumberProp({
       label: "Offset X",
-      description: "Moved the shadow in the x direction",
+      description: "Moves the shadow in the x direction",
       defeaultValue: 0,
     }),
     offsetY: createStaticNumberProp({
       label: "Offset Y",
-      description: "Moved the shadow in the y direction",
+      description: "Moves the shadow in the y direction",
       defeaultValue: 0,
     }),
     showShadowSideStart: createStaticBoolProp({

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -37,6 +37,7 @@ export {
   ActionSheetCancel,
   Swiper,
   SwiperItem,
+  Shadow,
 } from "@draftbit/core";
 
 /**

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -30,6 +30,7 @@ export {
   useAuthState,
   DeckSwiper,
   DeckSwiperCard,
+  Shadow,
   /* Deprecated, needs fixing */
   ProgressBar,
   ProgressCircle,
@@ -39,7 +40,6 @@ export {
   ActionSheetCancel,
   Swiper,
   SwiperItem,
-  Shadow,
 } from "@draftbit/core";
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -5614,6 +5614,11 @@ color@^3.0.0, color@^3.1.2, color@^3.1.3:
     color-convert "^1.9.3"
     color-string "^1.6.0"
 
+colord@2.9.2:
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/colord/-/colord-2.9.2.tgz#25e2bacbbaa65991422c07ea209e2089428effb1"
+  integrity sha512-Uqbg+J445nc1TKn4FoDPS6ZZqAvEDnwrH42yo8B40JSOgSLxMZ/gt3h4nmCtPLQeXhjJJkqBx7SCY35WnIixaQ==
+
 colorette@^1.0.7:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.4.0.tgz#5190fbb87276259a86ad700bff2c6d6faa3fca40"
@@ -13817,6 +13822,13 @@ react-native-screens@~3.15.0:
   dependencies:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"
+
+react-native-shadow-2@^7.0.6:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/react-native-shadow-2/-/react-native-shadow-2-7.0.6.tgz#8fbdb975674b77f236c5fce6af3e0781af6a0ae1"
+  integrity sha512-kH0fKttPE67gIzTsnvmdJS0HAyb2utYAnUZguznmn6iNDRxRDD8RY1COsfW8YN1YuzYZgVtu60G394Az9bmuTg==
+  dependencies:
+    colord "2.9.2"
 
 react-native-svg@12.3.0:
   version "12.3.0"


### PR DESCRIPTION
Adds shadow component through usage of https://www.npmjs.com/package/react-native-shadow-2

Simple pass-through component that make use of draftbit-compatible props.

Based on: https://github.com/draftbit/react-native-jigsaw/pull/570

Closes EXT-36
https://linear.app/draftbit/issue/EXT-36/add-shadow-component

![Screenshot_1675968732](https://user-images.githubusercontent.com/58384527/217909990-ac464130-0c4d-41a1-bdc6-685d61eaaf39.png)
