### PR TITLE
Fix progress indicator issues on Snack

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@draftbit/example",
   "description": "Example app for @draftbit/ui",
-  "version": "48.2.0",
+  "version": "48.2.1",
   "private": true,
   "main": "__generated__/AppEntry.js",
   "scripts": {
@@ -16,8 +16,8 @@
     "clean:modules": "rimraf node_modules"
   },
   "dependencies": {
-    "@draftbit/maps": "48.2.0",
-    "@draftbit/ui": "48.2.0",
+    "@draftbit/maps": "48.2.1",
+    "@draftbit/ui": "48.2.1",
     "@expo/dev-server": "0.1.123",
     "@expo/webpack-config": "^18.0.1",
     "@react-navigation/drawer": "^5.12.9",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "48.2.0",
+  "version": "48.2.1",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "packages": ["packages/*", "example"],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draftbit/core",
-  "version": "48.2.0",
+  "version": "48.2.1",
   "description": "Core (non-native) Components",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",
@@ -41,7 +41,7 @@
   "dependencies": {
     "@date-io/date-fns": "^1.3.13",
     "@draftbit/react-theme-provider": "^2.1.1",
-    "@draftbit/types": "48.2.0",
+    "@draftbit/types": "48.2.1",
     "@expo/vector-icons": "^13.0.0",
     "@material-ui/core": "^4.11.0",
     "@material-ui/pickers": "^3.2.10",

--- a/packages/core/src/components/Progress/CircularProgress/CircularProgress.tsx
+++ b/packages/core/src/components/Progress/CircularProgress/CircularProgress.tsx
@@ -153,6 +153,7 @@ export const CircularProgress: React.FC<
           strokeLinecap={lineCap}
           strokeDasharray={customDashArray || dashArray}
           strokeDashoffset={dashOffset}
+          onPress={() => {}} //Addresses reanimated issue with SVG (https://github.com/software-mansion/react-native-reanimated/issues/3321#issuecomment-1256983430)
         />
       </Svg>
     </View>

--- a/packages/core/src/components/Progress/CircularProgress/CircularProgress.tsx
+++ b/packages/core/src/components/Progress/CircularProgress/CircularProgress.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Svg, { Path, PathProps } from "react-native-svg";
+import { View } from "react-native";
 import Animated, {
   useAnimatedProps,
   useSharedValue,
@@ -115,8 +116,7 @@ export const CircularProgress: React.FC<
   }, [circumfrence, onFullPathWidth]);
 
   return (
-    <Svg
-      testID={testID ?? "circular-progress-component"}
+    <View
       onLayout={(event) => {
         const width = event.nativeEvent.layout.width;
         setSvgContainerWidth(width);
@@ -128,32 +128,34 @@ export const CircularProgress: React.FC<
         style,
       ]}
     >
-      {showTrack && (
-        <Path
-          d={circlePath(
-            radius,
-            radius,
-            radius - thicknessOffset,
-            startAngle,
-            startAngle + 360
-          )}
-          stroke={trackColor}
-          strokeWidth={trackThickness}
-          strokeOpacity={trackOpacity}
-          strokeLinecap={trackLineCap}
-          strokeDasharray={trackCustomDashArray || trackDashArray}
-          strokeDashoffset={trackDashOffset}
+      <Svg testID={testID ?? "circular-progress-component"} style={{ flex: 1 }}>
+        {showTrack && (
+          <Path
+            d={circlePath(
+              radius,
+              radius,
+              radius - thicknessOffset,
+              startAngle,
+              startAngle + 360
+            )}
+            stroke={trackColor}
+            strokeWidth={trackThickness}
+            strokeOpacity={trackOpacity}
+            strokeLinecap={trackLineCap}
+            strokeDasharray={trackCustomDashArray || trackDashArray}
+            strokeDashoffset={trackDashOffset}
+          />
+        )}
+        <AnimatedPath
+          animatedProps={progressPathAnimatedProps}
+          stroke={color}
+          strokeWidth={thickness}
+          strokeLinecap={lineCap}
+          strokeDasharray={customDashArray || dashArray}
+          strokeDashoffset={dashOffset}
         />
-      )}
-      <AnimatedPath
-        animatedProps={progressPathAnimatedProps}
-        stroke={color}
-        strokeWidth={thickness}
-        strokeLinecap={lineCap}
-        strokeDasharray={customDashArray || dashArray}
-        strokeDashoffset={dashOffset}
-      />
-    </Svg>
+      </Svg>
+    </View>
   );
 };
 

