### PR TITLE
Add progress indicator components (47)

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -59,7 +59,8 @@ import BottomSheetExample from "./BottomSheetExample";
 import YoutubeExample from "./YoutubeExample";
 import TableExample from "./TableExample";
 import SwipeableItemExample from "./SwipeableItemExample";
-import ProgressExample from "./ProgressExample";
+import LinearProgressExample from "./LinearProgressExample";
+import CircularProgressExample from "./CircularProgressExample";
 import SectionListExample from "./SectionListExample";
 
 const ROUTES = {
@@ -95,7 +96,8 @@ const ROUTES = {
   Youtube: YoutubeExample,
   Table: TableExample,
   SwipeableView: SwipeableItemExample,
-  Progress: ProgressExample,
+  LinearProgress: LinearProgressExample,
+  CircularProgress: CircularProgressExample,
   SectionList: SectionListExample,
 };
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -59,6 +59,7 @@ import BottomSheetExample from "./BottomSheetExample";
 import YoutubeExample from "./YoutubeExample";
 import TableExample from "./TableExample";
 import SwipeableItemExample from "./SwipeableItemExample";
+import ProgressExample from "./ProgressExample";
 import SectionListExample from "./SectionListExample";
 
 const ROUTES = {
@@ -94,6 +95,7 @@ const ROUTES = {
   Youtube: YoutubeExample,
   Table: TableExample,
   SwipeableView: SwipeableItemExample,
+  Progress: ProgressExample,
   SectionList: SectionListExample,
 };
 

--- a/example/src/CircularProgressExample.tsx
+++ b/example/src/CircularProgressExample.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import Section, { Container } from "./Section";
+import { CircularProgress, Button } from "@draftbit/ui";
+import { Text } from "react-native";
+
+const ProgressExample: React.FC = () => {
+  const [value, setValue] = React.useState(50);
+
+  return (
+    <Container style={{}}>
+      <Section title="Circular Progress (Default)" style={{ width: 200 }}>
+        <CircularProgress value={value} />
+      </Section>
+
+      <Section title="Circular Progress (Different Styles)" style={{}}>
+        <CircularProgress
+          style={{ width: 200 }}
+          thickness={40}
+          trackThickness={20}
+          value={value}
+        />
+        <CircularProgress
+          style={{ marginTop: 30, width: 200 }}
+          color="rgb(0,255,0)"
+          trackColor="gray"
+          thickness={20}
+          trackThickness={30}
+          value={value}
+          lineCap="square"
+        />
+        <CircularProgress
+          style={{ marginTop: 30, width: 200 }}
+          thickness={20}
+          trackThickness={25}
+          dashWidth={20}
+          dashGap={30}
+          value={value}
+        />
+      </Section>
+
+      <Section title="Circular Progress (Indeterminate)" style={{}}>
+        <CircularProgress style={{ width: 200 }} indeterminate />
+      </Section>
+
+      <Text>Current: {value}</Text>
+      <Button
+        //@ts-ignore
+        title="Randomize Progress"
+        onPress={() => setValue(Math.random() * 101)}
+      />
+    </Container>
+  );
+};
+
+export default ProgressExample;

--- a/example/src/LinearProgressExample.tsx
+++ b/example/src/LinearProgressExample.tsx
@@ -38,9 +38,11 @@ const ProgressExample: React.FC = () => {
           value={value}
         />
       </Section>
+
       <Section title="Linear Progress (Indeterminate)" style={{}}>
         <LinearProgress indeterminate />
       </Section>
+
       <Text>Current: {value}</Text>
       <Button
         //@ts-ignore

--- a/example/src/ProgressExample.tsx
+++ b/example/src/ProgressExample.tsx
@@ -9,13 +9,7 @@ const ProgressExample: React.FC = () => {
   return (
     <Container style={{}}>
       <Section title="Linear Progress (Default)" style={{}}>
-        <LinearProgress
-          dashOffset={0}
-          dashGap={200}
-          dashWidth={200}
-          animationDuration={500}
-          indeterminate
-        />
+        <LinearProgress value={value} />
       </Section>
 
       <Section title="Linear Progress (Different Styles)" style={{}}>
@@ -43,6 +37,9 @@ const ProgressExample: React.FC = () => {
           trackThickness={20}
           value={value}
         />
+      </Section>
+      <Section title="Linear Progress (Indeterminate)" style={{}}>
+        <LinearProgress indeterminate />
       </Section>
       <Text>Current: {value}</Text>
       <Button

--- a/example/src/ProgressExample.tsx
+++ b/example/src/ProgressExample.tsx
@@ -1,20 +1,46 @@
 import React from "react";
 import Section, { Container } from "./Section";
-import { LinearProgress } from "@draftbit/ui";
+import { LinearProgress, Button } from "@draftbit/ui";
 
 const ProgressExample: React.FC = () => {
+  const [value, setValue] = React.useState(50);
   return (
     <Container style={{}}>
-      <Section title="Linear Progress" style={{}}>
+      <Section title="Linear Progress (Default)" style={{}}>
+        <LinearProgress value={value} />
+      </Section>
+
+      <Section title="Linear Progress (Different Styles)" style={{}}>
         <LinearProgress
-          value={0}
-          thickness={15}
-          trackThickness={15}
-          trackColor="red"
-          trackOpacity={0.3}
-          lineCap="round"
+          color="rgb(0,255,0)"
+          trackColor="gray"
+          thickness={20}
+          trackThickness={30}
+          value={value}
+          lineCap="square"
+        />
+        <LinearProgress
+          style={{ marginTop: 30 }}
+          thickness={20}
+          trackThickness={25}
+          dashWidth={20}
+          dashGap={30}
+          trackDashWidth={20}
+          trackDashGap={30}
+          value={value}
+        />
+        <LinearProgress
+          style={{ marginTop: 30 }}
+          thickness={40}
+          trackThickness={20}
+          value={value}
         />
       </Section>
+      <Button
+        //@ts-ignore
+        title="Randomize Progress"
+        onPress={() => setValue(Math.random() * 101)}
+      />
     </Container>
   );
 };

--- a/example/src/ProgressExample.tsx
+++ b/example/src/ProgressExample.tsx
@@ -1,13 +1,21 @@
 import React from "react";
 import Section, { Container } from "./Section";
 import { LinearProgress, Button } from "@draftbit/ui";
+import { Text } from "react-native";
 
 const ProgressExample: React.FC = () => {
   const [value, setValue] = React.useState(50);
+
   return (
     <Container style={{}}>
       <Section title="Linear Progress (Default)" style={{}}>
-        <LinearProgress value={value} />
+        <LinearProgress
+          dashOffset={0}
+          dashGap={200}
+          dashWidth={200}
+          animationDuration={500}
+          indeterminate
+        />
       </Section>
 
       <Section title="Linear Progress (Different Styles)" style={{}}>
@@ -36,6 +44,7 @@ const ProgressExample: React.FC = () => {
           value={value}
         />
       </Section>
+      <Text>Current: {value}</Text>
       <Button
         //@ts-ignore
         title="Randomize Progress"

--- a/example/src/ProgressExample.tsx
+++ b/example/src/ProgressExample.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import Section, { Container } from "./Section";
+import { LinearProgress } from "@draftbit/ui";
+
+const ProgressExample: React.FC = () => {
+  return (
+    <Container style={{}}>
+      <Section title="Linear Progress" style={{}}>
+        <LinearProgress
+          value={0}
+          thickness={15}
+          trackThickness={15}
+          trackColor="red"
+          trackOpacity={0.3}
+          lineCap="round"
+        />
+      </Section>
+    </Container>
+  );
+};
+
+export default ProgressExample;

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@testing-library/jest-native": "^5.4.2",
     "@testing-library/react-native": "^12.1.2",
     "@types/jest": "^29.5.0",
+    "@types/react-test-renderer": "^18.0.0",
     "babel-jest": "^29.5.0",
     "dotenv": "^9.0.2",
     "eslint": "^8.18.0",

--- a/packages/core/babel.config.js
+++ b/packages/core/babel.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   presets: ["module:metro-react-native-babel-preset"],
+  plugins: ["react-native-reanimated/plugin"],
 };

--- a/packages/core/jest-setup.js
+++ b/packages/core/jest-setup.js
@@ -1,3 +1,9 @@
 import "@shopify/flash-list/jestSetup";
-import { setUpTests } from "react-native-reanimated/lib/reanimated2/jestUtils";
-setUpTests();
+import { setUpTests as setupReaanimatedTests } from "react-native-reanimated/lib/reanimated2/jestUtils";
+
+setupReaanimatedTests();
+
+// Fixes reanimated jest bug: https://github.com/software-mansion/react-native-reanimated/issues/3125
+global.ReanimatedDataMock = {
+  now: () => 0,
+};

--- a/packages/core/jest-setup.js
+++ b/packages/core/jest-setup.js
@@ -1,1 +1,3 @@
-require("@shopify/flash-list/jestSetup");
+import "@shopify/flash-list/jestSetup";
+import { setUpTests } from "react-native-reanimated/lib/reanimated2/jestUtils";
+setUpTests();

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -83,15 +83,18 @@
   ],
   "jest": {
     "preset": "react-native",
-    "setupFiles": [
-      "./jest-setup.js"
-    ],
     "setupFilesAfterEnv": [
-      "@testing-library/jest-native/extend-expect"
+      "@testing-library/jest-native/extend-expect",
+      "./jest-setup.js"
     ],
     "testPathIgnorePatterns": [
       "lib",
-      "__mocks__"
-    ]
+      "__mocks__",
+      "declarations.d.ts"
+    ],
+    "transformIgnorePatterns": [
+      "node_modules/(?!(react-native-reanimated|@react-native|react-native)/)"
+    ],
+    "testEnvironment": "node"
   }
 }

--- a/packages/core/src/__tests__/components/CircularProgress.test.tsx
+++ b/packages/core/src/__tests__/components/CircularProgress.test.tsx
@@ -1,15 +1,15 @@
 import React from "react";
 import { render, screen } from "@testing-library/react-native";
-import { default as LinearProgress } from "../../components/Progress/LinearProgress";
+import { default as CircularProgrss } from "../../components/Progress/CircularProgress";
 import Theme from "../../styles/DefaultTheme";
-import { AnimatedLine } from "../../components/Progress/LinearProgress/LinearProgress";
+import { AnimatedPath } from "../../components/Progress/CircularProgress/CircularProgress";
 import { DEFAULT_ANIMATION_DURATION } from "../../components/Progress/ProgressCommon";
 
 jest.useFakeTimers();
 
-describe("LinearProgress tests", () => {
+describe("CircularProgress tests", () => {
   test("should render indeterminate progress bar when prop set to true", () => {
-    render(<LinearProgress theme={Theme as any} indeterminate={true} />);
+    render(<CircularProgrss theme={Theme as any} indeterminate={true} />);
 
     const indeterminateProgress = screen.queryByTestId(
       "indeterminate-progress"
@@ -18,7 +18,7 @@ describe("LinearProgress tests", () => {
   });
 
   test("should not render indeterminate progress bar when prop set to false", () => {
-    render(<LinearProgress theme={Theme as any} indeterminate={false} />);
+    render(<CircularProgrss theme={Theme as any} indeterminate={false} />);
 
     const indeterminateProgress = screen.queryByTestId(
       "indeterminate-progress"
@@ -27,10 +27,10 @@ describe("LinearProgress tests", () => {
   });
 
   test.each([5, 10, 50, 70, 100])(
-    "should progress line be visible when at %p%",
+    "should progress path be visible when at %p%",
     (value) => {
       render(
-        <LinearProgress
+        <CircularProgrss
           value={value}
           theme={Theme as any}
           indeterminate={false}
@@ -41,10 +41,10 @@ describe("LinearProgress tests", () => {
 
       jest.advanceTimersByTime(DEFAULT_ANIMATION_DURATION);
 
-      const svgContainer = screen.getByTestId("linear-progress-component");
-      const progressLine = svgContainer.findByType(AnimatedLine);
+      const svgContainer = screen.getByTestId("circular-progress-component");
+      const progressPath = svgContainer.findByType(AnimatedPath);
 
-      expect(progressLine).toBeVisible();
+      expect(progressPath).toBeVisible();
     }
   );
 });

--- a/packages/core/src/__tests__/components/LinearProgress.test.tsx
+++ b/packages/core/src/__tests__/components/LinearProgress.test.tsx
@@ -9,7 +9,18 @@ describe("LinearProgress tests", () => {
   test("should render indeterminate progress bar when prop set to true", () => {
     render(<LinearProgress theme={Theme as any} indeterminate={true} />);
 
-    const indeterminateProgress = screen.getByTestId("indeterminate-progress");
+    const indeterminateProgress = screen.queryByTestId(
+      "indeterminate-progress"
+    );
     expect(indeterminateProgress).toBeTruthy();
+  });
+
+  test("should not render indeterminate progress bar when prop set to false", () => {
+    render(<LinearProgress theme={Theme as any} indeterminate={false} />);
+
+    const indeterminateProgress = screen.queryByTestId(
+      "indeterminate-progress"
+    );
+    expect(indeterminateProgress).toBeUndefined();
   });
 });

--- a/packages/core/src/__tests__/components/LinearProgress.test.tsx
+++ b/packages/core/src/__tests__/components/LinearProgress.test.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { render, screen } from "@testing-library/react-native";
+import { default as LinearProgress } from "../../components/Progress/LinearProgress";
+import Theme from "../../styles/DefaultTheme";
+
+jest.useFakeTimers();
+
+describe("LinearProgress tests", () => {
+  test("should render indeterminate progress bar when prop set to true", () => {
+    render(<LinearProgress theme={Theme as any} indeterminate={true} />);
+
+    const indeterminateProgress = screen.getByTestId("indeterminate-progress");
+    expect(indeterminateProgress).toBeTruthy();
+  });
+});

--- a/packages/core/src/__tests__/components/SectionList.test.tsx
+++ b/packages/core/src/__tests__/components/SectionList.test.tsx
@@ -116,7 +116,7 @@ describe("SectionList tests", () => {
     );
 
     const foodWithoutCategoryText = screen.getByTestId("food-no-category");
-    expect(foodWithoutCategoryText.props.children[0]).toEqual(DEFAULT_SECTION);
+    expect(foodWithoutCategoryText).toHaveTextContent(DEFAULT_SECTION);
   });
 });
 

--- a/packages/core/src/__tests__/declarations.d.ts
+++ b/packages/core/src/__tests__/declarations.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@testing-library/jest-native/" />

--- a/packages/core/src/components/Progress/CircularProgress/CircularProgress.tsx
+++ b/packages/core/src/components/Progress/CircularProgress/CircularProgress.tsx
@@ -1,0 +1,198 @@
+import React from "react";
+import Svg, { Path, PathProps } from "react-native-svg";
+import Animated, {
+  useAnimatedProps,
+  useSharedValue,
+  withTiming,
+} from "react-native-reanimated";
+import {
+  DEFAULT_ANIMATION_DURATION,
+  ValueProgressProps,
+  CircularProgressProps,
+} from "../ProgressCommon";
+
+const AnimatedPath = Animated.createAnimatedComponent(Path);
+
+export const CircularProgress: React.FC<
+  ValueProgressProps & CircularProgressProps
+> = ({
+  theme,
+  minimumValue = 0,
+  maximumValue = 100,
+  value = minimumValue,
+  thickness = 10,
+  trackThickness = thickness,
+  color = theme.colors.primary,
+  trackColor = theme.colors.divider,
+  trackOpacity = 1,
+  showTrack = true,
+  animationDuration = DEFAULT_ANIMATION_DURATION,
+  isAnimated = true,
+  lineCap = "round",
+  trackLineCap = lineCap,
+  dashWidth,
+  trackDashWidth,
+  dashGap,
+  trackDashGap,
+  dashOffset,
+  trackDashOffset,
+  customDashArray,
+  trackCustomDashArray,
+  onFullPathWidth,
+  startPosition = "top",
+  style,
+}) => {
+  const [svgContainerWidth, setSvgContainerWidth] = React.useState(0);
+  const [circumfrence, setCircumefrence] = React.useState(0);
+
+  const dashArray =
+    dashWidth !== undefined
+      ? `${dashWidth} ${dashGap || dashWidth}`
+      : undefined;
+  const trackDashArray =
+    trackDashWidth !== undefined
+      ? `${trackDashWidth} ${trackDashGap || trackDashWidth}`
+      : undefined;
+
+  const maxThickness = Math.max(thickness, trackThickness);
+  const thicknessOffset = maxThickness / 2; // This offset guarantees nothing is cut off by view bounds
+
+  const radius = svgContainerWidth / 2;
+
+  const c = 2 * Math.PI * radius;
+  if (c !== circumfrence) {
+    setCircumefrence(c);
+  }
+
+  const startAngle = React.useMemo(() => {
+    switch (startPosition) {
+      case "top":
+        return 0;
+      case "right":
+        return 90;
+      case "bottom":
+        return 180;
+      case "left":
+        return 270;
+    }
+  }, [startPosition]);
+
+  const currentFillPercentage = value / (maximumValue + minimumValue);
+  const currentAngle = useSharedValue(startAngle + currentFillPercentage * 360);
+
+  const progressPathAnimatedProps = useAnimatedProps<PathProps>(() => {
+    const isMinAngle = currentAngle.value <= startAngle;
+    return {
+      d: circlePath(
+        radius,
+        radius,
+        radius - thicknessOffset,
+        startAngle,
+        Math.min(currentAngle.value, startAngle + 360) //Prevents going beyond the max angle
+      ),
+      strokeOpacity: isMinAngle ? 0.0 : 1.0,
+    };
+  });
+
+  React.useEffect(() => {
+    currentAngle.value = withTiming(startAngle + currentFillPercentage * 360, {
+      duration: isAnimated ? animationDuration : 0,
+    });
+  }, [
+    value,
+    currentFillPercentage,
+    animationDuration,
+    currentAngle,
+    maximumValue,
+    minimumValue,
+    isAnimated,
+    startAngle,
+  ]);
+
+  React.useEffect(() => {
+    onFullPathWidth?.(circumfrence);
+  }, [circumfrence, onFullPathWidth]);
+
+  return (
+    <Svg
+      onLayout={(event) => {
+        const width = event.nativeEvent.layout.width;
+        setSvgContainerWidth(width);
+      }}
+      style={[
+        {
+          height: svgContainerWidth,
+        },
+        style,
+      ]}
+    >
+      {showTrack && (
+        <Path
+          d={circlePath(
+            radius,
+            radius,
+            radius - thicknessOffset,
+            startAngle,
+            startAngle + 360
+          )}
+          stroke={trackColor}
+          strokeWidth={trackThickness}
+          strokeOpacity={trackOpacity}
+          strokeLinecap={trackLineCap}
+          strokeDasharray={trackCustomDashArray || trackDashArray}
+          strokeDashoffset={trackDashOffset}
+        />
+      )}
+      <AnimatedPath
+        animatedProps={progressPathAnimatedProps}
+        stroke={color}
+        strokeWidth={thickness}
+        strokeLinecap={lineCap}
+        strokeDasharray={customDashArray || dashArray}
+        strokeDashoffset={dashOffset}
+      />
+    </Svg>
+  );
+};
+
+// From: https://github.com/bartgryszko/react-native-circular-progress/blob/a93b501aea40306126c8ede72089741eead52308/src/CircularProgress.js#L15
+function circlePath(
+  x: number,
+  y: number,
+  radius: number,
+  startAngle: number,
+  endAngle: number
+) {
+  "worklet"; // Reanimated worklet to be runnable on the UI thread
+
+  function polarToCartesian(
+    centerX: number,
+    centerY: number,
+    radius: number,
+    angleInDegrees: number
+  ) {
+    var angleInRadians = ((angleInDegrees - 90) * Math.PI) / 180.0;
+    return {
+      x: centerX + radius * Math.cos(angleInRadians),
+      y: centerY + radius * Math.sin(angleInRadians),
+    };
+  }
+
+  var start = polarToCartesian(x, y, radius, endAngle * 0.9999);
+  var end = polarToCartesian(x, y, radius, startAngle);
+  var largeArcFlag = endAngle - startAngle <= 180 ? "0" : "1";
+  var d = [
+    "M",
+    start.x,
+    start.y,
+    "A",
+    radius,
+    radius,
+    0,
+    largeArcFlag,
+    0,
+    end.x,
+    end.y,
+  ];
+  return d.join(" ");
+}

--- a/packages/core/src/components/Progress/CircularProgress/CircularProgress.tsx
+++ b/packages/core/src/components/Progress/CircularProgress/CircularProgress.tsx
@@ -41,6 +41,7 @@ export const CircularProgress: React.FC<
   onFullPathWidth,
   startPosition = "top",
   style,
+  testID,
 }) => {
   const [svgContainerWidth, setSvgContainerWidth] = React.useState(0);
   const [circumfrence, setCircumefrence] = React.useState(0);
@@ -115,6 +116,7 @@ export const CircularProgress: React.FC<
 
   return (
     <Svg
+      testID={testID}
       onLayout={(event) => {
         const width = event.nativeEvent.layout.width;
         setSvgContainerWidth(width);

--- a/packages/core/src/components/Progress/CircularProgress/CircularProgress.tsx
+++ b/packages/core/src/components/Progress/CircularProgress/CircularProgress.tsx
@@ -11,7 +11,7 @@ import {
   CircularProgressProps,
 } from "../ProgressCommon";
 
-const AnimatedPath = Animated.createAnimatedComponent(Path);
+export const AnimatedPath = Animated.createAnimatedComponent(Path);
 
 export const CircularProgress: React.FC<
   ValueProgressProps & CircularProgressProps
@@ -116,7 +116,7 @@ export const CircularProgress: React.FC<
 
   return (
     <Svg
-      testID={testID}
+      testID={testID ?? "circular-progress-component"}
       onLayout={(event) => {
         const width = event.nativeEvent.layout.width;
         setSvgContainerWidth(width);

--- a/packages/core/src/components/Progress/CircularProgress/CircularProgress.tsx
+++ b/packages/core/src/components/Progress/CircularProgress/CircularProgress.tsx
@@ -81,7 +81,7 @@ export const CircularProgress: React.FC<
   const currentAngle = useSharedValue(startAngle + currentFillPercentage * 360);
 
   const progressPathAnimatedProps = useAnimatedProps<PathProps>(() => {
-    const isMinAngle = currentAngle.value <= startAngle;
+    const isBelowMinAngle = currentAngle.value <= startAngle;
     return {
       d: circlePath(
         radius,
@@ -90,7 +90,7 @@ export const CircularProgress: React.FC<
         startAngle,
         Math.min(currentAngle.value, startAngle + 360) //Prevents going beyond the max angle
       ),
-      strokeOpacity: isMinAngle ? 0.0 : 1.0,
+      strokeOpacity: isBelowMinAngle ? 0.0 : 1.0,
     };
   });
 

--- a/packages/core/src/components/Progress/CircularProgress/index.tsx
+++ b/packages/core/src/components/Progress/CircularProgress/index.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import IndeterminateProgress from "../IndeterminateProgress";
+import {
+  CircularProgressProps,
+  IndeterminateProgressProps,
+  ValueProgressProps,
+} from "../ProgressCommon";
+import { CircularProgress as CircularProgressComponent } from "./CircularProgress";
+import { withTheme } from "../../../theming";
+
+const CircularProgress: React.FC<
+  ValueProgressProps & IndeterminateProgressProps & CircularProgressProps
+> = (props) => {
+  if (props.indeterminate) {
+    return (
+      <IndeterminateProgress
+        ProgressComponent={
+          CircularProgressComponent as React.FunctionComponent<ValueProgressProps>
+        }
+        {...props}
+      />
+    );
+  } else {
+    return <CircularProgressComponent {...props} />;
+  }
+};
+
+export default withTheme(CircularProgress);

--- a/packages/core/src/components/Progress/IndeterminateProgress.tsx
+++ b/packages/core/src/components/Progress/IndeterminateProgress.tsx
@@ -19,7 +19,7 @@ const IndeterminateProgress: React.FC<IndeterminateProgressProps> = ({
   ProgressComponent,
   ...rest
 }) => {
-  const [componentWidth, setComponentWidth] = React.useState(0);
+  const [pathWidth, setPathWidth] = React.useState(0);
   const [value, setValue] = React.useState(0);
   const [dashOffset, setDashOffset] = React.useState(0);
   const animationDuration =
@@ -36,7 +36,7 @@ const IndeterminateProgress: React.FC<IndeterminateProgressProps> = ({
   const repeatIndeterminateAnimation = React.useCallback(() => {
     if (value === 0) {
       setValue(100);
-      currentOffset.value = withTiming(componentWidth, {
+      currentOffset.value = withTiming(pathWidth, {
         duration: animationDuration,
       });
     } else {
@@ -45,7 +45,7 @@ const IndeterminateProgress: React.FC<IndeterminateProgressProps> = ({
         duration: animationDuration,
       });
     }
-  }, [currentOffset, value, animationDuration, componentWidth]);
+  }, [currentOffset, value, animationDuration, pathWidth]);
 
   React.useEffect(() => {
     const timeout = setTimeout(() => {
@@ -57,13 +57,13 @@ const IndeterminateProgress: React.FC<IndeterminateProgressProps> = ({
   return (
     <ProgressComponent
       {...rest}
-      onWidth={(width) => {
-        setComponentWidth(width);
-        rest.onWidth?.(width);
+      onFullPathWidth={(width) => {
+        setPathWidth(width);
+        rest.onFullPathWidth?.(width);
       }}
       dashOffset={dashOffset}
-      dashGap={componentWidth / 2}
-      dashWidth={componentWidth / 2}
+      dashGap={pathWidth / 2}
+      dashWidth={pathWidth / 2}
       animationDuration={animationDuration}
       value={100}
     />

--- a/packages/core/src/components/Progress/IndeterminateProgress.tsx
+++ b/packages/core/src/components/Progress/IndeterminateProgress.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import {
+  AnimateProps,
+  useAnimatedProps,
+  useSharedValue,
+  withTiming,
+} from "react-native-reanimated";
+import { BaseProgressProps, ValueProgressProps } from "./ProgressCommon";
+
+interface IndeterminateProgressProps extends BaseProgressProps {
+  AnimatedProgressComponent: React.ComponentClass<
+    AnimateProps<ValueProgressProps>
+  >;
+}
+
+const IndeterminateProgress: React.FC<IndeterminateProgressProps> = ({
+  AnimatedProgressComponent,
+  ...rest
+}) => {
+  const [value, setValue] = React.useState(0);
+  const animationDuration = rest.animationDuration;
+
+  const currentOffset = useSharedValue(0);
+
+  const animatedProgressComponentProps = useAnimatedProps<ValueProgressProps>(
+    () => {
+      return {
+        dashOffset: currentOffset.value,
+      };
+    }
+  );
+
+  React.useEffect(() => {
+    const timeout = setTimeout(() => {
+      if (value === 0) {
+        setValue(100);
+        currentOffset.value = withTiming(200, { duration: animationDuration });
+      } else {
+        setValue(0);
+        currentOffset.value = withTiming(0, {
+          duration: animationDuration,
+        });
+      }
+    }, animationDuration);
+    return () => clearTimeout(timeout);
+  }, [value, animationDuration, currentOffset]);
+
+  return (
+    <AnimatedProgressComponent
+      {...rest}
+      animatedProps={animatedProgressComponentProps}
+      dashGap={200}
+      dashWidth={200}
+      animationDuration={animationDuration}
+      value={100}
+    />
+  );
+};
+
+export default IndeterminateProgress;

--- a/packages/core/src/components/Progress/IndeterminateProgress.tsx
+++ b/packages/core/src/components/Progress/IndeterminateProgress.tsx
@@ -57,6 +57,7 @@ const IndeterminateProgress: React.FC<IndeterminateProgressProps> = ({
   return (
     <ProgressComponent
       {...rest}
+      testID={rest.testID || "indeterminate-progress"}
       onFullPathWidth={(width) => {
         setPathWidth(width);
         rest.onFullPathWidth?.(width);

--- a/packages/core/src/components/Progress/LinearProgress.tsx
+++ b/packages/core/src/components/Progress/LinearProgress.tsx
@@ -1,0 +1,127 @@
+import React from "react";
+import { StyleProp, ViewStyle } from "react-native";
+import Svg, { Line, LineProps } from "react-native-svg";
+import { withTheme } from "../../theming";
+import { Theme } from "../../styles/DefaultTheme";
+import Animated, {
+  useAnimatedProps,
+  useSharedValue,
+  withTiming,
+} from "react-native-reanimated";
+
+//TODO: Allow stroke gaps and widths
+type LineCap = "round" | "square";
+
+interface LinearProgressProps {
+  value: number;
+  minimumValue?: number;
+  maximumValue?: number;
+  initialValueToAnimateFrom?: number;
+  thickness?: number;
+  trackThickness?: number;
+  color?: string;
+  trackColor?: string;
+  trackOpacity?: number;
+  showTrack?: boolean;
+  animationDuration?: number;
+  isAnimated?: boolean;
+  lineCap?: LineCap;
+  trackLineCap?: LineCap;
+  style?: StyleProp<ViewStyle>;
+  theme: Theme;
+}
+
+const AnimatedLine = Animated.createAnimatedComponent(Line);
+
+const LinearProgress: React.FC<LinearProgressProps> = ({
+  theme,
+  value,
+  minimumValue = 0,
+  maximumValue = 100,
+  initialValueToAnimateFrom: initialValue = minimumValue,
+  thickness = 10,
+  trackThickness = thickness,
+  color = theme.colors.primary,
+  trackColor = theme.colors.divider,
+  trackOpacity = 1,
+  showTrack = true,
+  animationDuration = 2000,
+  // isAnimated = true,
+  lineCap = "round",
+  trackLineCap = "round",
+
+  style,
+}) => {
+  const [svgContainerWidth, setSvgContainerWidth] = React.useState(0);
+
+  //This offset guarantees nothing is cut off by view bounds
+  const thicknessOffset = thickness / 2;
+  const trackThicknessOffset = trackThickness / 2;
+  const maxThickness = Math.max(thicknessOffset, trackThicknessOffset);
+
+  const progressLineWidth = svgContainerWidth - thicknessOffset;
+  const trackProgressLineWidth = svgContainerWidth - trackThicknessOffset;
+
+  const currentProgressLineWidth = useSharedValue(initialValue);
+
+  const progressLineAnimatedProps = useAnimatedProps<LineProps>(() => {
+    return {
+      x2: currentProgressLineWidth.value,
+    };
+  });
+
+  React.useEffect(() => {
+    const newLineWidth =
+      progressLineWidth * (value / (maximumValue + minimumValue)) +
+      thicknessOffset;
+    console.log(newLineWidth);
+
+    currentProgressLineWidth.value = withTiming(newLineWidth, {
+      duration: animationDuration,
+    });
+  }, [
+    value,
+    progressLineWidth,
+    animationDuration,
+    currentProgressLineWidth,
+    maximumValue,
+    minimumValue,
+    thicknessOffset,
+  ]);
+
+  return (
+    <Svg
+      onLayout={(event) => setSvgContainerWidth(event.nativeEvent.layout.width)}
+      style={[
+        {
+          height: Math.max(thickness, trackThickness),
+        },
+        style,
+      ]}
+    >
+      {showTrack && (
+        <Line
+          x1={trackThicknessOffset}
+          y1={maxThickness}
+          x2={trackProgressLineWidth}
+          y2={maxThickness}
+          stroke={trackColor}
+          strokeWidth={trackThickness}
+          strokeOpacity={trackOpacity}
+          strokeLinecap={trackLineCap}
+        />
+      )}
+      <AnimatedLine
+        animatedProps={progressLineAnimatedProps}
+        x1={thicknessOffset}
+        y1={maxThickness}
+        y2={maxThickness}
+        stroke={color}
+        strokeWidth={thickness}
+        strokeLinecap={lineCap}
+      />
+    </Svg>
+  );
+};
+
+export default withTheme(LinearProgress);

--- a/packages/core/src/components/Progress/LinearProgress.tsx
+++ b/packages/core/src/components/Progress/LinearProgress.tsx
@@ -9,7 +9,6 @@ import Animated, {
   withTiming,
 } from "react-native-reanimated";
 
-//TODO: Allow stroke gaps and widths
 type LineCap = "round" | "square";
 
 interface LinearProgressProps {
@@ -27,6 +26,14 @@ interface LinearProgressProps {
   isAnimated?: boolean;
   lineCap?: LineCap;
   trackLineCap?: LineCap;
+  dashWidth?: string | number;
+  trackDashWidth?: string | number;
+  dashGap?: string | number;
+  trackDashGap?: string | number;
+  dashOffset?: string | number;
+  trackDashOffset?: string | number;
+  customDashArray?: string;
+  trackCustomDashArray?: string;
   style?: StyleProp<ViewStyle>;
   theme: Theme;
 }
@@ -38,47 +45,61 @@ const LinearProgress: React.FC<LinearProgressProps> = ({
   value,
   minimumValue = 0,
   maximumValue = 100,
-  initialValueToAnimateFrom: initialValue = minimumValue,
+  initialValueToAnimateFrom = minimumValue,
   thickness = 10,
   trackThickness = thickness,
   color = theme.colors.primary,
   trackColor = theme.colors.divider,
   trackOpacity = 1,
   showTrack = true,
-  animationDuration = 2000,
-  // isAnimated = true,
+  animationDuration = 500,
+  isAnimated = true,
   lineCap = "round",
-  trackLineCap = "round",
-
+  trackLineCap = lineCap,
+  dashWidth,
+  trackDashWidth,
+  dashGap,
+  trackDashGap,
+  dashOffset,
+  trackDashOffset,
+  customDashArray,
+  trackCustomDashArray,
   style,
 }) => {
   const [svgContainerWidth, setSvgContainerWidth] = React.useState(0);
 
-  //This offset guarantees nothing is cut off by view bounds
-  const thicknessOffset = thickness / 2;
-  const trackThicknessOffset = trackThickness / 2;
-  const maxThickness = Math.max(thicknessOffset, trackThicknessOffset);
+  const dashArray =
+    dashWidth !== undefined
+      ? `${dashWidth} ${dashGap || dashWidth}`
+      : undefined;
+  const trackDashArray =
+    trackDashWidth !== undefined
+      ? `${trackDashWidth} ${trackDashGap || trackDashWidth}`
+      : undefined;
+
+  const maxThickness = Math.max(thickness, trackThickness);
+  const thicknessOffset = maxThickness / 2; // This offset guarantees nothing is cut off by view bounds
 
   const progressLineWidth = svgContainerWidth - thicknessOffset;
-  const trackProgressLineWidth = svgContainerWidth - trackThicknessOffset;
+  const trackProgressLineWidth = svgContainerWidth - thicknessOffset;
 
-  const currentProgressLineWidth = useSharedValue(initialValue);
+  const currentProgressLineWidth = useSharedValue(initialValueToAnimateFrom);
 
   const progressLineAnimatedProps = useAnimatedProps<LineProps>(() => {
+    const isBelowMinWidth = currentProgressLineWidth.value <= thicknessOffset;
     return {
-      x2: currentProgressLineWidth.value,
+      x2: Math.min(progressLineWidth, currentProgressLineWidth.value), //Prevents going beyond the max width
+      strokeOpacity: isBelowMinWidth ? 0.0 : 1.0,
     };
   });
 
   React.useEffect(() => {
-    const newLineWidth =
-      progressLineWidth * (value / (maximumValue + minimumValue)) +
-      thicknessOffset;
-    console.log(newLineWidth);
-
-    currentProgressLineWidth.value = withTiming(newLineWidth, {
-      duration: animationDuration,
-    });
+    currentProgressLineWidth.value = withTiming(
+      progressLineWidth * (value / (maximumValue + minimumValue)),
+      {
+        duration: isAnimated ? animationDuration : 0,
+      }
+    );
   }, [
     value,
     progressLineWidth,
@@ -86,7 +107,7 @@ const LinearProgress: React.FC<LinearProgressProps> = ({
     currentProgressLineWidth,
     maximumValue,
     minimumValue,
-    thicknessOffset,
+    isAnimated,
   ]);
 
   return (
@@ -94,31 +115,35 @@ const LinearProgress: React.FC<LinearProgressProps> = ({
       onLayout={(event) => setSvgContainerWidth(event.nativeEvent.layout.width)}
       style={[
         {
-          height: Math.max(thickness, trackThickness),
+          height: maxThickness,
         },
         style,
       ]}
     >
       {showTrack && (
         <Line
-          x1={trackThicknessOffset}
-          y1={maxThickness}
+          x1={thicknessOffset}
+          y1={thicknessOffset}
           x2={trackProgressLineWidth}
-          y2={maxThickness}
+          y2={thicknessOffset}
           stroke={trackColor}
           strokeWidth={trackThickness}
           strokeOpacity={trackOpacity}
           strokeLinecap={trackLineCap}
+          strokeDasharray={trackCustomDashArray || trackDashArray}
+          strokeDashoffset={trackDashOffset}
         />
       )}
       <AnimatedLine
         animatedProps={progressLineAnimatedProps}
         x1={thicknessOffset}
-        y1={maxThickness}
-        y2={maxThickness}
+        y1={thicknessOffset}
+        y2={thicknessOffset}
         stroke={color}
         strokeWidth={thickness}
         strokeLinecap={lineCap}
+        strokeDasharray={customDashArray || dashArray}
+        strokeDashoffset={dashOffset}
       />
     </Svg>
   );

--- a/packages/core/src/components/Progress/LinearProgress/LinearProgress.tsx
+++ b/packages/core/src/components/Progress/LinearProgress/LinearProgress.tsx
@@ -5,7 +5,10 @@ import Animated, {
   useSharedValue,
   withTiming,
 } from "react-native-reanimated";
-import { ValueProgressProps } from "../ProgressCommon";
+import {
+  DEFAULT_ANIMATION_DURATION,
+  ValueProgressProps,
+} from "../ProgressCommon";
 
 const AnimatedLine = Animated.createAnimatedComponent(Line);
 
@@ -21,7 +24,7 @@ export const LinearProgress: React.FC<ValueProgressProps> = ({
   trackColor = theme.colors.divider,
   trackOpacity = 1,
   showTrack = true,
-  animationDuration = 500,
+  animationDuration = DEFAULT_ANIMATION_DURATION,
   isAnimated = true,
   lineCap = "round",
   trackLineCap = lineCap,
@@ -33,6 +36,7 @@ export const LinearProgress: React.FC<ValueProgressProps> = ({
   trackDashOffset,
   customDashArray,
   trackCustomDashArray,
+  onWidth,
   style,
 }) => {
   const [svgContainerWidth, setSvgContainerWidth] = React.useState(0);
@@ -81,7 +85,11 @@ export const LinearProgress: React.FC<ValueProgressProps> = ({
 
   return (
     <Svg
-      onLayout={(event) => setSvgContainerWidth(event.nativeEvent.layout.width)}
+      onLayout={(event) => {
+        const width = event.nativeEvent.layout.width;
+        setSvgContainerWidth(width);
+        onWidth?.(width);
+      }}
       style={[
         {
           height: maxThickness,

--- a/packages/core/src/components/Progress/LinearProgress/LinearProgress.tsx
+++ b/packages/core/src/components/Progress/LinearProgress/LinearProgress.tsx
@@ -10,7 +10,7 @@ import {
   ValueProgressProps,
 } from "../ProgressCommon";
 
-const AnimatedLine = Animated.createAnimatedComponent(Line);
+export const AnimatedLine = Animated.createAnimatedComponent(Line);
 
 export const LinearProgress: React.FC<ValueProgressProps> = ({
   theme,
@@ -89,7 +89,7 @@ export const LinearProgress: React.FC<ValueProgressProps> = ({
 
   return (
     <Svg
-      testID={testID}
+      testID={testID ?? "linear-progress-component"}
       onLayout={(event) => {
         const width = event.nativeEvent.layout.width;
         setSvgContainerWidth(width);

--- a/packages/core/src/components/Progress/LinearProgress/LinearProgress.tsx
+++ b/packages/core/src/components/Progress/LinearProgress/LinearProgress.tsx
@@ -17,7 +17,6 @@ export const LinearProgress: React.FC<ValueProgressProps> = ({
   minimumValue = 0,
   maximumValue = 100,
   value = minimumValue,
-  initialValueToAnimateFrom = minimumValue,
   thickness = 10,
   trackThickness = thickness,
   color = theme.colors.primary,
@@ -36,7 +35,7 @@ export const LinearProgress: React.FC<ValueProgressProps> = ({
   trackDashOffset,
   customDashArray,
   trackCustomDashArray,
-  onWidth,
+  onFullPathWidth,
   style,
 }) => {
   const [svgContainerWidth, setSvgContainerWidth] = React.useState(0);
@@ -56,7 +55,10 @@ export const LinearProgress: React.FC<ValueProgressProps> = ({
   const progressLineWidth = svgContainerWidth - thicknessOffset;
   const trackProgressLineWidth = svgContainerWidth - thicknessOffset;
 
-  const currentProgressLineWidth = useSharedValue(initialValueToAnimateFrom);
+  const currentFillPercentage = value / (maximumValue + minimumValue);
+  const currentProgressLineWidth = useSharedValue(
+    currentFillPercentage * progressLineWidth
+  );
 
   const progressLineAnimatedProps = useAnimatedProps<LineProps>(() => {
     const isBelowMinWidth = currentProgressLineWidth.value <= thicknessOffset;
@@ -68,7 +70,7 @@ export const LinearProgress: React.FC<ValueProgressProps> = ({
 
   React.useEffect(() => {
     currentProgressLineWidth.value = withTiming(
-      progressLineWidth * (value / (maximumValue + minimumValue)),
+      progressLineWidth * currentFillPercentage,
       {
         duration: isAnimated ? animationDuration : 0,
       }
@@ -76,6 +78,7 @@ export const LinearProgress: React.FC<ValueProgressProps> = ({
   }, [
     value,
     progressLineWidth,
+    currentFillPercentage,
     animationDuration,
     currentProgressLineWidth,
     maximumValue,
@@ -88,7 +91,7 @@ export const LinearProgress: React.FC<ValueProgressProps> = ({
       onLayout={(event) => {
         const width = event.nativeEvent.layout.width;
         setSvgContainerWidth(width);
-        onWidth?.(width);
+        onFullPathWidth?.(width);
       }}
       style={[
         {

--- a/packages/core/src/components/Progress/LinearProgress/LinearProgress.tsx
+++ b/packages/core/src/components/Progress/LinearProgress/LinearProgress.tsx
@@ -37,6 +37,7 @@ export const LinearProgress: React.FC<ValueProgressProps> = ({
   trackCustomDashArray,
   onFullPathWidth,
   style,
+  testID,
 }) => {
   const [svgContainerWidth, setSvgContainerWidth] = React.useState(0);
 
@@ -88,6 +89,7 @@ export const LinearProgress: React.FC<ValueProgressProps> = ({
 
   return (
     <Svg
+      testID={testID}
       onLayout={(event) => {
         const width = event.nativeEvent.layout.width;
         setSvgContainerWidth(width);

--- a/packages/core/src/components/Progress/LinearProgress/LinearProgress.tsx
+++ b/packages/core/src/components/Progress/LinearProgress/LinearProgress.tsx
@@ -1,50 +1,19 @@
 import React from "react";
-import { StyleProp, ViewStyle } from "react-native";
 import Svg, { Line, LineProps } from "react-native-svg";
-import { withTheme } from "../../theming";
-import { Theme } from "../../styles/DefaultTheme";
 import Animated, {
   useAnimatedProps,
   useSharedValue,
   withTiming,
 } from "react-native-reanimated";
-
-type LineCap = "round" | "square";
-
-interface LinearProgressProps {
-  value: number;
-  minimumValue?: number;
-  maximumValue?: number;
-  initialValueToAnimateFrom?: number;
-  thickness?: number;
-  trackThickness?: number;
-  color?: string;
-  trackColor?: string;
-  trackOpacity?: number;
-  showTrack?: boolean;
-  animationDuration?: number;
-  isAnimated?: boolean;
-  lineCap?: LineCap;
-  trackLineCap?: LineCap;
-  dashWidth?: string | number;
-  trackDashWidth?: string | number;
-  dashGap?: string | number;
-  trackDashGap?: string | number;
-  dashOffset?: string | number;
-  trackDashOffset?: string | number;
-  customDashArray?: string;
-  trackCustomDashArray?: string;
-  style?: StyleProp<ViewStyle>;
-  theme: Theme;
-}
+import { ValueProgressProps } from "../ProgressCommon";
 
 const AnimatedLine = Animated.createAnimatedComponent(Line);
 
-const LinearProgress: React.FC<LinearProgressProps> = ({
+export const LinearProgress: React.FC<ValueProgressProps> = ({
   theme,
-  value,
   minimumValue = 0,
   maximumValue = 100,
+  value = minimumValue,
   initialValueToAnimateFrom = minimumValue,
   thickness = 10,
   trackThickness = thickness,
@@ -148,5 +117,3 @@ const LinearProgress: React.FC<LinearProgressProps> = ({
     </Svg>
   );
 };
-
-export default withTheme(LinearProgress);

--- a/packages/core/src/components/Progress/LinearProgress/index.tsx
+++ b/packages/core/src/components/Progress/LinearProgress/index.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import IndeterminateProgress from "../IndeterminateProgress";
+import {
+  IndeterminateProgressProps,
+  ValueProgressProps,
+} from "../ProgressCommon";
+import { LinearProgress as LinearProgressComponent } from "./LinearProgress";
+import Animated from "react-native-reanimated";
+import { withTheme } from "../../../theming";
+
+class LinearProgressClassWrapper extends React.Component<ValueProgressProps> {
+  render(): React.ReactNode {
+    return <LinearProgressComponent {...this.props} />;
+  }
+}
+
+const AnimatedLinearProgress = Animated.createAnimatedComponent(
+  LinearProgressClassWrapper
+);
+
+const LinearProgress: React.FC<
+  ValueProgressProps & IndeterminateProgressProps
+> = (props) => {
+  if (props.indeterminate) {
+    return (
+      <IndeterminateProgress
+        AnimatedProgressComponent={AnimatedLinearProgress}
+        {...props}
+      />
+    );
+  } else {
+    return <LinearProgressComponent {...props} />;
+  }
+};
+
+export default withTheme(LinearProgress);

--- a/packages/core/src/components/Progress/LinearProgress/index.tsx
+++ b/packages/core/src/components/Progress/LinearProgress/index.tsx
@@ -5,18 +5,7 @@ import {
   ValueProgressProps,
 } from "../ProgressCommon";
 import { LinearProgress as LinearProgressComponent } from "./LinearProgress";
-import Animated from "react-native-reanimated";
 import { withTheme } from "../../../theming";
-
-class LinearProgressClassWrapper extends React.Component<ValueProgressProps> {
-  render(): React.ReactNode {
-    return <LinearProgressComponent {...this.props} />;
-  }
-}
-
-const AnimatedLinearProgress = Animated.createAnimatedComponent(
-  LinearProgressClassWrapper
-);
 
 const LinearProgress: React.FC<
   ValueProgressProps & IndeterminateProgressProps
@@ -24,7 +13,7 @@ const LinearProgress: React.FC<
   if (props.indeterminate) {
     return (
       <IndeterminateProgress
-        AnimatedProgressComponent={AnimatedLinearProgress}
+        ProgressComponent={LinearProgressComponent}
         {...props}
       />
     );

--- a/packages/core/src/components/Progress/ProgressCommon.ts
+++ b/packages/core/src/components/Progress/ProgressCommon.ts
@@ -1,0 +1,37 @@
+import { StyleProp, ViewStyle } from "react-native";
+import { Theme } from "../../styles/DefaultTheme";
+
+type LineCap = "round" | "square";
+
+export interface BaseProgressProps {
+  thickness?: number;
+  trackThickness?: number;
+  color?: string;
+  trackColor?: string;
+  trackOpacity?: number;
+  showTrack?: boolean;
+  animationDuration?: number;
+  isAnimated?: boolean;
+  lineCap?: LineCap;
+  trackLineCap?: LineCap;
+  dashWidth?: string | number;
+  trackDashWidth?: string | number;
+  dashGap?: string | number;
+  trackDashGap?: string | number;
+  dashOffset?: string | number;
+  trackDashOffset?: string | number;
+  customDashArray?: string;
+  trackCustomDashArray?: string;
+  style?: StyleProp<ViewStyle>;
+  theme: Theme;
+}
+export interface ValueProgressProps extends BaseProgressProps {
+  value?: number;
+  minimumValue?: number;
+  maximumValue?: number;
+  initialValueToAnimateFrom?: number;
+}
+
+export interface IndeterminateProgressProps extends BaseProgressProps {
+  indeterminate?: boolean;
+}

--- a/packages/core/src/components/Progress/ProgressCommon.ts
+++ b/packages/core/src/components/Progress/ProgressCommon.ts
@@ -3,6 +3,8 @@ import { Theme } from "../../styles/DefaultTheme";
 
 type LineCap = "round" | "square";
 
+export const DEFAULT_ANIMATION_DURATION = 500;
+
 export interface BaseProgressProps {
   thickness?: number;
   trackThickness?: number;
@@ -22,6 +24,7 @@ export interface BaseProgressProps {
   trackDashOffset?: string | number;
   customDashArray?: string;
   trackCustomDashArray?: string;
+  onWidth?: (width: number) => void;
   style?: StyleProp<ViewStyle>;
   theme: Theme;
 }

--- a/packages/core/src/components/Progress/ProgressCommon.ts
+++ b/packages/core/src/components/Progress/ProgressCommon.ts
@@ -24,7 +24,7 @@ export interface BaseProgressProps {
   trackDashOffset?: string | number;
   customDashArray?: string;
   trackCustomDashArray?: string;
-  onWidth?: (width: number) => void;
+  onFullPathWidth?: (width: number) => void;
   style?: StyleProp<ViewStyle>;
   theme: Theme;
 }
@@ -32,9 +32,12 @@ export interface ValueProgressProps extends BaseProgressProps {
   value?: number;
   minimumValue?: number;
   maximumValue?: number;
-  initialValueToAnimateFrom?: number;
 }
 
 export interface IndeterminateProgressProps extends BaseProgressProps {
   indeterminate?: boolean;
+}
+
+export interface CircularProgressProps {
+  startPosition?: "left" | "top" | "right" | "bottom";
 }

--- a/packages/core/src/components/Progress/ProgressCommon.ts
+++ b/packages/core/src/components/Progress/ProgressCommon.ts
@@ -27,6 +27,7 @@ export interface BaseProgressProps {
   onFullPathWidth?: (width: number) => void;
   style?: StyleProp<ViewStyle>;
   theme: Theme;
+  testID?: string;
 }
 export interface ValueProgressProps extends BaseProgressProps {
   value?: number;

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -50,6 +50,7 @@ export { default as DatePicker } from "./components/DatePicker/DatePicker";
 export { default as Picker } from "./components/Picker/Picker";
 export { default as Slider } from "./components/Slider";
 export { default as Stepper } from "./components/Stepper";
+export { default as LinearProgress } from "./components/Progress/LinearProgress";
 export { SectionList, SectionHeader } from "./components/SectionList";
 
 /* Deprecated: Fix or Delete!  */

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -51,6 +51,7 @@ export { default as Picker } from "./components/Picker/Picker";
 export { default as Slider } from "./components/Slider";
 export { default as Stepper } from "./components/Stepper";
 export { default as LinearProgress } from "./components/Progress/LinearProgress";
+export { default as CircularProgress } from "./components/Progress/CircularProgress";
 export { SectionList, SectionHeader } from "./components/SectionList";
 
 /* Deprecated: Fix or Delete!  */

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -50,6 +50,7 @@ export {
   ActionSheetCancel,
   Swiper,
   SwiperItem,
+  LinearProgress,
   SectionList,
   SectionHeader,
 } from "@draftbit/core";

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -51,6 +51,7 @@ export {
   Swiper,
   SwiperItem,
   LinearProgress,
+  CircularProgress,
   SectionList,
   SectionHeader,
 } from "@draftbit/core";

--- a/yarn.lock
+++ b/yarn.lock
@@ -3727,6 +3727,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-test-renderer@^18.0.0":
+  version "18.0.0"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-18.0.0.tgz#7b7f69ca98821ea5501b21ba24ea7b6139da2243"
+  integrity sha512-C7/5FBJ3g3sqUahguGi03O79b8afNeSD6T8/GU50oQrJCU0bVCCGQHaGKUbg2Ce8VQEEqTw8/HiS6lXHHdgkdQ==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-transition-group@^4.2.0":
   version "4.4.5"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.5.tgz#aae20dcf773c5aa275d5b9f7cdbca638abc5e416"


### PR DESCRIPTION
- Add `LinearProgress` and `CircularProgress`


https://github.com/draftbit/react-native-jigsaw/assets/58384527/5652030b-c7d8-474d-81a0-db7e1d26b023


https://github.com/draftbit/react-native-jigsaw/assets/58384527/f1894d02-cee4-4e92-b506-2cc1cf0f8a08

