### PR TITLE
Minor DeckSwiper and Shadow fixes

### DIFF
--- a/packages/core/src/components/DeckSwiper/DeckSwiper.tsx
+++ b/packages/core/src/components/DeckSwiper/DeckSwiper.tsx
@@ -120,6 +120,7 @@ const DeckSwiper = <T extends object>({
 const styles = StyleSheet.create({
   cardsContainer: {
     flex: 1,
+    position: "absolute",
   },
   card: {
     left: 0,

--- a/packages/core/src/components/DeckSwiper/DeckSwiper.tsx
+++ b/packages/core/src/components/DeckSwiper/DeckSwiper.tsx
@@ -83,6 +83,7 @@ const DeckSwiper = <T extends object>({
    * By default react-native-deck-swiper positions everything with absolute position.
    * To overcome this, it is wrapped in a View to be able to add the component in any layout structure.
    *
+   *
    * Since all children of that View are absolutley positioned, the View does not have a height and still looks and behaves weird.
    * To fix/mitage this without setting a static height, the first card is rendered in invisible state to take up space.
    * This effectivley makes the default height of the container be the height of the first card.

--- a/packages/core/src/components/DeckSwiper/DeckSwiper.tsx
+++ b/packages/core/src/components/DeckSwiper/DeckSwiper.tsx
@@ -120,7 +120,6 @@ const DeckSwiper = <T extends object>({
 
 const styles = StyleSheet.create({
   cardsContainer: {
-    flex: 1,
     position: "absolute",
   },
   card: {

--- a/packages/core/src/components/DeckSwiper/DeckSwiper.tsx
+++ b/packages/core/src/components/DeckSwiper/DeckSwiper.tsx
@@ -43,9 +43,6 @@ const DeckSwiper = <T extends object>({
     );
   }
 
-  const [isRenderingCardFillerHeight, setIsRenderingCardFillerHeight] =
-    React.useState<boolean>(false);
-
   const childrenArray = React.useMemo(
     () => React.Children.toArray(children),
     [children]
@@ -91,26 +88,9 @@ const DeckSwiper = <T extends object>({
    * This effectivley makes the default height of the container be the height of the first card.
    */
 
-  /**
-   * isRenderingCardFillerHeight:
-   * Only render first card filler when component height is 0.
-   * Draftbit draft view already fills height appropriatley and does not need to render first card to compensate
-   * This check prevents double height and only fills height when it needs to
-   */
-
   return (
-    <View
-      onLayout={(event) => {
-        const height = event.nativeEvent.layout.height;
-        if (height === 0 && !isRenderingCardFillerHeight) {
-          setIsRenderingCardFillerHeight(true);
-        }
-      }}
-    >
-      {isRenderingCardFillerHeight ? (
-        <View style={styles.containerHeightFiller}>{renderFirstCard()}</View>
-      ) : undefined}
-
+    <View>
+      <View style={styles.containerHeightFiller}>{renderFirstCard()}</View>
       <DeckSwiperComponent
         cards={cardsData as any[]}
         renderCard={renderCard}

--- a/packages/core/src/components/DeckSwiper/DeckSwiper.tsx
+++ b/packages/core/src/components/DeckSwiper/DeckSwiper.tsx
@@ -86,7 +86,6 @@ const DeckSwiper = <T extends object>({
    * By default react-native-deck-swiper positions everything with absolute position.
    * To overcome this, it is wrapped in a View to be able to add the component in any layout structure.
    *
-   *
    * Since all children of that View are absolutley positioned, the View does not have a height and still looks and behaves weird.
    * To fix/mitage this without setting a static height, the first card is rendered in invisible state to take up space.
    * This effectivley makes the default height of the container be the height of the first card.

--- a/packages/core/src/components/DeckSwiper/DeckSwiper.tsx
+++ b/packages/core/src/components/DeckSwiper/DeckSwiper.tsx
@@ -43,6 +43,9 @@ const DeckSwiper = <T extends object>({
     );
   }
 
+  const [isRenderingCardFillerHeight, setIsRenderingCardFillerHeight] =
+    React.useState<boolean>(false);
+
   const childrenArray = React.useMemo(
     () => React.Children.toArray(children),
     [children]
@@ -89,9 +92,26 @@ const DeckSwiper = <T extends object>({
    * This effectivley makes the default height of the container be the height of the first card.
    */
 
+  /**
+   * isRenderingCardFillerHeight:
+   * Only render first card filler when component height is 0.
+   * Draftbit draft view already fills height appropriatley and does not need to render first card to compensate
+   * This check prevents double height and only fills height when it needs to
+   */
+
   return (
-    <View>
-      <View style={styles.containerHeightFiller}>{renderFirstCard()}</View>
+    <View
+      onLayout={(event) => {
+        const height = event.nativeEvent.layout.height;
+        if (height === 0 && !isRenderingCardFillerHeight) {
+          setIsRenderingCardFillerHeight(true);
+        }
+      }}
+    >
+      {isRenderingCardFillerHeight ? (
+        <View style={styles.containerHeightFiller}>{renderFirstCard()}</View>
+      ) : undefined}
+
       <DeckSwiperComponent
         cards={cardsData as any[]}
         renderCard={renderCard}

--- a/packages/core/src/components/DeckSwiper/DeckSwiper.tsx
+++ b/packages/core/src/components/DeckSwiper/DeckSwiper.tsx
@@ -120,7 +120,7 @@ const DeckSwiper = <T extends object>({
 
 const styles = StyleSheet.create({
   cardsContainer: {
-    width: "100%",
+    flex: 1,
   },
   card: {
     left: 0,

--- a/packages/core/src/components/DeckSwiper/DeckSwiperCard.tsx
+++ b/packages/core/src/components/DeckSwiper/DeckSwiperCard.tsx
@@ -27,7 +27,6 @@ const DeckSwiperCard: React.FC<
 
 const styles = StyleSheet.create({
   card: {
-    flex: 1,
     alignItems: "center",
     justifyContent: "center",
     padding: 20,

--- a/packages/core/src/components/Shadow.tsx
+++ b/packages/core/src/components/Shadow.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { StyleProp, ViewStyle, StyleSheet } from "react-native";
 import { Shadow as ShadowComponent } from "react-native-shadow-2";
-import { extractBorderAndMarginStyles } from "../utilities";
+import { extractBorderAndMarginStyles, extractSizeStyles } from "../utilities";
 
 interface ShadowProps {
   disabled?: boolean;
@@ -40,8 +40,13 @@ const Shadow: React.FC<React.PropsWithChildren<ShadowProps>> = ({
 }) => {
   const { borderStyles } = extractBorderAndMarginStyles(style);
 
+  const shadowStyles = StyleSheet.flatten([
+    borderStyles,
+    extractSizeStyles(style),
+  ]);
+
   const containerStyle = StyleSheet.flatten(style) as StyleProp<any>;
-  Object.keys(borderStyles).forEach((key) => delete containerStyle[key]);
+  Object.keys(shadowStyles).forEach((key) => delete containerStyle[key]);
 
   return (
     <ShadowComponent
@@ -58,7 +63,7 @@ const Shadow: React.FC<React.PropsWithChildren<ShadowProps>> = ({
         bottomStart: showShadowCornerBottomStart,
         bottomEnd: showShadowCornerBottomEnd,
       }}
-      style={borderStyles}
+      style={shadowStyles}
       containerStyle={containerStyle}
       paintInside={paintInside}
       {...rest}

--- a/packages/core/src/components/Shadow.tsx
+++ b/packages/core/src/components/Shadow.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { StyleProp, ViewStyle } from "react-native";
+import { StyleProp, ViewStyle, StyleSheet } from "react-native";
 import { Shadow as ShadowComponent } from "react-native-shadow-2";
+import { extractBorderAndMarginStyles } from "../utilities";
 
 interface ShadowProps {
   disabled?: boolean;
@@ -33,10 +34,15 @@ const Shadow: React.FC<React.PropsWithChildren<ShadowProps>> = ({
   showShadowCornerTopEnd = true,
   showShadowCornerBottomStart = true,
   showShadowCornerBottomEnd = true,
-  paintInside = false,
+  paintInside = true,
   style,
   ...rest
 }) => {
+  const { borderStyles } = extractBorderAndMarginStyles(style);
+
+  const containerStyle = StyleSheet.flatten(style) as StyleProp<any>;
+  Object.keys(borderStyles).forEach((key) => delete containerStyle[key]);
+
   return (
     <ShadowComponent
       offset={[offsetX, offsetY]}
@@ -52,7 +58,8 @@ const Shadow: React.FC<React.PropsWithChildren<ShadowProps>> = ({
         bottomStart: showShadowCornerBottomStart,
         bottomEnd: showShadowCornerBottomEnd,
       }}
-      containerStyle={style}
+      style={borderStyles}
+      containerStyle={containerStyle}
       paintInside={paintInside}
       {...rest}
     />

--- a/packages/core/src/mappings/DeckSwiper.ts
+++ b/packages/core/src/mappings/DeckSwiper.ts
@@ -14,7 +14,6 @@ export const SEED_DATA = {
   category: COMPONENT_TYPES.swiper,
   stylesPanelSections: [
     StylesPanelSections.Size,
-    StylesPanelSections.LayoutSelectedItem,
     StylesPanelSections.Margins,
     StylesPanelSections.Effects,
   ],

--- a/packages/core/src/mappings/DeckSwiper.ts
+++ b/packages/core/src/mappings/DeckSwiper.ts
@@ -4,7 +4,7 @@ import {
   createActionProp,
   createStaticNumberProp,
   createStaticBoolProp,
-  BLOCK_STYLES_SECTIONS,
+  StylesPanelSections,
 } from "@draftbit/types";
 
 export const SEED_DATA = {
@@ -12,9 +12,13 @@ export const SEED_DATA = {
   tag: "DeckSwiper",
   description: "Deck swiper container",
   category: COMPONENT_TYPES.swiper,
-  stylesPanelSections: BLOCK_STYLES_SECTIONS,
+  stylesPanelSections: [
+    StylesPanelSections.Size,
+    StylesPanelSections.Margins,
+    StylesPanelSections.Effects,
+  ],
   layout: {
-    width: "100%",
+    flex: 1,
   },
   triggers: [Triggers.OnIndexChanged, Triggers.OnEndReached],
   props: {

--- a/packages/core/src/mappings/DeckSwiper.ts
+++ b/packages/core/src/mappings/DeckSwiper.ts
@@ -14,6 +14,7 @@ export const SEED_DATA = {
   category: COMPONENT_TYPES.swiper,
   stylesPanelSections: [
     StylesPanelSections.Size,
+    StylesPanelSections.LayoutSelectedItem,
     StylesPanelSections.Margins,
     StylesPanelSections.Effects,
   ],

--- a/packages/core/src/mappings/DeckSwiper.ts
+++ b/packages/core/src/mappings/DeckSwiper.ts
@@ -19,6 +19,7 @@ export const SEED_DATA = {
   ],
   layout: {
     flex: 1,
+    position: "absolute",
   },
   triggers: [Triggers.OnIndexChanged, Triggers.OnEndReached],
   props: {

--- a/packages/core/src/mappings/DeckSwiper.ts
+++ b/packages/core/src/mappings/DeckSwiper.ts
@@ -18,7 +18,6 @@ export const SEED_DATA = {
     StylesPanelSections.Effects,
   ],
   layout: {
-    flex: 1,
     position: "absolute",
   },
   triggers: [Triggers.OnIndexChanged, Triggers.OnEndReached],

--- a/packages/core/src/mappings/DeckSwiperCard.ts
+++ b/packages/core/src/mappings/DeckSwiperCard.ts
@@ -1,16 +1,20 @@
-import {
-  COMPONENT_TYPES,
-  CONTAINER_COMPONENT_STYLES_SECTIONS,
-} from "@draftbit/types";
+import { COMPONENT_TYPES, StylesPanelSections } from "@draftbit/types";
 
 export const SEED_DATA = {
   name: "Deck Swiper Card",
   tag: "DeckSwiperCard",
   description: "Single Deck Swiper Card item to be used in DeckSwiper",
   category: COMPONENT_TYPES.swiper,
-  stylesPanelSections: CONTAINER_COMPONENT_STYLES_SECTIONS,
+  stylesPanelSections: [
+    StylesPanelSections.LayoutFlexItems,
+    StylesPanelSections.LayoutContent,
+    StylesPanelSections.Background,
+    StylesPanelSections.Size,
+    StylesPanelSections.MarginsAndPaddings,
+    StylesPanelSections.Borders,
+    StylesPanelSections.Effects,
+  ],
   layout: {
-    flex: 1,
     alignItems: "center",
     justifyContent: "center",
     padding: 20,

--- a/packages/core/src/mappings/Shadow.ts
+++ b/packages/core/src/mappings/Shadow.ts
@@ -1,11 +1,11 @@
 import {
   COMPONENT_TYPES,
-  CONTAINER_COMPONENT_STYLES_SECTIONS,
   createColorProp,
   createStaticNumberProp,
   createStaticBoolProp,
   createDisabledProp,
   GROUPS,
+  StylesPanelSections,
 } from "@draftbit/types";
 
 export const SEED_DATA = {
@@ -13,7 +13,14 @@ export const SEED_DATA = {
   tag: "Shadow",
   description: "A cross-platform, universal shadow.",
   category: COMPONENT_TYPES.view,
-  stylesPanelSections: CONTAINER_COMPONENT_STYLES_SECTIONS,
+  stylesPanelSections: [
+    StylesPanelSections.LayoutSelectedItem,
+    StylesPanelSections.Size,
+    StylesPanelSections.Margins,
+    StylesPanelSections.Position,
+    StylesPanelSections.Borders,
+    StylesPanelSections.Effects,
+  ],
   props: {
     disabled: createDisabledProp({
       description: "Disables the shadow.",
@@ -35,7 +42,7 @@ export const SEED_DATA = {
     paintInside: createStaticBoolProp({
       label: "Paint Inside",
       description: "Apply the shadow below/inside the content.",
-      defaultValue: false,
+      defaultValue: true,
     }),
     stretch: createStaticBoolProp({
       label: "Stretch",

--- a/packages/core/src/mappings/Shadow.ts
+++ b/packages/core/src/mappings/Shadow.ts
@@ -14,7 +14,6 @@ export const SEED_DATA = {
   description: "A cross-platform, universal shadow.",
   category: COMPONENT_TYPES.view,
   stylesPanelSections: [
-    StylesPanelSections.LayoutSelectedItem,
     StylesPanelSections.Size,
     StylesPanelSections.Margins,
     StylesPanelSections.Position,

--- a/packages/core/src/utilities.ts
+++ b/packages/core/src/utilities.ts
@@ -98,6 +98,25 @@ export function extractBorderAndMarginStyles(
   return { borderStyles, marginStyles };
 }
 
+export const sizeStyleNames = ["width", "height"];
+
+export function extractSizeStyles(
+  style: StyleProp<any>,
+  additionalSizeStyles?: string[]
+) {
+  const flatStyle = StyleSheet.flatten(style || {});
+
+  const sizeStyles = pickBy(
+    pick(flatStyle, [
+      ...sizeStyleNames,
+      ...(additionalSizeStyles ? additionalSizeStyles : []),
+    ]),
+    identity
+  );
+
+  return sizeStyles;
+}
+
 /**
  * Merges a style object on top of another style object. In React Native,
  * keys with undefined values in a style object will still override styles


### PR DESCRIPTION
Straightforward fixes that address reported issues

Closes https://linear.app/draftbit/issue/P-3411/shadow-offset-props-dont-work-as-expected
Closes https://linear.app/draftbit/issue/P-3410/deckswiper-renders-off-the-screen-on-ios-and-android
Closes https://linear.app/draftbit/issue/P-3408/deckswiper-appears-outside-view-its-nested-inside-on-draft-view