### PR TITLE
Update disableXSwipe prop to be consistent with swipe directions (46)

### DIFF
--- a/packages/core/src/components/SwipeableItem/SwipeableItem.tsx
+++ b/packages/core/src/components/SwipeableItem/SwipeableItem.tsx
@@ -83,6 +83,8 @@ const SwipeableItem: React.FC<React.PropsWithChildren<Props>> = ({
   stopLeftSwipe,
   stopRightSwipe,
   friction = 20,
+  disableLeftSwipe,
+  disableRightSwipe,
   ...rest
 }) => {
   const instanceOfSwipeableItemButtonProps = (
@@ -242,6 +244,8 @@ const SwipeableItem: React.FC<React.PropsWithChildren<Props>> = ({
         swipeGestureEnded={onStopSwiping}
         closeOnRowPress={closeOnPress}
         friction={friction}
+        disableLeftSwipe={disableRightSwipe}
+        disableRightSwipe={disableLeftSwipe}
         {...rest}
       >
         <View style={styles.behindContainer}>


### PR DESCRIPTION
- `disableLeftSwipe` refers to swipe from right -> left and not the other way around
- same for `disableRightSwipe`