### PR TITLE
Fix DeckSwiper and Swiper with stateful children

### DIFF
--- a/packages/core/src/components/DeckSwiper/DeckSwiper.tsx
+++ b/packages/core/src/components/DeckSwiper/DeckSwiper.tsx
@@ -96,7 +96,7 @@ const DeckSwiper = <T extends object>({
   This forces an update on every re-render to reflect any parent state changes
   */
   React.useEffect(() => {
-    deckSwiperRef?.current?.forceUpdate();
+    deckSwiperRef.current?.forceUpdate();
   });
 
   /**

--- a/packages/core/src/components/DeckSwiper/DeckSwiper.tsx
+++ b/packages/core/src/components/DeckSwiper/DeckSwiper.tsx
@@ -53,6 +53,8 @@ const DeckSwiper = <T extends object>({
     );
   }
 
+  const deckSwiperRef = React.useRef<DeckSwiperComponent<T>>(null);
+
   const childrenArray = React.useMemo(
     () => React.Children.toArray(children),
     [children]
@@ -89,6 +91,14 @@ const DeckSwiper = <T extends object>({
     }
   };
 
+  /* 
+  react-native-deck-swiper does not re-render cards when parent state changes
+  This forces an update on every re-render to reflect any parent state changes
+  */
+  React.useEffect(() => {
+    deckSwiperRef?.current?.forceUpdate();
+  });
+
   /**
    * By default react-native-deck-swiper positions everything with absolute position.
    * To overcome this, it is wrapped in a View to be able to add the component in any layout structure.
@@ -103,6 +113,7 @@ const DeckSwiper = <T extends object>({
     <View>
       <View style={styles.containerHeightFiller}>{renderFirstCard()}</View>
       <DeckSwiperComponent
+        ref={deckSwiperRef}
         cards={cardsData as any[]}
         renderCard={renderCard}
         keyExtractor={cardKeyExtractor}


### PR DESCRIPTION
- Both Swiper and DeckSwiper behaved unexpectedly when one of their children contains a component that relies on and updates a hoisted state of a parent.
  - Effectively `TextInput`, `Switch` and similar were unusable within a `Swiper` or `DeckSwiper`
- This fixes both of them, each in a different way due to the issue being different in each of them, just the same result.