--- a/packages/core/src/components/Progress/LinearProgress/LinearProgress.tsx
+++ b/packages/core/src/components/Progress/LinearProgress/LinearProgress.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Svg, { Line, LineProps } from "react-native-svg";
+import { View } from "react-native";
 import Animated, {
   useAnimatedProps,
   useSharedValue,
@@ -88,8 +89,7 @@ export const LinearProgress: React.FC<ValueProgressProps> = ({
   ]);
 
   return (
-    <Svg
-      testID={testID ?? "linear-progress-component"}
+    <View
       onLayout={(event) => {
         const width = event.nativeEvent.layout.width;
         setSvgContainerWidth(width);
@@ -102,31 +102,33 @@ export const LinearProgress: React.FC<ValueProgressProps> = ({
         style,
       ]}
     >
-      {showTrack && (
-        <Line
+      <Svg testID={testID ?? "linear-progress-component"} style={{ flex: 1 }}>
+        {showTrack && (
+          <Line
+            x1={thicknessOffset}
+            y1={thicknessOffset}
+            x2={trackProgressLineWidth}
+            y2={thicknessOffset}
+            stroke={trackColor}
+            strokeWidth={trackThickness}
+            strokeOpacity={trackOpacity}
+            strokeLinecap={trackLineCap}
+            strokeDasharray={trackCustomDashArray || trackDashArray}
+            strokeDashoffset={trackDashOffset}
+          />
+        )}
+        <AnimatedLine
+          animatedProps={progressLineAnimatedProps}
           x1={thicknessOffset}
           y1={thicknessOffset}
-          x2={trackProgressLineWidth}
           y2={thicknessOffset}
-          stroke={trackColor}
-          strokeWidth={trackThickness}
-          strokeOpacity={trackOpacity}
-          strokeLinecap={trackLineCap}
-          strokeDasharray={trackCustomDashArray || trackDashArray}
-          strokeDashoffset={trackDashOffset}
+          stroke={color}
+          strokeWidth={thickness}
+          strokeLinecap={lineCap}
+          strokeDasharray={customDashArray || dashArray}
+          strokeDashoffset={dashOffset}
         />
-      )}
-      <AnimatedLine
-        animatedProps={progressLineAnimatedProps}
-        x1={thicknessOffset}
-        y1={thicknessOffset}
-        y2={thicknessOffset}
-        stroke={color}
-        strokeWidth={thickness}
-        strokeLinecap={lineCap}
-        strokeDasharray={customDashArray || dashArray}
-        strokeDashoffset={dashOffset}
-      />
-    </Svg>
+      </Svg>
+    </View>
   );
 };

--- a/packages/core/src/components/Progress/LinearProgress/LinearProgress.tsx
+++ b/packages/core/src/components/Progress/LinearProgress/LinearProgress.tsx
@@ -127,6 +127,7 @@ export const LinearProgress: React.FC<ValueProgressProps> = ({
           strokeLinecap={lineCap}
           strokeDasharray={customDashArray || dashArray}
           strokeDashoffset={dashOffset}
+          onPress={() => {}} //Addresses reanimated issue with SVG (https://github.com/software-mansion/react-native-reanimated/issues/3321#issuecomment-1256983430)
         />
       </Svg>
     </View>

--- a/packages/maps/package.json
+++ b/packages/maps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draftbit/maps",
-  "version": "48.2.0",
+  "version": "48.2.1",
   "description": "Map Components",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draftbit/native",
-  "version": "48.2.0",
+  "version": "48.2.1",
   "description": "Draftbit UI Components that Depend on Native Components",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/draftbit/react-native-jigsaw#readme",
   "dependencies": {
-    "@draftbit/types": "48.2.0",
+    "@draftbit/types": "48.2.1",
     "@expo/vector-icons": "^13.0.0",
     "@react-native-community/datetimepicker": "6.3.5",
     "@react-native-community/slider": "4.4.2",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draftbit/types",
-  "version": "48.2.0",
+  "version": "48.2.1",
   "description": "Shared constants and types between native and core components",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draftbit/ui",
-  "version": "48.2.0",
+  "version": "48.2.1",
   "description": "Draftbit UI Library",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",
@@ -43,8 +43,8 @@
   },
   "homepage": "https://github.com/draftbit/react-native-jigsaw#readme",
   "dependencies": {
-    "@draftbit/core": "48.2.0",
-    "@draftbit/native": "48.2.0"
+    "@draftbit/core": "48.2.1",
+    "@draftbit/native": "48.2.1"
   },
   "eslintIgnore": [
     "node_modules/",


### PR DESCRIPTION
Fixes issues where progress indicators did not work on snack
- Wrapped in `View` to fix `onLayout` not being called on `Svg`
- Added empty `onPress` to to fix reanimated issue with SVG https://github.com/software-mansion/react-native-reanimated/issues/3321#issuecomment-1256983430