### PR TITLE
Added support for renderItem in DeckSwiper

### DIFF
--- a/example/src/DeckSwiperExample.tsx
+++ b/example/src/DeckSwiperExample.tsx
@@ -1,7 +1,30 @@
 import React from "react";
 import { Image, Text } from "react-native";
 import Section, { Container } from "./Section";
-import { DeckSwiper, DeckSwiperCard } from "@draftbit/core";
+import { DeckSwiper, DeckSwiperCard } from "@draftbit/ui";
+
+const sampleData = [
+  {
+    id: 1,
+    fullName: "Susan Williamson",
+  },
+  {
+    id: 2,
+    fullName: "Henrietta Wagner",
+  },
+  {
+    id: 3,
+    fullName: "Lydia Snyder",
+  },
+  {
+    id: 4,
+    fullName: "Harold Herrera",
+  },
+  {
+    id: 5,
+    fullName: "Richard Garrett",
+  },
+];
 
 const DeckSwiperExample: React.FC = () => {
   return (
@@ -44,6 +67,20 @@ const DeckSwiperExample: React.FC = () => {
             />
           </DeckSwiperCard>
         </DeckSwiper>
+      </Section>
+
+      <Section title="Lazy Rendering (renderItem)" style={{}}>
+        <DeckSwiper
+          infiniteSwiping
+          visibleCardCount={2}
+          data={sampleData}
+          renderItem={({ item }) => (
+            <DeckSwiperCard>
+              <Text>{item.fullName}</Text>
+            </DeckSwiperCard>
+          )}
+          keyExtractor={(item) => item.id.toString()}
+        />
       </Section>
     </Container>
   );

--- a/packages/core/src/components/DeckSwiper/DeckSwiper.tsx
+++ b/packages/core/src/components/DeckSwiper/DeckSwiper.tsx
@@ -75,7 +75,7 @@ const DeckSwiper = <T extends object>({
     if (keyExtractor) {
       return keyExtractor(card);
     } else {
-      return card.toString();
+      return card?.toString();
     }
   };
 

--- a/packages/core/src/components/DeckSwiper/DeckSwiperCard.tsx
+++ b/packages/core/src/components/DeckSwiper/DeckSwiperCard.tsx
@@ -5,15 +5,12 @@ import { withTheme } from "../../theming";
 
 export interface DeckSwiperCardProps {
   style?: StyleProp<ViewStyle>;
-  children: React.ReactNode;
   theme: Theme;
 }
 
-const DeckSwiperCard: React.FC<DeckSwiperCardProps> = ({
-  style,
-  children,
-  theme,
-}) => (
+const DeckSwiperCard: React.FC<
+  React.PropsWithChildren<DeckSwiperCardProps>
+> = ({ style, children, theme }) => (
   <View
     style={[
       styles.card,


### PR DESCRIPTION
- Made DeckSwiper work when provided `data` and `renderItem` instead of children.
- Direct children still works if these not provided