### PR TITLE
Added Markdown component

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -73,6 +73,8 @@ import SurfaceExample from "./SurfaceExample";
 
 import DeckSwiperExample from "./DeckSwiperExample";
 
+import MarkdownExample from "./MarkdownExample";
+
 const ROUTES = {
   AudioPlayer: AudioPlayerExample,
   Layout: LayoutExample,
@@ -118,6 +120,7 @@ const ROUTES = {
   NumberInput: NumberInputExample,
   WebView: WebViewExample,
   DeckSwiper: DeckSwiperExample,
+  Markdown: MarkdownExample,
 };
 
 let customFonts = {

--- a/example/src/MarkdownExample.tsx
+++ b/example/src/MarkdownExample.tsx
@@ -1,0 +1,47 @@
+import * as React from "react";
+import { Markdown, withTheme } from "@draftbit/ui";
+import Section, { Container } from "./Section";
+
+const sampleMarkdown = `
+---
+# h1 Heading 8-)
+## h2 Heading
+### h3 Heading
+#### h4 Heading
+##### h5 Heading
+###### h6 Heading
+## Horizontal Rules
+___
+---
+***
+## Typographic replacements
+Enable typographer option to see result.
+(c) (C) (r) (R) (tm) (TM) (p) (P) +-
+test.. test... test..... test?..... test!....
+!!!!!! ???? ,,  -- ---
+"Smartypants, double quotes" and 'single quotes'
+## Emphasis
+**This is bold text**
+__This is bold text__
+*This is italic text*
+_This is italic text_
+~~Strikethrough~~
+## Blockquotes
+> Blockquotes can also be nested...
+>> ...by using additional greater-than signs right next to each other...
+> > > ...or with spaces between arrows.
+## Lists
+Unordered
+`;
+
+function MarkdownExample() {
+  return (
+    <Container style={{}}>
+      <Section title="Markdown">
+        <Markdown>{sampleMarkdown}</Markdown>
+      </Section>
+    </Container>
+  );
+}
+
+export default withTheme(MarkdownExample);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,6 +54,7 @@
     "lodash.omit": "^4.5.0",
     "lodash.tonumber": "^4.0.3",
     "react-native-deck-swiper": "^2.0.12",
+    "react-native-markdown-display": "^7.0.0-alpha.2",
     "react-native-modal-datetime-picker": "^13.0.0",
     "react-native-svg": "12.3.0",
     "react-native-typography": "^1.4.1",

--- a/packages/core/src/components/Markdown.tsx
+++ b/packages/core/src/components/Markdown.tsx
@@ -11,7 +11,7 @@ const Markdown: React.FC<React.PropsWithChildren<MarkdownProps>> = ({
   style,
 }) => {
   return (
-    //'body' style used for main parent container
+    //'body' style applies to all markdown components
     //@ts-ignore TS does not like the type of this named style for some reason
     <MarkdownComponent style={{ body: StyleSheet.flatten(style) }}>
       {children}

--- a/packages/core/src/components/Markdown.tsx
+++ b/packages/core/src/components/Markdown.tsx
@@ -1,0 +1,22 @@
+import * as React from "react";
+import { StyleProp, ViewStyle, StyleSheet } from "react-native";
+import MarkdownComponent from "react-native-markdown-display";
+
+type MarkdownProps = {
+  style?: StyleProp<ViewStyle>;
+};
+
+const Markdown: React.FC<React.PropsWithChildren<MarkdownProps>> = ({
+  children,
+  style,
+}) => {
+  return (
+    //'body' style used for main parent container
+    //@ts-ignore TS does not like the type of this named style for some reason
+    <MarkdownComponent style={{ body: StyleSheet.flatten(style) }}>
+      {children}
+    </MarkdownComponent>
+  );
+};
+
+export default Markdown;

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -53,6 +53,8 @@ export {
 
 export { DeckSwiper, DeckSwiperCard } from "./components/DeckSwiper";
 
+export { default as Markdown } from "./components/Markdown";
+
 /* Deprecated: Fix or Delete!  */
 export { default as DatePicker } from "./components/DatePicker/DatePicker";
 export { default as Picker } from "./components/Picker/Picker";

--- a/packages/core/src/mappings/Markdown.ts
+++ b/packages/core/src/mappings/Markdown.ts
@@ -1,9 +1,9 @@
 import {
-  BLOCK_STYLES_SECTIONS,
   COMPONENT_TYPES,
   FORM_TYPES,
   GROUPS,
   PROP_TYPES,
+  StylesPanelSections,
 } from "@draftbit/types";
 
 export const SEED_DATA = {
@@ -11,12 +11,17 @@ export const SEED_DATA = {
   tag: "Markdown",
   description: "A component that renders markdown",
   category: COMPONENT_TYPES.basic,
-  stylesPanelSections: BLOCK_STYLES_SECTIONS,
+  stylesPanelSections: [
+    StylesPanelSections.Typography,
+    StylesPanelSections.LayoutSelectedItem,
+    StylesPanelSections.MarginsAndPaddings,
+    StylesPanelSections.Effects,
+  ],
   props: {
     children: {
       group: GROUPS.data,
       label: "Markdown Text",
-      description: "Markdownt text to be rendered ",
+      description: "Markdown text to be rendered ",
       editable: true,
       required: true,
       formType: FORM_TYPES.string,

--- a/packages/core/src/mappings/Markdown.ts
+++ b/packages/core/src/mappings/Markdown.ts
@@ -10,7 +10,7 @@ export const SEED_DATA = {
   name: "Markdown",
   tag: "Markdown",
   description: "A component that renders markdown",
-  category: COMPONENT_TYPES.basic,
+  category: COMPONENT_TYPES.text,
   stylesPanelSections: [
     StylesPanelSections.Typography,
     StylesPanelSections.LayoutSelectedItem,

--- a/packages/core/src/mappings/Markdown.ts
+++ b/packages/core/src/mappings/Markdown.ts
@@ -1,0 +1,27 @@
+import {
+  BLOCK_STYLES_SECTIONS,
+  COMPONENT_TYPES,
+  FORM_TYPES,
+  GROUPS,
+  PROP_TYPES,
+} from "@draftbit/types";
+
+export const SEED_DATA = {
+  name: "Markdown",
+  tag: "Markdown",
+  description: "A component that renders markdown",
+  category: COMPONENT_TYPES.basic,
+  stylesPanelSections: BLOCK_STYLES_SECTIONS,
+  props: {
+    children: {
+      group: GROUPS.data,
+      label: "Markdown Text",
+      description: "Markdownt text to be rendered ",
+      editable: true,
+      required: true,
+      formType: FORM_TYPES.string,
+      propType: PROP_TYPES.STRING,
+      defaultValue: "## Double click me to edit 👀",
+    },
+  },
+};

--- a/packages/core/src/mappings/Markdown.ts
+++ b/packages/core/src/mappings/Markdown.ts
@@ -26,7 +26,7 @@ export const SEED_DATA = {
       required: true,
       formType: FORM_TYPES.string,
       propType: PROP_TYPES.STRING,
-      defaultValue: "## Double click me to edit 👀",
+      defaultValue: "### Markdown",
     },
   },
 };

--- a/packages/types/src/component-types.d.ts
+++ b/packages/types/src/component-types.d.ts
@@ -66,6 +66,7 @@ export declare const COMPONENT_TYPES: {
   deprecated: string;
   screen: string;
   codeComponent: string;
+  text: string;
 };
 export declare const createElevationType: (defaultValue: any) => {
   defaultValue: any;

--- a/packages/types/src/component-types.ts
+++ b/packages/types/src/component-types.ts
@@ -126,6 +126,7 @@ export const COMPONENT_TYPES = {
   swiper: "swiper",
   map: "map",
   view: "view",
+  text: "text",
   /* Deprecated */
   row: "row",
   card: "card",

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -30,6 +30,7 @@ export {
   useAuthState,
   DeckSwiper,
   DeckSwiperCard,
+  Markdown,
   /* Deprecated, needs fixing */
   ProgressBar,
   ProgressCircle,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3646,9 +3646,9 @@
     "@types/react" "*"
 
 "@types/react@*", "@types/react@~18.0.0":
-  version "18.0.26"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.26.tgz#8ad59fc01fef8eaf5c74f4ea392621749f0b7917"
-  integrity sha512-hCR3PJQsAIXyxhTNSiDFY//LhnMZWpNNr5etoCqx/iUfGc5gXWtQR2Phl908jVR6uPXacojQWTg4qRpkxTuGug==
+  version "18.0.28"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.28.tgz#accaeb8b86f4908057ad629a26635fe641480065"
+  integrity sha512-RD0ivG1kEztNBdoAK7lekI9M+azSnitIn85h4iOiaLjaTrMjzslhaqCGaI4IyCJ1RljWiLCEu4jyrLLgqxBTew==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -5267,6 +5267,11 @@ camelcase@^6.0.0, camelcase@^6.2.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
+camelize@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.1.tgz#89b7e16884056331a35d6b5ad064332c91daa6c3"
+  integrity sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==
+
 caniuse-api@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/caniuse-api/-/caniuse-api-3.0.0.tgz#5e4d90e2274961d46291997df599e3ed008ee4c0"
@@ -6147,6 +6152,11 @@ crypto-random-string@^2.0.0:
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
   integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
 
+css-color-keywords@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
+  integrity sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==
+
 css-color-names@0.0.4, css-color-names@^0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
@@ -6212,6 +6222,15 @@ css-select@^4.1.3, css-select@^4.2.1:
     domhandler "^4.3.1"
     domutils "^2.8.0"
     nth-check "^2.0.1"
+
+css-to-react-native@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-3.1.0.tgz#e783474149997608986afcff614405714a8fe1ac"
+  integrity sha512-AryfkFA29b4I3vG7N4kxFboq15DxwSXzhXM37XNEjwJMgjYIc8BcqfiprpAqX0zadI5PMByEIwAMzXxk5Vcc4g==
+  dependencies:
+    camelize "^1.0.0"
+    css-color-keywords "^1.0.0"
+    postcss-value-parser "^4.0.2"
 
 css-tree@1.0.0-alpha.37:
   version "1.0.0-alpha.37"
@@ -6976,6 +6995,11 @@ entities@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
+
+entities@~2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.3.tgz#5c487e5742ab93c15abb5da22759b8590ec03b7f"
+  integrity sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==
 
 env-editor@^0.4.1:
   version "0.4.2"
@@ -10769,6 +10793,13 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
+linkify-it@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-2.2.0.tgz#e3b54697e78bf915c70a38acd78fd09e0058b1cf"
+  integrity sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==
+  dependencies:
+    uc.micro "^1.0.1"
+
 lint-staged@>=13:
   version "13.0.3"
   resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-13.0.3.tgz#d7cdf03a3830b327a2b63c6aec953d71d9dc48c6"
@@ -11115,6 +11146,17 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+markdown-it@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-10.0.0.tgz#abfc64f141b1722d663402044e43927f1f50a8dc"
+  integrity sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==
+  dependencies:
+    argparse "^1.0.7"
+    entities "~2.0.0"
+    linkify-it "^2.0.0"
+    mdurl "^1.0.1"
+    uc.micro "^1.0.5"
+
 md5-file@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/md5-file/-/md5-file-3.2.3.tgz#f9bceb941eca2214a4c0727f5e700314e770f06f"
@@ -11163,6 +11205,11 @@ mdn-data@2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.4.tgz#699b3c38ac6f1d728091a64650b65d388502fd5b"
   integrity sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==
+
+mdurl@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
+  integrity sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -13645,7 +13692,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@*, prop-types@15.8.1, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@*, prop-types@15.8.1, prop-types@^15.5.10, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -13983,6 +14030,13 @@ react-native-deck-swiper@^2.0.12:
   dependencies:
     prop-types "15.5.10"
 
+react-native-fit-image@^1.5.5:
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/react-native-fit-image/-/react-native-fit-image-1.5.5.tgz#c660d1ad74b9dcaa1cba27a0d9c23837e000226c"
+  integrity sha512-Wl3Vq2DQzxgsWKuW4USfck9zS7YzhvLNPpkwUUCF90bL32e1a0zOVQ3WsJILJOwzmPdHfzZmWasiiAUNBkhNkg==
+  dependencies:
+    prop-types "^15.5.10"
+
 react-native-gesture-handler@~2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-2.5.0.tgz#61385583570ed0a45a9ed142425e35f8fe8274fb"
@@ -14011,6 +14065,16 @@ react-native-maps@0.31.1:
   dependencies:
     "@types/geojson" "^7946.0.7"
     deprecated-react-native-prop-types "^2.3.0"
+
+react-native-markdown-display@^7.0.0-alpha.2:
+  version "7.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/react-native-markdown-display/-/react-native-markdown-display-7.0.0-alpha.2.tgz#a48a70d3cb5c510a52ecf7f1509a4a3d14d728aa"
+  integrity sha512-Od1a4wJEcVGwO1bh02sHivsEkKKpu99+ew/OtmVTPRmfT8V3B0aTut7k7ICV0Vej9F4ZjylRHvm28/maYUBeGw==
+  dependencies:
+    css-to-react-native "^3.0.0"
+    markdown-it "^10.0.0"
+    prop-types "^15.7.2"
+    react-native-fit-image "^1.5.5"
 
 react-native-modal-datetime-picker@^13.0.0:
   version "13.1.2"
@@ -16259,6 +16323,11 @@ ua-parser-js@^0.7.30:
   version "0.7.31"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.31.tgz#649a656b191dffab4f21d5e053e27ca17cbff5c6"
   integrity sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==
+
+uc.micro@^1.0.1, uc.micro@^1.0.5:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
+  integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
 
 uglify-es@^3.1.9:
   version "3.3.9"


### PR DESCRIPTION
- Changes from https://github.com/draftbit/react-native-jigsaw/pull/365 (modified)
- Uses https://www.npmjs.com/package/react-native-markdown-display instead of https://www.npmjs.com/package/react-native-markdown-package
  - Other package did not render markdown properly. This one is more popular with more downloads 
- Made markdown text be input as children rather than prop