### PR TITLE
Update how Markers/Callout are rendered (47.3.4)

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@draftbit/example",
   "description": "Example app for @draftbit/ui",
-  "version": "47.3.3",
+  "version": "47.3.4",
   "private": true,
   "main": "__generated__/AppEntry.js",
   "scripts": {
@@ -15,8 +15,8 @@
     "clean:modules": "rimraf node_modules"
   },
   "dependencies": {
-    "@draftbit/maps": "47.3.3",
-    "@draftbit/ui": "47.3.3",
+    "@draftbit/maps": "47.3.4",
+    "@draftbit/ui": "47.3.4",
     "@expo/dev-server": "0.1.123",
     "@expo/webpack-config": "^0.17.2",
     "@react-navigation/drawer": "^5.12.9",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "47.3.3",
+  "version": "47.3.4",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "packages": ["packages/*", "example"],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draftbit/core",
-  "version": "47.3.3",
+  "version": "47.3.4",
   "description": "Core (non-native) Components",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",
@@ -39,7 +39,7 @@
   "dependencies": {
     "@date-io/date-fns": "^1.3.13",
     "@draftbit/react-theme-provider": "^2.1.1",
-    "@draftbit/types": "47.3.3",
+    "@draftbit/types": "47.3.4",
     "@expo/vector-icons": "^13.0.0",
     "@material-ui/core": "^4.11.0",
     "@material-ui/pickers": "^3.2.10",

--- a/packages/maps/package.json
+++ b/packages/maps/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/draftbit/react-native-jigsaw#readme",
   "dependencies": {
-    "@teovilla/react-native-web-maps": "^0.9.0",
+    "@teovilla/react-native-web-maps": "^0.9.1",
     "react-native-maps": "1.3.2"
   },
   "eslintIgnore": [

--- a/packages/maps/package.json
+++ b/packages/maps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draftbit/maps",
-  "version": "47.3.3",
+  "version": "47.3.4",
   "description": "Map Components",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",

--- a/packages/maps/src/components/MapCallout.tsx
+++ b/packages/maps/src/components/MapCallout.tsx
@@ -1,17 +1,27 @@
 import * as React from "react";
-import { Callout as MapCalloutComponent } from "./react-native-maps";
 import type { MapCalloutProps as MapCalloutComponentProps } from "react-native-maps";
+import { Callout as MapCalloutComponent } from "./react-native-maps";
 
 export interface MapCalloutProps
   extends Omit<MapCalloutComponentProps, "tooltip"> {
   showTooltip?: boolean;
 }
 
-// Has to be a function named 'Callout' to be matched as a Callout component and not a custom view for marker
-// See: https://github.com/teovillanueva/react-native-web-maps/blob/81278079c6f26a707d915d69de9a00080c305957/packages/react-native-web-maps/src/components/marker.web.tsx#L79
-export function Callout({
-  showTooltip,
-  ...rest
-}: React.PropsWithChildren<MapCalloutProps>) {
-  return <MapCalloutComponent tooltip={!showTooltip} {...rest} />;
+/**
+ * Renders nothing, serves as placeholder for props
+ * Rendering exposed as function to avoid having an intermediary component that changes the type
+ *
+ * This is done because the underlying package has logic dependant on the type of child
+ * See: https://github.com/teovillanueva/react-native-web-maps/blob/5f3d0ec7c24f789c3df30c1d6d7223e638ff5868/packages/react-native-web-maps/src/components/marker.web.tsx#L79
+ */
+const MapCallout: React.FC<React.PropsWithChildren<MapCalloutProps>> = () => {
+  return null;
+};
+
+export function renderCallout(props: MapCalloutProps, key: React.Key) {
+  return (
+    <MapCalloutComponent key={key} tooltip={!props.showTooltip} {...props} />
+  );
 }
+
+export default MapCallout;

--- a/packages/maps/src/components/MapMarker.tsx
+++ b/packages/maps/src/components/MapMarker.tsx
@@ -1,7 +1,14 @@
 import * as React from "react";
-import { Image, ImageSourcePropType } from "react-native";
+import {
+  Image,
+  ImageSourcePropType,
+  View,
+  StyleSheet,
+  Text,
+} from "react-native";
 import { Marker as MapMarkerComponent } from "./react-native-maps";
 import type { MapMarkerProps as MapMarkerComponentProps } from "react-native-maps";
+import MapCallout, { renderCallout } from "./MapCallout";
 
 export interface MapMarkerProps
   extends Omit<MapMarkerComponentProps, "onPress" | "coordinate"> {
@@ -12,17 +19,55 @@ export interface MapMarkerProps
   onPress?: (latitude: number, longitude: number) => void;
 }
 
-const MapMarker: React.FC<React.PropsWithChildren<MapMarkerProps>> = ({
-  latitude,
-  longitude,
-  pinImage,
-  pinImageSize = 50,
-  onPress,
-  children,
-  ...rest
-}) => {
+/**
+ * Renders nothing, serves as placeholder for props
+ * Rendering exposed as function to avoid having an intermediary component that changes the type
+ *
+ * This is done because the underlying package has logic dependant on the type of child
+ */
+const MapMarker: React.FC<React.PropsWithChildren<MapMarkerProps>> = () => {
+  return null;
+};
+
+export function renderMarker(
+  {
+    latitude,
+    longitude,
+    pinImage,
+    pinImageSize = 50,
+    onPress,
+    children,
+    title,
+    description,
+    ...rest
+  }: MapMarkerProps,
+  key: React.Key
+) {
+  const childrenArray = React.Children.toArray(children);
+
+  const calloutChildren = childrenArray.filter(
+    (child) => (child as React.ReactElement).type === MapCallout
+  );
+
+  const nonCalloutChildren = childrenArray.filter(
+    (child) => (child as React.ReactElement).type !== MapCallout
+  );
+
+  // Add default callout for title/description
+  if (calloutChildren.length === 0 && (title || description)) {
+    calloutChildren.push(
+      <MapCallout showTooltip>
+        <View>
+          {title && <Text style={style.title}>{title}</Text>}
+          {description && <Text style={style.description}>{description}</Text>}
+        </View>
+      </MapCallout>
+    );
+  }
+
   return (
     <MapMarkerComponent
+      key={key}
       coordinate={{
         latitude,
         longitude,
@@ -33,6 +78,8 @@ const MapMarker: React.FC<React.PropsWithChildren<MapMarkerProps>> = ({
       }}
       {...rest}
     >
+      {nonCalloutChildren}
+
       {pinImage && (
         <Image
           source={typeof pinImage === "string" ? { uri: pinImage } : pinImage}
@@ -43,9 +90,22 @@ const MapMarker: React.FC<React.PropsWithChildren<MapMarkerProps>> = ({
           }}
         />
       )}
-      {children}
+
+      {calloutChildren.map((callout, index) =>
+        renderCallout((callout as React.ReactElement).props, index)
+      )}
     </MapMarkerComponent>
   );
-};
+}
+
+const style = StyleSheet.create({
+  title: {
+    fontWeight: "600",
+    textAlign: "center",
+  },
+  description: {
+    textAlign: "center",
+  },
+});
 
 export default MapMarker;

--- a/packages/maps/src/index.tsx
+++ b/packages/maps/src/index.tsx
@@ -1,3 +1,3 @@
 export { default as MapView } from "./components/MapView";
 export { default as MapMarker } from "./components/MapMarker";
-export { Callout as MapCallout } from "./components/MapCallout";
+export { default as MapCallout } from "./components/MapCallout";

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draftbit/native",
-  "version": "47.3.3",
+  "version": "47.3.4",
   "description": "Draftbit UI Components that Depend on Native Components",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/draftbit/react-native-jigsaw#readme",
   "dependencies": {
-    "@draftbit/types": "47.3.3",
+    "@draftbit/types": "47.3.4",
     "@expo/vector-icons": "^13.0.0",
     "@react-native-community/datetimepicker": "6.3.5",
     "@react-native-community/slider": "4.2.4",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draftbit/types",
-  "version": "47.3.3",
+  "version": "47.3.4",
   "description": "Shared constants and types between native and core components",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draftbit/ui",
-  "version": "47.3.3",
+  "version": "47.3.4",
   "description": "Draftbit UI Library",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",
@@ -41,8 +41,8 @@
   },
   "homepage": "https://github.com/draftbit/react-native-jigsaw#readme",
   "dependencies": {
-    "@draftbit/core": "47.3.3",
-    "@draftbit/native": "47.3.3"
+    "@draftbit/core": "47.3.4",
+    "@draftbit/native": "47.3.4"
   },
   "eslintIgnore": [
     "node_modules/",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3527,10 +3527,10 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@teovilla/react-native-web-maps@^0.9.0":
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/@teovilla/react-native-web-maps/-/react-native-web-maps-0.9.0.tgz#9c08f5a3c32db243209b88d01b0e96398a8130bf"
-  integrity sha512-svG9eQxoKqf3btXvTG4LB8Oa7ot9P2uENJWX9EJv0A+N1XIQCBCCR/DVS6R7GbMMhh9C7JKvzL+QgKz8gqMdiw==
+"@teovilla/react-native-web-maps@^0.9.1":
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/@teovilla/react-native-web-maps/-/react-native-web-maps-0.9.1.tgz#0f83d563a6513db4352ecf25c5f906a9d7a3a1ae"
+  integrity sha512-cv0cLiR7P/tAxUsySpaWO+OuRoOIH6ggHxviMX3QOfUoJUyfKHzhZyVPH54e8s/202QUtlB0ab7goSYKSS3ycA==
   dependencies:
     "@react-google-maps/api" "^2.12.0"
     expo-location "~15.1.1"


### PR DESCRIPTION
- Update how Markers/Callouts are rendered to maintain the type of the original underlying component
  - i.e. no intermediary component, library component rendered directly
- Update the version of `@teovilla/react-native-web-maps` 
- Jigsaw bump