### PR TITLE
Add React Native Paper Dates Modal (for v46)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,6 +54,7 @@
     "lodash.omit": "^4.5.0",
     "lodash.tonumber": "^4.0.3",
     "react-native-modal-datetime-picker": "^13.0.0",
+    "react-native-paper-dates": "^0.12.0",
     "react-native-svg": "12.3.0",
     "react-native-typography": "^1.4.1",
     "react-native-web-swiper": "^2.2.3"

--- a/packages/core/src/mappings/DatePickerModal.ts
+++ b/packages/core/src/mappings/DatePickerModal.ts
@@ -1,7 +1,6 @@
 import {
   COMPONENT_TYPES,
   FORM_TYPES,
-  FIELD_NAME,
   Triggers,
   StylesPanelSections,
   createBoolProp,
@@ -9,12 +8,17 @@ import {
   createTextEnumProp,
   createStaticBoolProp,
   createStaticNumberProp,
+  createFieldNameProp,
+  createActionProp,
 } from "@draftbit/types";
 
-export const SEED_DATA = {
-  name: "Date Picker Modal",
+/**
+ * Maps react-native-paper-dates DatePickerModal in modes: "single" and "multiple"
+ * Cannot map mode "range" because it relies on 2 fieldNames (startDate and endDate)
+ */
+
+const SHARED_SEED_DATA = {
   tag: "DatePickerModal",
-  description: "Date Picker modal for date selection",
   packageName: "react-native-paper-dates",
   triggers: [Triggers.OnDismiss, Triggers.OnConfirm, Triggers.OnChange],
   category: COMPONENT_TYPES.input,
@@ -25,59 +29,140 @@ export const SEED_DATA = {
     StylesPanelSections.MarginsAndPaddings,
     StylesPanelSections.Position,
   ],
-  props: {
-    locale: {},
-    visible: createBoolProp({
-      label: "Visible",
-      description: "If true, show the modal. If false, hide the modal.",
-      required: true,
-    }),
-    label: createTextProp({
-      label: "Label",
-      description:
-        "Label used as the header in the component, defaults to `Select Date`",
-    }),
-    saveLabel: createTextProp({
-      label: "Save Label",
-      description:
-        "Label used to confirm a date selection. Defaults to `Save`.",
-    }),
-    saveLabelDisabled: createStaticBoolProp({
-      label: "Disable Save Label",
-      description:
-        "Flag indicating if the save label should be disabled and unable to receive events",
-    }),
-    uppercase: createStaticBoolProp({
-      label: "Uppercase",
-      description:
-        "Flag indicating if the text in the component should be uppercase. Defaults to true.",
-    }),
-    startYear: createStaticNumberProp({
-      label: "Start Year",
-      description:
-        "The start year when the component is rendered. Defaults to 1800.",
-      required: false,
-    }),
-    endYear: createStaticNumberProp({
-      label: "End Year",
-      description:
-        "The end year when the component is rendered. Defaults to 2200.",
-      required: false,
-    }),
-    mode: createTextEnumProp({
-      label: "Mode",
-      description: "The selection mode of the date picker",
-      required: true,
-      options: ["single", "multiple", "range"],
-      editable: false,
-      defaultValue: "single",
-      formType: FORM_TYPES.flatArray,
-    }),
-    fieldName: {
-      ...FIELD_NAME,
-      handlerPropName: "onConfirm",
-      valuePropName: "date",
-      defaultValue: "date",
+};
+
+const SHARED_SEED_DATA_PROPS = {
+  onDismiss: createActionProp({
+    label: "On Dismiss",
+    description: "Called when date picker dimissed",
+    required: true,
+  }),
+  locale: createTextProp({
+    label: "Locale",
+    description:
+      "A locale can be composed of both a base language, the country (territory) of use, and possibly codeset (which is usually assumed). For example, German is de",
+    defaultValue: "en",
+    required: true,
+  }),
+  visible: createBoolProp({
+    label: "Visible",
+    description: "Flag indicating if the component should be displayed",
+    required: true,
+  }),
+  label: createTextProp({
+    label: "Label",
+    description: "The label used as the header in the component",
+    defaultValue: "Select date",
+  }),
+  saveLabel: createTextProp({
+    label: "Save Label",
+    description: "Label used to confirm a date selection",
+    defaultValue: "Save",
+  }),
+  saveLabelDisabled: createStaticBoolProp({
+    label: "Disable Save Label",
+    description:
+      "Flag indicating if the save label should be disabled and unable to receive events",
+  }),
+  uppercase: createStaticBoolProp({
+    label: "Uppercase",
+    description:
+      "Flag indicating if the text in the component should be uppercase",
+    defaultValue: true,
+  }),
+  startYear: createStaticNumberProp({
+    label: "Start Year",
+    description: "The start year when the component is rendered",
+    required: false,
+    defaultValue: 1800,
+  }),
+  endYear: createStaticNumberProp({
+    label: "End Year",
+    description: "The end year when the component is rendered",
+    required: false,
+    defaultValue: 2200,
+  }),
+};
+
+export const SEED_DATA = [
+  {
+    ...SHARED_SEED_DATA,
+    name: "Date Picker Modal",
+    description: "Date Picker modal for date selection",
+    props: {
+      ...SHARED_SEED_DATA_PROPS,
+      onConfirm: createActionProp({
+        label: "On Confirm",
+        description: "Called when date selected and confirmed",
+        required: true,
+      }),
+      onChange: createActionProp({
+        label: "On Change",
+        description: "Called when date selection changes",
+      }),
+      mode: createTextEnumProp({
+        label: "Mode",
+        description: "The selection mode of the date picker",
+        required: true,
+        options: ["single"],
+        editable: false,
+        defaultValue: "single",
+        formType: FORM_TYPES.flatArray,
+      }),
+      fieldName: createFieldNameProp({
+        defaultValue: "date",
+        handlerPropName: "onConfirm",
+        valuePropName: "date",
+      }),
     },
   },
-};
+  {
+    ...SHARED_SEED_DATA,
+    name: "Multiple Date Picker Modal",
+    description: "Date Picker modal for multiple date selection",
+    props: {
+      ...SHARED_SEED_DATA_PROPS,
+      onConfirm: createActionProp({
+        label: "On Confirm",
+        description: "Called when dates selected and confirmed",
+        required: true,
+      }),
+      onChange: createActionProp({
+        label: "On Change",
+        description: "Called when dates selection changes",
+      }),
+      mode: createTextEnumProp({
+        label: "Mode",
+        description: "The selection mode of the date picker",
+        required: true,
+        options: ["multiple"],
+        editable: false,
+        defaultValue: "multiple",
+        formType: FORM_TYPES.flatArray,
+      }),
+      moreLabel: createTextProp({
+        label: "More Label",
+        description:
+          "The label used display when multiple dates have been selected in the component",
+        defaultValue: "More",
+      }),
+      startLabel: createTextProp({
+        label: "Start Label",
+        description:
+          "The label used as the prefix to the starting date in the component",
+        defaultValue: "Start",
+      }),
+      endLabel: createTextProp({
+        label: "End Label",
+        description:
+          "The label used as the suffix to the ending date in the component",
+        defaultValue: "End",
+      }),
+      fieldName: createFieldNameProp({
+        defaultValue: "dates",
+        handlerPropName: "onConfirm",
+        valuePropName: "dates",
+      }),
+    },
+  },
+];

--- a/packages/core/src/mappings/DatePickerModal.ts
+++ b/packages/core/src/mappings/DatePickerModal.ts
@@ -1,0 +1,83 @@
+import {
+  COMPONENT_TYPES,
+  FORM_TYPES,
+  FIELD_NAME,
+  Triggers,
+  StylesPanelSections,
+  createBoolProp,
+  createTextProp,
+  createTextEnumProp,
+  createStaticBoolProp,
+  createStaticNumberProp,
+} from "@draftbit/types";
+
+export const SEED_DATA = {
+  name: "Date Picker Modal",
+  tag: "DatePickerModal",
+  description: "Date Picker modal for date selection",
+  packageName: "react-native-paper-dates",
+  triggers: [Triggers.OnDismiss, Triggers.OnConfirm, Triggers.OnChange],
+  category: COMPONENT_TYPES.input,
+  StylesPanelSections: [
+    StylesPanelSections.Typography,
+    StylesPanelSections.Background,
+    StylesPanelSections.Size,
+    StylesPanelSections.MarginsAndPaddings,
+    StylesPanelSections.Position,
+  ],
+  props: {
+    locale: {},
+    visible: createBoolProp({
+      label: "Visible",
+      description: "If true, show the modal. If false, hide the modal.",
+      required: true,
+    }),
+    label: createTextProp({
+      label: "Label",
+      description:
+        "Label used as the header in the component, defaults to `Select Date`",
+    }),
+    saveLabel: createTextProp({
+      label: "Save Label",
+      description:
+        "Label used to confirm a date selection. Defaults to `Save`.",
+    }),
+    saveLabelDisabled: createStaticBoolProp({
+      label: "Disable Save Label",
+      description:
+        "Flag indicating if the save label should be disabled and unable to receive events",
+    }),
+    uppercase: createStaticBoolProp({
+      label: "Uppercase",
+      description:
+        "Flag indicating if the text in the component should be uppercase. Defaults to true.",
+    }),
+    startYear: createStaticNumberProp({
+      label: "Start Year",
+      description:
+        "The start year when the component is rendered. Defaults to 1800.",
+      required: false,
+    }),
+    endYear: createStaticNumberProp({
+      label: "End Year",
+      description:
+        "The end year when the component is rendered. Defaults to 2200.",
+      required: false,
+    }),
+    mode: createTextEnumProp({
+      label: "Mode",
+      description: "The selection mode of the date picker",
+      required: true,
+      options: ["single", "multiple", "range"],
+      editable: false,
+      defaultValue: "single",
+      formType: FORM_TYPES.flatArray,
+    }),
+    fieldName: {
+      ...FIELD_NAME,
+      handlerPropName: "onConfirm",
+      valuePropName: "date",
+      defaultValue: "date",
+    },
+  },
+};

--- a/packages/core/src/mappings/DatePickerModal.ts
+++ b/packages/core/src/mappings/DatePickerModal.ts
@@ -10,6 +10,7 @@ import {
   createStaticNumberProp,
   createFieldNameProp,
   createActionProp,
+  GROUPS,
 } from "@draftbit/types";
 
 /**
@@ -43,6 +44,7 @@ const SHARED_SEED_DATA_PROPS = {
       "A locale can be composed of both a base language, the country (territory) of use, and possibly codeset (which is usually assumed). For example, German is de",
     defaultValue: "en",
     required: true,
+    group: GROUPS.basic,
   }),
   visible: createBoolProp({
     label: "Visible",
@@ -53,11 +55,13 @@ const SHARED_SEED_DATA_PROPS = {
     label: "Label",
     description: "The label used as the header in the component",
     defaultValue: "Select date",
+    group: GROUPS.basic,
   }),
   saveLabel: createTextProp({
     label: "Save Label",
     description: "Label used to confirm a date selection",
     defaultValue: "Save",
+    group: GROUPS.basic,
   }),
   saveLabelDisabled: createStaticBoolProp({
     label: "Disable Save Label",
@@ -145,18 +149,21 @@ export const SEED_DATA = [
         description:
           "The label used display when multiple dates have been selected in the component",
         defaultValue: "More",
+        group: GROUPS.basic,
       }),
       startLabel: createTextProp({
         label: "Start Label",
         description:
           "The label used as the prefix to the starting date in the component",
         defaultValue: "Start",
+        group: GROUPS.basic,
       }),
       endLabel: createTextProp({
         label: "End Label",
         description:
           "The label used as the suffix to the ending date in the component",
         defaultValue: "End",
+        group: GROUPS.basic,
       }),
       fieldName: createFieldNameProp({
         defaultValue: "dates",

--- a/packages/types/src/component-types.ts
+++ b/packages/types/src/component-types.ts
@@ -16,6 +16,8 @@ export const Triggers = {
   OnPressIcon: "ON_PRESS_ICON",
   OnIndexChanged: "ON_INDEX_CHANGED",
   OnEndReached: "ON_END_REACHED",
+  OnDismiss: "ON_DISMISS",
+  OnConfirm: "ON_CONFIRM",
 };
 
 export const StylesPanelSections = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5606,7 +5606,7 @@ color-support@^1.1.3:
   resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
   integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
 
-color@^3.0.0, color@^3.1.2, color@^3.1.3:
+color@^3.0.0, color@^3.1.2, color@^3.1.3, color@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/color/-/color-3.2.1.tgz#3544dc198caf4490c3ecc9a790b54fe9ff45e164"
   integrity sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==
@@ -13790,6 +13790,13 @@ react-native-modal-datetime-picker@^13.0.0:
   integrity sha512-PZDkuY7HayRX1KE2X2dm29CvCLzwj/vn6B6QdPbjZea/GEKvHBMOLGdhFCcA9+gD64Y41+VqfytUh2fdvUvQ1g==
   dependencies:
     prop-types "^15.7.2"
+
+react-native-paper-dates@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/react-native-paper-dates/-/react-native-paper-dates-0.12.0.tgz#8007d67bb7a2ccb06856a6331f59b9e741112240"
+  integrity sha512-oT4YgtADFx4YFBSYzJrqmRgs7l9Bc4mnVVd08W9ccTnLELEFCTjMnf5SuFKAdjRDJf96pDnWFwQXiRwOJIMytQ==
+  dependencies:
+    color "^3.2.1"
 
 react-native-reanimated@~2.9.1:
   version "2.9.1"


### PR DESCRIPTION
- Changes from https://github.com/draftbit/react-native-jigsaw/pull/555
- Refactored to include 2 modes of the modal: `single` and `multiple`.
The `range` mode cannot be mapped because it requires 2 'value' props (fieldNames). I don't think there's a way to map that to Draftbit, let me know if I am wrong.