### PR TITLE
Added Swipeable View Components

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -84,6 +84,8 @@ import YoutubeExample from "./YoutubeExample";
 
 import TableExample from "./TableExample";
 
+import SwipeableViewExample from "./SwipeableViewExample";
+
 const ROUTES = {
   AudioPlayer: AudioPlayerExample,
   Layout: LayoutExample,
@@ -135,6 +137,7 @@ const ROUTES = {
   BottomSheet: BottomSheetExample,
   Youtube: YoutubeExample,
   Table: TableExample,
+  SwipeableView: SwipeableViewExample,
 };
 
 let customFonts = {

--- a/example/src/SwipeableViewExample.tsx
+++ b/example/src/SwipeableViewExample.tsx
@@ -1,0 +1,42 @@
+import {
+  SwipeableView,
+  SwipeableViewButton,
+  SwipeableViewSwipeHandler,
+} from "@draftbit/ui";
+import React from "react";
+import { Text } from "react-native";
+import Section, { Container } from "./Section";
+
+const DeckSwiperExample: React.FC = () => {
+  return (
+    <Container style={{ flex: 1 }}>
+      <Section title="Swipeable View" style={{ flex: 1 }}>
+        <SwipeableView>
+          <Text>Some Content</Text>
+
+          <SwipeableViewButton
+            onPress={null}
+            side="left"
+            title="Button"
+            icon="add"
+          />
+          <SwipeableViewButton
+            onPress={null}
+            side="left"
+            title="Button"
+            icon="add"
+          />
+          <SwipeableViewSwipeHandler
+            onSwipe={null}
+            side="right"
+            title="Swipe"
+            icon="add"
+            backgroundColor="red"
+          />
+        </SwipeableView>
+      </Section>
+    </Container>
+  );
+};
+
+export default DeckSwiperExample;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -61,6 +61,7 @@
     "react-native-reanimated": "~2.9.1",
     "react-native-shadow-2": "^7.0.6",
     "react-native-svg": "12.3.0",
+    "react-native-swipe-list-view": "^3.2.9",
     "react-native-tab-view": "^3.4.0",
     "react-native-typography": "^1.4.1",
     "react-native-web-swiper": "^2.2.3",

--- a/packages/core/src/components/SwipeableView/SwipeableView.tsx
+++ b/packages/core/src/components/SwipeableView/SwipeableView.tsx
@@ -166,9 +166,6 @@ const SwipeableView: React.FC<React.PropsWithChildren<SwipeableViewProps>> = ({
     throw Error("Cannot combine swiper handler and buttons on the same side");
   }
 
-  const isLeftSwipeHandler = !!leftSwipeHandlers.length;
-  const isRightSwipeHandler = !!rightSwipeHandlers.length;
-
   //Renders a single button/item. Used for both buttons and swipe handler
   const renderBehindItem = (
     props: SwipeableViewSwipeHandlerProps | SwipeableViewButtonProps,
@@ -196,6 +193,9 @@ const SwipeableView: React.FC<React.PropsWithChildren<SwipeableViewProps>> = ({
       </Text>
     </Pressable>
   );
+
+  const isLeftSwipeHandler = !!leftSwipeHandlers.length;
+  const isRightSwipeHandler = !!rightSwipeHandlers.length;
 
   const defaultLeftOpenValue = componentWidth ? componentWidth / 2 : 0;
   const defaultRightOpenValue = componentWidth ? -componentWidth / 2 : 0;

--- a/packages/core/src/components/SwipeableView/SwipeableView.tsx
+++ b/packages/core/src/components/SwipeableView/SwipeableView.tsx
@@ -59,7 +59,6 @@ const SwipeableView: React.FC<React.PropsWithChildren<SwipeableViewProps>> = ({
   swipeActivationPercentage = 80,
   stopLeftSwipe,
   stopRightSwipe,
-  swipeToOpenPercent = 30,
   friction = 20,
   ...rest
 }) => {
@@ -238,7 +237,6 @@ const SwipeableView: React.FC<React.PropsWithChildren<SwipeableViewProps>> = ({
             : undefined
         }
         closeOnRowPress={closeOnPress}
-        swipeToOpenPercent={swipeToOpenPercent}
         friction={friction}
         {...rest}
       >

--- a/packages/core/src/components/SwipeableView/SwipeableView.tsx
+++ b/packages/core/src/components/SwipeableView/SwipeableView.tsx
@@ -35,8 +35,6 @@ export interface SwipeableViewProps extends IconSlot {
   directionalDistanceChangeThreshold?: number;
   friction?: number;
   tension?: number;
-  restSpeedThreshold?: number;
-  restDisplacementThreshold?: number;
   disableLeftSwipe?: boolean;
   disableRightSwipe?: boolean;
   swipeToOpenVelocityContribution?: number;

--- a/packages/core/src/components/SwipeableView/SwipeableView.tsx
+++ b/packages/core/src/components/SwipeableView/SwipeableView.tsx
@@ -13,6 +13,7 @@ import {
   extractEffectStyles,
   extractFlexItemStyles,
   extractPositionStyles,
+  extractSizeStyles,
   extractStyles,
 } from "../../utilities";
 import { SwipeRow } from "react-native-swipe-list-view";
@@ -56,6 +57,7 @@ const SwipeableView: React.FC<React.PropsWithChildren<SwipeableViewProps>> = ({
     extractFlexItemStyles(viewStyles),
     extractPositionStyles(viewStyles),
     extractEffectStyles(viewStyles),
+    extractSizeStyles(viewStyles),
   ]);
 
   //Remove styles already consumed from viewStyles
@@ -126,8 +128,8 @@ const SwipeableView: React.FC<React.PropsWithChildren<SwipeableViewProps>> = ({
   }
 
   if (
-    (leftButtons && leftSwipeHandlers) ||
-    (rightButtons && rightSwipeHandlers)
+    (leftButtons.length && leftSwipeHandlers.length) ||
+    (rightButtons.length && rightSwipeHandlers.length)
   ) {
     throw Error("Cannot combine swiper handler and buttons on the same side");
   }
@@ -137,9 +139,11 @@ const SwipeableView: React.FC<React.PropsWithChildren<SwipeableViewProps>> = ({
 
   //Renders a single button/item. Used for both buttons and swipe handler
   const renderBehindItem = (
-    props: SwipeableViewSwipeHandlerProps | SwipeableViewButtonProps
+    props: SwipeableViewSwipeHandlerProps | SwipeableViewButtonProps,
+    index: number
   ) => (
     <Pressable
+      key={index.toString()}
       onPress={(props as any).onPress}
       style={[
         styles.buttonContainer,
@@ -148,13 +152,16 @@ const SwipeableView: React.FC<React.PropsWithChildren<SwipeableViewProps>> = ({
     >
       {props.icon && (
         <Icon
-          style={styles.buttonIcon}
           name={props.icon}
-          size={16}
-          color={props.color}
+          size={props.iconSize || 25}
+          color={props.color || theme.colors.surface}
         />
       )}
-      <Text style={[textStyles, { color: props.color }]}>{props.title}</Text>
+      <Text
+        style={[textStyles, { color: props.color || theme.colors.surface }]}
+      >
+        {props.title}
+      </Text>
     </Pressable>
   );
 
@@ -176,21 +183,31 @@ const SwipeableView: React.FC<React.PropsWithChildren<SwipeableViewProps>> = ({
         <View
           style={[
             styles.behindContainer,
-            { backgroundColor: theme.colors.primary },
+            {
+              backgroundColor: theme.colors.primary,
+            },
           ]}
         >
           <View style={styles.behindContainerItem}>
             {(isLeftSwipeHandler ? leftSwipeHandlers : leftButtons).map(
-              (item) => renderBehindItem(item.props)
+              (item, index) => renderBehindItem(item.props, index)
             )}
           </View>
           <View style={styles.behindContainerItem}>
             {(isRightSwipeHandler ? rightSwipeHandlers : rightButtons).map(
-              (item) => renderBehindItem(item.props)
+              (item, index) => renderBehindItem(item.props, index)
             )}
           </View>
         </View>
-        <View style={[styles.surfaceContainer, surfaceContainerStyles]}>
+        <View
+          style={[
+            styles.surfaceContainer,
+            {
+              backgroundColor: theme.colors.background,
+            },
+            surfaceContainerStyles,
+          ]}
+        >
           {remainingChildren}
         </View>
       </SwipeRow>
@@ -201,22 +218,31 @@ const SwipeableView: React.FC<React.PropsWithChildren<SwipeableViewProps>> = ({
 const styles = StyleSheet.create({
   parentContainer: {
     overflow: "hidden",
+    minHeight: 50,
   },
   behindContainer: {
     flex: 1,
+    width: "100%",
+    height: "100%",
+    flexDirection: "row",
   },
   behindContainerItem: {
     flex: 1,
+    flexDirection: "row",
   },
   buttonContainer: {
     flex: 1,
     alignItems: "center",
     justifyContent: "center",
   },
-  buttonIcon: {
-    marginBottom: 10,
+  surfaceContainer: {
+    flexDirection: "row",
+    width: "100%",
+    height: "100%",
+    padding: 10,
+    alignItems: "center",
+    overflow: "hidden",
   },
-  surfaceContainer: {},
 });
 
 export default withTheme(SwipeableView);

--- a/packages/core/src/components/SwipeableView/SwipeableView.tsx
+++ b/packages/core/src/components/SwipeableView/SwipeableView.tsx
@@ -1,0 +1,222 @@
+import React from "react";
+import {
+  View,
+  StyleProp,
+  ViewStyle,
+  TextStyle,
+  StyleSheet,
+  Text,
+} from "react-native";
+import Pressable from "../Pressable";
+import {
+  extractBorderAndMarginStyles,
+  extractEffectStyles,
+  extractFlexItemStyles,
+  extractPositionStyles,
+  extractStyles,
+} from "../../utilities";
+import { SwipeRow } from "react-native-swipe-list-view";
+import { IconSlot } from "../../interfaces/Icon";
+import type { Theme } from "../../styles/DefaultTheme";
+import { withTheme } from "../../theming";
+import { SwipeableViewButtonProps } from "./SwipeableViewButton";
+import { SwipeableViewSwipeHandlerProps } from "./SwipeableViewSwipeHandler";
+
+export interface SwipeableViewProps extends IconSlot {
+  style?: StyleProp<ViewStyle | TextStyle>;
+  theme: Theme;
+}
+
+const SwipeableView: React.FC<React.PropsWithChildren<SwipeableViewProps>> = ({
+  theme,
+  style,
+  children,
+  Icon,
+}) => {
+  const instanceOfSwipeableViewButtonProps = (
+    object: any
+  ): object is SwipeableViewButtonProps => {
+    return "title" in object && "side" in object && "onPress" in object;
+  };
+
+  const instanceOfSwipeableViewSwipeHandlerProps = (
+    object: any
+  ): object is SwipeableViewSwipeHandlerProps => {
+    return "title" in object && "side" in object && "onSwipe" in object;
+  };
+
+  const { viewStyles, textStyles } = extractStyles(style);
+
+  const { borderStyles, marginStyles } =
+    extractBorderAndMarginStyles(viewStyles);
+
+  const parentContainerStyles = StyleSheet.flatten([
+    borderStyles,
+    marginStyles,
+    extractFlexItemStyles(viewStyles),
+    extractPositionStyles(viewStyles),
+    extractEffectStyles(viewStyles),
+  ]);
+
+  //Remove styles already consumed from viewStyles
+  Object.keys(parentContainerStyles).forEach((key) => delete viewStyles[key]);
+  const surfaceContainerStyles = viewStyles;
+
+  const leftButtons = React.useMemo(
+    () =>
+      React.Children.toArray(children).filter(
+        (child) =>
+          React.isValidElement(child) &&
+          instanceOfSwipeableViewButtonProps(child.props) &&
+          child.props.side === "left"
+      ) as React.ReactElement<SwipeableViewButtonProps>[],
+    [children]
+  );
+
+  const rightButtons = React.useMemo(
+    () =>
+      React.Children.toArray(children).filter(
+        (child) =>
+          React.isValidElement(child) &&
+          instanceOfSwipeableViewButtonProps(child.props) &&
+          child.props.side === "right"
+      ) as React.ReactElement<SwipeableViewButtonProps>[],
+    [children]
+  );
+
+  const leftSwipeHandlers = React.useMemo(
+    () =>
+      React.Children.toArray(children).filter(
+        (child) =>
+          React.isValidElement(child) &&
+          instanceOfSwipeableViewSwipeHandlerProps(child.props) &&
+          child.props.side === "left"
+      ) as React.ReactElement<SwipeableViewSwipeHandlerProps>[],
+    [children]
+  );
+
+  const rightSwipeHandlers = React.useMemo(
+    () =>
+      React.Children.toArray(children).filter(
+        (child) =>
+          React.isValidElement(child) &&
+          instanceOfSwipeableViewSwipeHandlerProps(child.props) &&
+          child.props.side === "right"
+      ) as React.ReactElement<SwipeableViewSwipeHandlerProps>[],
+    [children]
+  );
+
+  const remainingChildren = React.useMemo(
+    () =>
+      React.Children.toArray(children).filter(
+        (child) =>
+          React.isValidElement(child) &&
+          !instanceOfSwipeableViewSwipeHandlerProps(child.props) &&
+          !instanceOfSwipeableViewButtonProps(child.props)
+      ),
+    [children]
+  );
+
+  if (leftButtons.length > 2 || rightButtons.length > 2) {
+    throw Error("Cannot have more than 2 buttons per side");
+  }
+
+  if (leftSwipeHandlers.length > 1 || rightSwipeHandlers.length > 1) {
+    throw Error("Cannot have more than 1 swiper handler per side");
+  }
+
+  if (
+    (leftButtons && leftSwipeHandlers) ||
+    (rightButtons && rightSwipeHandlers)
+  ) {
+    throw Error("Cannot combine swiper handler and buttons on the same side");
+  }
+
+  const isLeftSwipeHandler = !!leftSwipeHandlers.length;
+  const isRightSwipeHandler = !!rightSwipeHandlers.length;
+
+  //Renders a single button/item. Used for both buttons and swipe handler
+  const renderBehindItem = (
+    props: SwipeableViewSwipeHandlerProps | SwipeableViewButtonProps
+  ) => (
+    <Pressable
+      onPress={(props as any).onPress}
+      style={[
+        styles.buttonContainer,
+        { backgroundColor: props.backgroundColor },
+      ]}
+    >
+      {props.icon && (
+        <Icon
+          style={styles.buttonIcon}
+          name={props.icon}
+          size={16}
+          color={props.color}
+        />
+      )}
+      <Text style={[textStyles, { color: props.color }]}>{props.title}</Text>
+    </Pressable>
+  );
+
+  return (
+    <View style={[styles.parentContainer, parentContainerStyles]}>
+      {/*@ts-ignore*/}
+      <SwipeRow
+        onLeftAction={
+          isLeftSwipeHandler
+            ? () => leftSwipeHandlers[0].props.onSwipe?.()
+            : undefined
+        }
+        onRightAction={
+          isRightSwipeHandler
+            ? () => rightSwipeHandlers[0].props.onSwipe?.()
+            : undefined
+        }
+      >
+        <View
+          style={[
+            styles.behindContainer,
+            { backgroundColor: theme.colors.primary },
+          ]}
+        >
+          <View style={styles.behindContainerItem}>
+            {(isLeftSwipeHandler ? leftSwipeHandlers : leftButtons).map(
+              (item) => renderBehindItem(item.props)
+            )}
+          </View>
+          <View style={styles.behindContainerItem}>
+            {(isRightSwipeHandler ? rightSwipeHandlers : rightButtons).map(
+              (item) => renderBehindItem(item.props)
+            )}
+          </View>
+        </View>
+        <View style={[styles.surfaceContainer, surfaceContainerStyles]}>
+          {remainingChildren}
+        </View>
+      </SwipeRow>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  parentContainer: {
+    overflow: "hidden",
+  },
+  behindContainer: {
+    flex: 1,
+  },
+  behindContainerItem: {
+    flex: 1,
+  },
+  buttonContainer: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  buttonIcon: {
+    marginBottom: 10,
+  },
+  surfaceContainer: {},
+});
+
+export default withTheme(SwipeableView);

--- a/packages/core/src/components/SwipeableView/SwipeableViewButton.tsx
+++ b/packages/core/src/components/SwipeableView/SwipeableViewButton.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+export interface SwipeableViewButtonProps {
+  title: string;
+  side: "left" | "right";
+  onPress: (() => void) | null; //Not optional in order to always exist in props
+  icon?: string;
+  backgroundColor?: string;
+  color?: string;
+}
+
+//Renders nothing, acts as a wrapper be used by SwipeableView
+const SwipeableViewButton: React.FC<SwipeableViewButtonProps> = () => {
+  return null;
+};
+
+export default SwipeableViewButton;

--- a/packages/core/src/components/SwipeableView/SwipeableViewButton.tsx
+++ b/packages/core/src/components/SwipeableView/SwipeableViewButton.tsx
@@ -5,6 +5,7 @@ export interface SwipeableViewButtonProps {
   side: "left" | "right";
   onPress: (() => void) | null; //Not optional in order to always exist in props
   icon?: string;
+  iconSize?: number;
   backgroundColor?: string;
   color?: string;
 }

--- a/packages/core/src/components/SwipeableView/SwipeableViewSwipeHandler.tsx
+++ b/packages/core/src/components/SwipeableView/SwipeableViewSwipeHandler.tsx
@@ -5,6 +5,7 @@ export interface SwipeableViewSwipeHandlerProps {
   side: "left" | "right";
   onSwipe: (() => void) | null; //Not optional in order to always exist in props
   icon?: string;
+  iconSize?: number;
   backgroundColor?: string;
   color?: string;
 }

--- a/packages/core/src/components/SwipeableView/SwipeableViewSwipeHandler.tsx
+++ b/packages/core/src/components/SwipeableView/SwipeableViewSwipeHandler.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+export interface SwipeableViewSwipeHandlerProps {
+  title: string;
+  side: "left" | "right";
+  onSwipe: (() => void) | null; //Not optional in order to always exist in props
+  icon?: string;
+  backgroundColor?: string;
+  color?: string;
+}
+
+//Renders nothing, acts as a wrapper to be used by SwipeableView
+const SwipeableViewSwipeHandler: React.FC<
+  SwipeableViewSwipeHandlerProps
+> = () => {
+  return null;
+};
+
+export default SwipeableViewSwipeHandler;

--- a/packages/core/src/components/SwipeableView/index.tsx
+++ b/packages/core/src/components/SwipeableView/index.tsx
@@ -1,0 +1,3 @@
+export { default as SwipeableView } from "./SwipeableView";
+export { default as SwipeableViewButton } from "./SwipeableViewButton";
+export { default as SwipeableViewSwipeHandler } from "./SwipeableViewSwipeHandler";

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -64,6 +64,12 @@ export { YoutubePlayer } from "./components/YoutubePlayer";
 
 export { Table, TableRow, TableCell } from "./components/Table";
 
+export {
+  SwipeableView,
+  SwipeableViewButton,
+  SwipeableViewSwipeHandler,
+} from "./components/SwipeableView";
+
 /* Deprecated: Fix or Delete!  */
 export { default as DatePicker } from "./components/DatePicker/DatePicker";
 export { default as Picker } from "./components/Picker/Picker";

--- a/packages/core/src/mappings/SwipeableView.ts
+++ b/packages/core/src/mappings/SwipeableView.ts
@@ -193,7 +193,7 @@ export const SEED_DATA = [
   },
   {
     name: "Swipeable View Swipe Handler",
-    tag: "SwipeableViewButton",
+    tag: "SwipeableViewSwipeHandler",
     description: "Component that renders and handles swipe of Swipeable View",
     category: COMPONENT_TYPES.view,
     stylesPanelSections: [],

--- a/packages/core/src/mappings/SwipeableView.ts
+++ b/packages/core/src/mappings/SwipeableView.ts
@@ -1,0 +1,210 @@
+import {
+  COMPONENT_TYPES,
+  createStaticNumberProp,
+  createStaticBoolProp,
+  CONTAINER_COMPONENT_STYLES_SECTIONS,
+  StylesPanelSections,
+  GROUPS,
+  createBoolProp,
+  createTextProp,
+  createIconProp,
+  createTextEnumProp,
+  createColorProp,
+  Triggers,
+  createActionProp,
+} from "@draftbit/types";
+
+const SHARED_SWIPEABLE_CHILDREN_PROPS = {
+  title: createTextProp({
+    label: "Title",
+    description: "Title of button/swipeable",
+    defaultValue: "Swipeable",
+    required: true,
+    group: GROUPS.basic,
+  }),
+  side: createTextEnumProp({
+    label: "Side",
+    description: "Side where button/swipeable is added",
+    options: ["left", "right"],
+    defaultValue: "left",
+    required: true,
+  }),
+  icon: createIconProp({
+    defaultValue: null,
+    required: false,
+  }),
+  iconSize: createStaticNumberProp({
+    label: "Icon size",
+    description: "Size of icon",
+    defaultValue: 25,
+    required: false,
+  }),
+  backgroundColor: createColorProp({
+    label: "Background color",
+    description: "Color of button/swipeable background",
+    defaultValue: "primary",
+  }),
+  color: createColorProp({
+    label: "Color",
+    description: "Color of text and icon of button/swipeable",
+    defaultValue: "surface",
+  }),
+};
+
+export const SEED_DATA = [
+  {
+    name: "Swipeable View",
+    tag: "SwipeableView",
+    doc_link:
+      "https://github.com/jemise111/react-native-swipe-list-view/blob/master/docs/SwipeRow.md",
+    description:
+      "A swipeable view that is able to show hidden buttons and/or handle swipe events",
+    category: COMPONENT_TYPES.view,
+    stylesPanelSections: [
+      ...CONTAINER_COMPONENT_STYLES_SECTIONS,
+      StylesPanelSections.Typography,
+    ],
+    layout: {
+      overflow: "hidden",
+      flexDirection: "row",
+      alignItems: "center",
+      padding: 10,
+    },
+    props: {
+      closeOnPress: createStaticBoolProp({
+        label: "Close on press",
+        description: "Whether the view should be closed/dismissed when pressed",
+        defaultValue: true,
+      }),
+      swipeActivationPercentage: createStaticNumberProp({
+        label: "Swipe activation percentage",
+        description:
+          "Percentage of swipe completion needed to trigger onSwipe. Overriden by 'Left activation value' and 'Right activation value'",
+        defaultValue: 80,
+        required: false,
+      }),
+      disableLeftSwipe: createBoolProp({
+        label: "Disable left swipe",
+        description: "Whether left swipe is enabled or not",
+        defaultValue: true,
+      }),
+      disableRightSwipe: createBoolProp({
+        label: "Disable right swipe",
+        description: "Whether right swipe is enabled or not",
+        defaultValue: true,
+      }),
+      leftOpenValue: createStaticNumberProp({
+        label: "Left open value",
+        description:
+          "The X translation value that left swipe snaps to (positive value). Defaults to half view width",
+        group: GROUPS.advanced,
+        required: false,
+      }),
+      rightOpenValue: createStaticNumberProp({
+        label: "Right open value",
+        description:
+          "The X translation value that right swipe snaps to (negative value). Defaults to negative half view width",
+        group: GROUPS.advanced,
+        required: false,
+      }),
+      leftActivationValue: createStaticNumberProp({
+        label: "Left activation value",
+        description:
+          "The X translation value that triggers onSwipe when surpassed (positive value). Defaults to 80% of half view width",
+        group: GROUPS.advanced,
+        required: false,
+      }),
+      rightActivationValue: createStaticNumberProp({
+        label: "Right activation value",
+        description:
+          "The X translation value that triggers onSwipe when surpassed (negative value). Defaults to negative 80% of half view width",
+        group: GROUPS.advanced,
+        required: false,
+      }),
+      stopLeftSwipe: createStaticNumberProp({
+        label: "Stop left swipe",
+        description:
+          "The maximum X translation value that is swipable from left (positive value). Defaults to half view width",
+        group: GROUPS.advanced,
+        required: false,
+      }),
+      stopRightSwipe: createStaticNumberProp({
+        label: "Stop right swipe",
+        description:
+          "The maximum X translation value that is swipable from right (negative value). Defaults to negative half view width",
+        group: GROUPS.advanced,
+        required: false,
+      }),
+      directionalDistanceChangeThreshold: createStaticNumberProp({
+        label: "Change threshold",
+        description: "Change the sensitivity of the swipe on the view",
+        group: GROUPS.advanced,
+        required: false,
+      }),
+      friction: createStaticNumberProp({
+        label: "Friction",
+        description: "Controls the 'bounciness' of the swipe animation",
+        defaultValue: 20,
+        group: GROUPS.advanced,
+        required: false,
+      }),
+      tension: createStaticNumberProp({
+        label: "Change threshold",
+        description: "Controls the tension/speed of the swipe animation",
+        group: GROUPS.advanced,
+        required: false,
+      }),
+      swipeToOpenVelocityContribution: createStaticNumberProp({
+        label: "Swipe Velocity Contribution",
+        description:
+          "Describes how much the ending velocity of the gesture affects whether the swipe will result in the item being closed or open. A velocity factor of 0 (the default) means that the velocity will have no bearing on whether the swipe settles on a closed or open position and it'll just take into consideration the swipeToOpenPercent. Ideal values for this prop tend to be between 5 and 15",
+        group: GROUPS.advanced,
+        required: false,
+      }),
+      swipeToOpenPercent: createStaticNumberProp({
+        label: "Swipe to open percentage",
+        description:
+          "What % of the left/right does the user need to swipe past to trigger the view opening",
+        group: GROUPS.advanced,
+        defaultValue: 50,
+        required: false,
+      }),
+      swipeToClosePercent: createStaticNumberProp({
+        label: "Swipe to close percentage",
+        description:
+          "What % of the left/right does the user need to swipe past to trigger the view closing",
+        group: GROUPS.advanced,
+        defaultValue: 50,
+        required: false,
+      }),
+    },
+  },
+  {
+    name: "Swipeable View Button",
+    tag: "SwipeableViewButton",
+    description: "Button to be rendered under a Swipeable View",
+    category: COMPONENT_TYPES.view,
+    stylesPanelSections: [],
+    triggers: [Triggers.OnPress],
+    props: {
+      ...SHARED_SWIPEABLE_CHILDREN_PROPS,
+      onPress: createActionProp(),
+    },
+  },
+  {
+    name: "Swipeable View Swipe Handler",
+    tag: "SwipeableViewButton",
+    description: "Component that renders and handles swipe of Swipeable View",
+    category: COMPONENT_TYPES.view,
+    stylesPanelSections: [],
+    triggers: [Triggers.OnSwipe],
+    props: {
+      ...SHARED_SWIPEABLE_CHILDREN_PROPS,
+      onSwipe: createActionProp({
+        label: "On swipe",
+        description:
+          "Called when Swipeable View swiped in the direction this is configured to",
+      }),
+    },
+  },
+];

--- a/packages/core/src/utilities.ts
+++ b/packages/core/src/utilities.ts
@@ -169,6 +169,25 @@ export function extractEffectStyles(
   return effectStyles;
 }
 
+export const sizeStyleNames = ["width", "height"];
+
+export function extractSizeStyles(
+  style: StyleProp<any>,
+  additionalSizeStyles?: string[]
+) {
+  const flatStyle = StyleSheet.flatten(style || {});
+
+  const sizeStyles = pickBy(
+    pick(flatStyle, [
+      ...sizeStyleNames,
+      ...(additionalSizeStyles ? additionalSizeStyles : []),
+    ]),
+    identity
+  );
+
+  return sizeStyles;
+}
+
 /**
  * Merges a style object on top of another style object. In React Native,
  * keys with undefined values in a style object will still override styles

--- a/packages/core/src/utilities.ts
+++ b/packages/core/src/utilities.ts
@@ -98,6 +98,77 @@ export function extractBorderAndMarginStyles(
   return { borderStyles, marginStyles };
 }
 
+export const flexItemStyleNames = [
+  "alignSelf",
+  "flexBasis",
+  "flexShrink",
+  "flexGrow",
+  "flex",
+];
+
+export function extractFlexItemStyles(
+  style: StyleProp<any>,
+  additionalFlexItemStyles?: string[]
+) {
+  const flatStyle = StyleSheet.flatten(style || {});
+
+  const flexItemStyles = pickBy(
+    pick(flatStyle, [
+      ...flexItemStyleNames,
+      ...(additionalFlexItemStyles ? additionalFlexItemStyles : []),
+    ]),
+    identity
+  );
+
+  return flexItemStyles;
+}
+
+export const positionStyleNames = [
+  "position",
+  "left",
+  "right",
+  "top",
+  "bottom",
+  "zIndex",
+  "overflow",
+];
+
+export function extractPositionStyles(
+  style: StyleProp<any>,
+  additionalPositionStyles?: string[]
+) {
+  const flatStyle = StyleSheet.flatten(style || {});
+
+  const positionStyles = pickBy(
+    pick(flatStyle, [
+      ...positionStyleNames,
+      ...(additionalPositionStyles ? additionalPositionStyles : []),
+    ]),
+    identity
+  );
+
+  return positionStyles;
+}
+
+export const effectsStyleNames = ["opacity", "elevation"];
+
+export function extractEffectStyles(
+  style: StyleProp<any>,
+  additionalEffectStyles?: string[]
+) {
+  const flatStyle = StyleSheet.flatten(style || {});
+
+  const effectStyles = pickBy(
+    pick(flatStyle, [
+      ...effectsStyleNames,
+      ...(additionalEffectStyles ? additionalEffectStyles : []),
+    ]),
+    identity
+  );
+
+  return effectStyles;
+}
+
 /**
  * Merges a style object on top of another style object. In React Native,
  * keys with undefined values in a style object will still override styles

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -38,6 +38,8 @@ export {
   Table,
   TableRow,
   TableCell,
+  SwipeableViewButton,
+  SwipeableViewSwipeHandler,
   /* Deprecated, needs fixing */
   ProgressBar,
   ProgressCircle,
@@ -84,6 +86,7 @@ import {
   AccordionGroup as BaseAccordionGroup,
   AccordionItem as BaseAccordionItem,
   TabView as BaseTabView,
+  SwipeableView as BaseSwipeableView,
 } from "@draftbit/core";
 
 export const AvatarEdit = injectIcon(BaseAvatarEdit, Icon);
@@ -112,3 +115,4 @@ export const Slider = injectIcon(BaseSlider, Icon);
 export const AccordionGroup = injectIcon(BaseAccordionGroup, Icon);
 export const AccordionItem = injectIcon(BaseAccordionItem, Icon);
 export const TabView = injectIcon(BaseTabView, Icon);
+export const SwipeableView = injectIcon(BaseSwipeableView, Icon);

--- a/yarn.lock
+++ b/yarn.lock
@@ -14142,6 +14142,11 @@ react-native-svg@12.3.0:
     css-select "^4.2.1"
     css-tree "^1.0.0-alpha.39"
 
+react-native-swipe-list-view@^3.2.9:
+  version "3.2.9"
+  resolved "https://registry.yarnpkg.com/react-native-swipe-list-view/-/react-native-swipe-list-view-3.2.9.tgz#d725c7cdf481dd5df12a00dbfe0120013b5f2e59"
+  integrity sha512-SjAEuHc/D6ovp+RjDUhfNmw6NYOntdT7+GFhfMGfP/BSLMuMWynpzJy9GKQeyB8sI78T6Lzip21TVbongOg1Mw==
+
 react-native-tab-view@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/react-native-tab-view/-/react-native-tab-view-3.4.0.tgz#12b2754333643b4527a1fd2da1451895f76b9587"


### PR DESCRIPTION
- Uses https://www.npmjs.com/package/react-native-swipe-list-view
- Adds 3 components `SwipeableView`, `SwipeableViewButton`, and `SwipeableViewSwipeHandler`  
  - Initial proposed approach of a single component and props did not work. Would needs duplication of each prop 4 times `leftTitle1`, `leftTitle2`, `leftIcon1`, `rightTitle1` etc. My new approach makes more sense imo
- Now you add a single `SwipeableView` and then include 2 buttons per side or a swipe handler (or both, either buttons or swipe per side though)
- Any children that are neither button or handler are rendered in the top container as normal children