### PR TITLE
Added keyboard auto dismiss to Picker and DatePicker

### DIFF
--- a/packages/core/src/components/DatePicker/DatePicker.tsx
+++ b/packages/core/src/components/DatePicker/DatePicker.tsx
@@ -12,6 +12,7 @@ import {
   I18nManager,
   LayoutChangeEvent,
   TextInput as NativeTextInput,
+  Keyboard,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
@@ -55,6 +56,7 @@ type Props = {
   rightIconName?: string;
   borderColor?: string;
   borderColorActive?: string;
+  autoDismissKeyboard?: boolean;
 } & IconSlot &
   TextInputProps;
 
@@ -93,6 +95,7 @@ const DatePicker: React.FC<React.PropsWithChildren<Props>> = ({
   placeholder,
   borderColor: inputBorderColor,
   borderColorActive: inputBorderColorActive,
+  autoDismissKeyboard = true,
   ...props
 }) => {
   const [value, setValue] = React.useState<any>(date || defaultValue);
@@ -203,6 +206,12 @@ const DatePicker: React.FC<React.PropsWithChildren<Props>> = ({
       clearTimeout(_showPlaceholder());
     };
   }, [focused, label, placeholder]);
+
+  React.useEffect(() => {
+    if (pickerVisible && autoDismissKeyboard) {
+      Keyboard.dismiss();
+    }
+  }, [pickerVisible, autoDismissKeyboard]);
 
   const _handleFocus = () => {
     if (disabled) {

--- a/packages/core/src/components/Picker/Picker.tsx
+++ b/packages/core/src/components/Picker/Picker.tsx
@@ -7,6 +7,7 @@ import {
   ViewStyle,
   StyleProp,
   Dimensions,
+  Keyboard,
 } from "react-native";
 import { omit, pickBy, identity, isObject } from "lodash";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -48,6 +49,7 @@ export type PickerProps = {
   placeholderTextColor?: string;
   rightIconName?: string;
   type?: "solid" | "underline";
+  autoDismissKeyboard?: boolean;
   theme: Theme;
   Icon: IconSlot["Icon"];
 };
@@ -107,6 +109,7 @@ const Picker: React.FC<PickerProps> = ({
   placeholderTextColor = unstyledColor,
   rightIconName,
   type = "solid",
+  autoDismissKeyboard = true,
 }) => {
   const androidPickerRef = React.useRef<any | undefined>(undefined);
 
@@ -137,6 +140,12 @@ const Picker: React.FC<PickerProps> = ({
       androidPickerRef?.current?.focus();
     }
   }, [pickerVisible, androidPickerRef]);
+
+  React.useEffect(() => {
+    if (pickerVisible && autoDismissKeyboard) {
+      Keyboard.dismiss();
+    }
+  }, [pickerVisible, autoDismissKeyboard]);
 
   const normalizedOptions = normalizeOptions(options);
 

--- a/packages/core/src/components/Picker/Picker.tsx
+++ b/packages/core/src/components/Picker/Picker.tsx
@@ -116,6 +116,7 @@ const Picker: React.FC<PickerProps> = ({
   const [internalValue, setInternalValue] = React.useState<string | undefined>(
     value || defaultValue
   );
+
   const [pickerVisible, setPickerVisible] = React.useState(false);
 
   const togglePickerVisible = () => {

--- a/packages/core/src/components/Picker/Picker.tsx
+++ b/packages/core/src/components/Picker/Picker.tsx
@@ -116,7 +116,6 @@ const Picker: React.FC<PickerProps> = ({
   const [internalValue, setInternalValue] = React.useState<string | undefined>(
     value || defaultValue
   );
-
   const [pickerVisible, setPickerVisible] = React.useState(false);
 
   const togglePickerVisible = () => {

--- a/packages/core/src/mappings/DatePicker.ts
+++ b/packages/core/src/mappings/DatePicker.ts
@@ -8,6 +8,7 @@ import {
   StylesPanelSections,
   createNumberProp,
   createColorProp,
+  createStaticBoolProp,
 } from "@draftbit/types";
 
 const SEED_DATA_PROPS = {
@@ -185,6 +186,11 @@ export const SEED_DATA = [
         required: true,
         group: GROUPS.basic,
       },
+      autoDismissKeyboard: createStaticBoolProp({
+        label: "Auto dismiss keyboard",
+        description: "Automatically dismiss keyboard when DatePicker is opened",
+        defaultValue: true,
+      }),
     },
   },
 ];

--- a/packages/core/src/mappings/Picker.ts
+++ b/packages/core/src/mappings/Picker.ts
@@ -8,6 +8,7 @@ import {
   createIconSizeProp,
   createColorProp,
   StylesPanelSections,
+  createStaticBoolProp,
 } from "@draftbit/types";
 
 const SEED_DATA_PROPS = {
@@ -157,6 +158,11 @@ export const SEED_DATA = [
       },
       iconSize: createIconSizeProp({ defaultValue: 24 }),
       iconColor: createColorProp({ label: "Icon Color" }),
+      autoDismissKeyboard: createStaticBoolProp({
+        label: "Auto dismiss keyboard",
+        description: "Automatically dismiss keyboard when Picker is opened",
+        defaultValue: true,
+      }),
     },
     layout: {},
   },


### PR DESCRIPTION
Added `autoDismissKeyboard` prop to Picker and DatePicker. Dismisses keyboard based on the picker visibility.