### PR TITLE
Fix to pin image handling of maps (+ 46.11.4 update)

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@draftbit/example",
   "description": "Example app for @draftbit/ui",
-  "version": "46.11.3",
+  "version": "46.11.4",
   "private": true,
   "main": "__generated__/AppEntry.js",
   "scripts": {
@@ -15,8 +15,8 @@
     "clean:modules": "rimraf node_modules"
   },
   "dependencies": {
-    "@draftbit/maps": "46.11.3",
-    "@draftbit/ui": "46.11.3",
+    "@draftbit/maps": "46.11.4",
+    "@draftbit/ui": "46.11.4",
     "@expo/dev-server": "0.1.120",
     "@expo/webpack-config": "^0.17.0",
     "@react-navigation/drawer": "^5.7.7",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "46.11.3",
+  "version": "46.11.4",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "packages": ["packages/*", "example"],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draftbit/core",
-  "version": "46.11.3",
+  "version": "46.11.4",
   "description": "Core (non-native) Components",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
@@ -41,7 +41,7 @@
   "dependencies": {
     "@date-io/date-fns": "^1.3.13",
     "@draftbit/react-theme-provider": "^2.1.1",
-    "@draftbit/types": "46.11.3",
+    "@draftbit/types": "46.11.4",
     "@material-ui/core": "^4.11.0",
     "@material-ui/pickers": "^3.2.10",
     "@react-native-community/slider": "4.2.3",

--- a/packages/core/src/mappings/MapMarker.ts
+++ b/packages/core/src/mappings/MapMarker.ts
@@ -64,7 +64,7 @@ export const SEED_DATA = {
       label: "Pin Color",
       description: "Sets the color of the marker",
     }),
-    pinImageUrl: createImageProp({
+    pinImage: createImageProp({
       label: "Pin image",
       description: "Image to be used instead of the default pin",
       editable: true,

--- a/packages/maps/package.json
+++ b/packages/maps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draftbit/maps",
-  "version": "46.11.3",
+  "version": "46.11.4",
   "description": "Map Components",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
@@ -39,8 +39,8 @@
   },
   "homepage": "https://github.com/draftbit/react-native-jigsaw#readme",
   "dependencies": {
-    "@draftbit/types": "46.11.3",
-    "@draftbit/web-maps": "46.11.3",
+    "@draftbit/types": "46.11.4",
+    "@draftbit/web-maps": "46.11.4",
     "react-native-maps": "0.31.1"
   },
   "react-native-builder-bob": {

--- a/packages/maps/src/components/MapMarker.tsx
+++ b/packages/maps/src/components/MapMarker.tsx
@@ -9,7 +9,7 @@ const MapMarker: React.FC<React.PropsWithChildren<MapMarkerProps>> = ({
   title,
   description,
   pinColor,
-  pinImageUrl,
+  pinImage,
   pinImageSize = 50,
   onPress,
   flat,
@@ -33,9 +33,9 @@ const MapMarker: React.FC<React.PropsWithChildren<MapMarkerProps>> = ({
       onPress={onPress}
       style={style}
     >
-      {pinImageUrl && (
+      {pinImage && (
         <Image
-          source={{ uri: pinImageUrl }}
+          source={typeof pinImage === "string" ? { uri: pinImage } : pinImage}
           style={{
             height: pinImageSize,
             width: pinImageSize,

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draftbit/native",
-  "version": "46.11.3",
+  "version": "46.11.4",
   "description": "Draftbit UI Components that Depend on Native Components",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/draftbit/react-native-jigsaw#readme",
   "dependencies": {
-    "@draftbit/types": "46.11.3",
+    "@draftbit/types": "46.11.4",
     "@expo/vector-icons": "^13.0.0",
     "@react-native-community/datetimepicker": "6.2.0",
     "@react-native-community/slider": "4.2.3",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draftbit/types",
-  "version": "46.11.3",
+  "version": "46.11.4",
   "description": "Shared constants and types between native and core components",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/packages/types/src/mapTypes.tsx
+++ b/packages/types/src/mapTypes.tsx
@@ -1,4 +1,4 @@
-import { StyleProp, ViewStyle } from "react-native";
+import { StyleProp, ViewStyle, ImageSourcePropType } from "react-native";
 
 type MapTypes =
   | "standard"
@@ -14,7 +14,7 @@ export interface MapMarkerProps {
   title?: string;
   description?: string;
   pinColor?: string;
-  pinImageUrl?: string;
+  pinImage?: string | ImageSourcePropType;
   pinImageSize?: number;
   onPress?: () => void;
   flat?: boolean;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draftbit/ui",
-  "version": "46.11.3",
+  "version": "46.11.4",
   "description": "Draftbit UI Library",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
@@ -43,8 +43,8 @@
   },
   "homepage": "https://github.com/draftbit/react-native-jigsaw#readme",
   "dependencies": {
-    "@draftbit/core": "46.11.3",
-    "@draftbit/native": "46.11.3"
+    "@draftbit/core": "46.11.4",
+    "@draftbit/native": "46.11.4"
   },
   "react-native-builder-bob": {
     "source": "src",

--- a/packages/web-maps/package.json
+++ b/packages/web-maps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draftbit/web-maps",
-  "version": "46.11.3",
+  "version": "46.11.4",
   "description": "Web Map Components",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/draftbit/react-native-jigsaw#readme",
   "dependencies": {
-    "@draftbit/types": "46.11.3",
+    "@draftbit/types": "46.11.4",
     "@react-google-maps/api": "^2.10.2"
   },
   "react-native-builder-bob": {

--- a/packages/web-maps/src/components/MapMarker.tsx
+++ b/packages/web-maps/src/components/MapMarker.tsx
@@ -24,7 +24,7 @@ export const markerContext = React.createContext<IMarkerContext>({
 });
 
 const MapMarker: React.FC<React.PropsWithChildren<MapMarkerProps>> = ({
-  pinImageUrl,
+  pinImage,
   pinImageSize = 50,
   onPress,
   pinColor,
@@ -90,9 +90,10 @@ const MapMarker: React.FC<React.PropsWithChildren<MapMarkerProps>> = ({
         }}
         onLoad={handleOnLoad}
         icon={
-          pinImageUrl
+          pinImage
             ? {
-                url: pinImageUrl,
+                url:
+                  typeof pinImage === "string" ? pinImage : { uri: pinImage },
                 scaledSize: new google.maps.Size(pinImageSize, pinImageSize),
               }
             : undefined


### PR DESCRIPTION
- Support non-url images for pin images since exported draftbit code bundles images in the app
- Update version to 46.11.4