### PR TITLE
Removed default styling of SwipeableView (v46.12.3)

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@draftbit/example",
   "description": "Example app for @draftbit/ui",
-  "version": "46.12.2",
+  "version": "46.12.3",
   "private": true,
   "main": "__generated__/AppEntry.js",
   "scripts": {
@@ -15,8 +15,8 @@
     "clean:modules": "rimraf node_modules"
   },
   "dependencies": {
-    "@draftbit/maps": "46.12.2",
-    "@draftbit/ui": "46.12.2",
+    "@draftbit/maps": "46.12.3",
+    "@draftbit/ui": "46.12.3",
     "@expo/dev-server": "0.1.120",
     "@expo/webpack-config": "^0.17.0",
     "@react-navigation/drawer": "^5.7.7",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "46.12.2",
+  "version": "46.12.3",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "packages": ["packages/*", "example"],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draftbit/core",
-  "version": "46.12.2",
+  "version": "46.12.3",
   "description": "Core (non-native) Components",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
@@ -41,7 +41,7 @@
   "dependencies": {
     "@date-io/date-fns": "^1.3.13",
     "@draftbit/react-theme-provider": "^2.1.1",
-    "@draftbit/types": "46.12.2",
+    "@draftbit/types": "46.12.3",
     "@material-ui/core": "^4.11.0",
     "@material-ui/pickers": "^3.2.10",
     "@react-native-community/slider": "4.2.3",

--- a/packages/core/src/components/ScreenContainer.tsx
+++ b/packages/core/src/components/ScreenContainer.tsx
@@ -12,10 +12,10 @@ import { withTheme } from "../theming";
 import type { Theme } from "../styles/DefaultTheme";
 
 type ScreenContainerProps = {
-  scrollable: boolean;
-  hasSafeArea: boolean;
-  hasTopSafeArea: boolean;
-  hasBottomSafeArea: boolean;
+  scrollable?: boolean;
+  hasSafeArea?: boolean;
+  hasTopSafeArea?: boolean;
+  hasBottomSafeArea?: boolean;
   theme: Theme;
   style?: StyleProp<ViewStyle>;
   children?: React.ReactNode;

--- a/packages/core/src/components/SwipeableView/SwipeableView.tsx
+++ b/packages/core/src/components/SwipeableView/SwipeableView.tsx
@@ -292,11 +292,8 @@ const styles = StyleSheet.create({
     justifyContent: "center",
   },
   surfaceContainer: {
-    flexDirection: "row",
     width: "100%",
     minHeight: 50,
-    padding: 10,
-    alignItems: "center",
     overflow: "hidden",
   },
 });

--- a/packages/maps/package.json
+++ b/packages/maps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draftbit/maps",
-  "version": "46.12.2",
+  "version": "46.12.3",
   "description": "Map Components",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
@@ -39,8 +39,8 @@
   },
   "homepage": "https://github.com/draftbit/react-native-jigsaw#readme",
   "dependencies": {
-    "@draftbit/types": "46.12.2",
-    "@draftbit/web-maps": "46.12.2",
+    "@draftbit/types": "46.12.3",
+    "@draftbit/web-maps": "46.12.3",
     "react-native-maps": "0.31.1"
   },
   "react-native-builder-bob": {

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draftbit/native",
-  "version": "46.12.2",
+  "version": "46.12.3",
   "description": "Draftbit UI Components that Depend on Native Components",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/draftbit/react-native-jigsaw#readme",
   "dependencies": {
-    "@draftbit/types": "46.12.2",
+    "@draftbit/types": "46.12.3",
     "@expo/vector-icons": "^13.0.0",
     "@react-native-community/datetimepicker": "6.2.0",
     "@react-native-community/slider": "4.2.3",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draftbit/types",
-  "version": "46.12.2",
+  "version": "46.12.3",
   "description": "Shared constants and types between native and core components",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draftbit/ui",
-  "version": "46.12.2",
+  "version": "46.12.3",
   "description": "Draftbit UI Library",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
@@ -43,8 +43,8 @@
   },
   "homepage": "https://github.com/draftbit/react-native-jigsaw#readme",
   "dependencies": {
-    "@draftbit/core": "46.12.2",
-    "@draftbit/native": "46.12.2"
+    "@draftbit/core": "46.12.3",
+    "@draftbit/native": "46.12.3"
   },
   "react-native-builder-bob": {
     "source": "src",

--- a/packages/web-maps/package.json
+++ b/packages/web-maps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draftbit/web-maps",
-  "version": "46.12.2",
+  "version": "46.12.3",
   "description": "Web Map Components",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/draftbit/react-native-jigsaw#readme",
   "dependencies": {
-    "@draftbit/types": "46.12.2",
+    "@draftbit/types": "46.12.3",
     "@react-google-maps/api": "^2.10.2"
   },
   "react-native-builder-bob": {


### PR DESCRIPTION
- Updated to 46.12.3
- Removed default styles of SwipeableView
- Made ScreenContainer props optional to prevent type errors in App.tsx