### PR TITLE
Fix `FlatList` not working because of the forced `flex` style attribute

### DIFF
--- a/packages/core/src/mappings/FlatList.ts
+++ b/packages/core/src/mappings/FlatList.ts
@@ -15,9 +15,6 @@ export const SEED_DATA = {
   description: "A basic List component",
   category: COMPONENT_TYPES.data,
   stylesPanelSections: CONTAINER_COMPONENT_STYLES_SECTIONS,
-  layout: {
-    flex: 1,
-  },
   triggers: [Triggers.OnRefresh, Triggers.OnEndReached],
   props: {
     onRefresh: createActionProp(),


### PR DESCRIPTION
Some testing in Snack showed that the `FlatList` component was not properly working, the main reason being that the `flex` style attribute was forced to `1` in the `FlatList` component.  For whatever reason, when this settings is set, either the Webpreview fail to render the FLatlist, or the Appetize preview do.