### PR TITLE
Updated allowed FlashList styles

### DIFF
--- a/packages/core/src/mappings/FlashList.ts
+++ b/packages/core/src/mappings/FlashList.ts
@@ -3,12 +3,12 @@ import {
   createNumColumnsType,
   createStaticBoolProp,
   createNumberProp,
-  CONTAINER_COMPONENT_STYLES_SECTIONS,
   GROUPS,
   Triggers,
   createActionProp,
   createStaticNumberProp,
   createColorProp,
+  StylesPanelSections,
 } from "@draftbit/types";
 
 export const SEED_DATA = [
@@ -18,10 +18,10 @@ export const SEED_DATA = [
     description: "Masonry Flashlist by Shopify",
     packageName: "@shopify/flash-list",
     category: COMPONENT_TYPES.data,
-    stylesPanelSections: CONTAINER_COMPONENT_STYLES_SECTIONS,
-    layout: {
-      flex: 1,
-    },
+    stylesPanelSections: [
+      StylesPanelSections.Background,
+      StylesPanelSections.MarginsAndPaddings,
+    ],
     triggers: [Triggers.OnRefresh, Triggers.OnEndReached],
     props: {
       onRefresh: createActionProp(),
@@ -72,10 +72,10 @@ export const SEED_DATA = [
     description: "Flashlist by Shopify",
     packageName: "@shopify/flash-list",
     category: COMPONENT_TYPES.data,
-    stylesPanelSections: CONTAINER_COMPONENT_STYLES_SECTIONS,
-    layout: {
-      flex: 1,
-    },
+    stylesPanelSections: [
+      StylesPanelSections.Background,
+      StylesPanelSections.MarginsAndPaddings,
+    ],
     triggers: [Triggers.OnRefresh, Triggers.OnEndReached],
     props: {
       onRefresh: createActionProp(),


### PR DESCRIPTION
- Updated styles of mapping to only allow background color and padding/margins (https://shopify.github.io/flash-list/docs/usage/#contentcontainerstyle)
- Although margins are also not supported, there seems to be no way to only include the padding styles