### PR TITLE
Multiple minor changes

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@draftbit/example",
   "description": "Example app for @draftbit/ui",
-  "version": "48.2.2",
+  "version": "48.2.3",
   "private": true,
   "main": "__generated__/AppEntry.js",
   "scripts": {
@@ -16,8 +16,8 @@
     "clean:modules": "rimraf node_modules"
   },
   "dependencies": {
-    "@draftbit/maps": "48.2.2",
-    "@draftbit/ui": "48.2.2",
+    "@draftbit/maps": "48.2.3",
+    "@draftbit/ui": "48.2.3",
     "@expo/dev-server": "0.1.123",
     "@expo/webpack-config": "^18.0.1",
     "@react-navigation/drawer": "^5.12.9",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "48.2.2",
+  "version": "48.2.3",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "packages": ["packages/*", "example"],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draftbit/core",
-  "version": "48.2.2",
+  "version": "48.2.3",
   "description": "Core (non-native) Components",
   "main": "lib/commonjs/index.js",
   "types": "lib/typescript/src/index.d.ts",
@@ -41,7 +41,7 @@
   "dependencies": {
     "@date-io/date-fns": "^1.3.13",
     "@draftbit/react-theme-provider": "^2.1.1",
-    "@draftbit/types": "48.2.2",
+    "@draftbit/types": "48.2.3",
     "@expo/vector-icons": "^13.0.0",
     "@material-ui/core": "^4.11.0",
     "@material-ui/pickers": "^3.2.10",

--- a/packages/core/src/__tests__/components/AudioPlayer.test.tsx
+++ b/packages/core/src/__tests__/components/AudioPlayer.test.tsx
@@ -153,6 +153,30 @@ describe("AudioPlayer tests", () => {
     expect(mockPauseAsync).toBeCalled();
   });
 
+  test("should play() play the audio", async () => {
+    const ref = React.createRef<AudioPlayerRef>();
+
+    render(<AudioPlayer ref={ref} source={mockAudioSource} />);
+
+    await act(async () => {
+      await waitForSoundToLoad();
+      ref.current?.play();
+    });
+    expect(mockPlayAsync).toBeCalled();
+  });
+
+  test("should pause() pause the audio", async () => {
+    const ref = React.createRef<AudioPlayerRef>();
+
+    render(<AudioPlayer ref={ref} source={mockAudioSource} />);
+
+    await act(async () => {
+      await waitForSoundToLoad();
+      ref.current?.pause();
+    });
+    expect(mockPauseAsync).toBeCalled();
+  });
+
   test("should audio be cleaned up/unloaded when unmounting", async () => {
     render(<AudioPlayer source={mockAudioSource} />);
 

--- a/packages/core/src/__tests__/components/VideoPlayer.test.tsx
+++ b/packages/core/src/__tests__/components/VideoPlayer.test.tsx
@@ -70,6 +70,42 @@ describe("VideoPlayer tests", () => {
     expect(mockPauseAsync).toBeCalled();
   });
 
+  test("should play() play the video", async () => {
+    const ref = React.createRef<VideoPlayerRef>();
+
+    render(
+      <VideoPlayer
+        ref={ref}
+        source={{
+          uri: "video-uri",
+        }}
+      />
+    );
+
+    act(() => {
+      ref.current?.play();
+    });
+    expect(mockPlayAsync).toBeCalled();
+  });
+
+  test("should pause() pause the video", async () => {
+    const ref = React.createRef<VideoPlayerRef>();
+
+    render(
+      <VideoPlayer
+        ref={ref}
+        source={{
+          uri: "video-uri",
+        }}
+      />
+    );
+
+    act(() => {
+      ref.current?.pause();
+    });
+    expect(mockPauseAsync).toBeCalled();
+  });
+
   test("should video be cleaned up/unloaded when unmounting", async () => {
     render(
       <VideoPlayer

--- a/packages/core/src/components/MediaPlayer/MediaPlaybackWrapper.tsx
+++ b/packages/core/src/components/MediaPlayer/MediaPlaybackWrapper.tsx
@@ -26,6 +26,16 @@ const MediaPlaybackWrapper = React.forwardRef<
     }
   }, [media, isPlaying, onTogglePlayback]);
 
+  const pause = React.useCallback(async () => {
+    onTogglePlayback?.();
+    await media?.pauseAsync();
+  }, [media, onTogglePlayback]);
+
+  const play = React.useCallback(async () => {
+    onTogglePlayback?.();
+    await media?.playAsync();
+  }, [media, onTogglePlayback]);
+
   const seekToPosition = React.useCallback(
     async (positionMillis: number) => {
       await media?.setPositionAsync(positionMillis);
@@ -46,8 +56,10 @@ const MediaPlaybackWrapper = React.forwardRef<
     () => ({
       seekToPosition,
       togglePlayback,
+      pause,
+      play,
     }),
-    [seekToPosition, togglePlayback]
+    [seekToPosition, togglePlayback, pause, play]
   );
 
   return <>{children}</>;

--- a/packages/core/src/components/MediaPlayer/MediaPlayerCommon.ts
+++ b/packages/core/src/components/MediaPlayer/MediaPlayerCommon.ts
@@ -14,6 +14,8 @@ export interface MediaPlayerStatus {
 export interface MediaPlayerRef {
   seekToPosition: (positionMillis: number) => void;
   togglePlayback: () => void;
+  pause: () => void;
+  play: () => void;
 }
 
 export interface MediaPlayerProps {

--- a/packages/core/src/components/MediaPlayer/VideoPlayer/VideoPlayer.tsx
+++ b/packages/core/src/components/MediaPlayer/VideoPlayer/VideoPlayer.tsx
@@ -105,6 +105,8 @@ const VideoPlayer = React.forwardRef<VideoPlayerRef, VideoPlayerProps>(
           mediaPlaybackWrapperRef.current?.seekToPosition || (() => {}),
         togglePlayback:
           mediaPlaybackWrapperRef.current?.togglePlayback || (() => {}),
+        pause: mediaPlaybackWrapperRef.current?.pause || (() => {}),
+        play: mediaPlaybackWrapperRef.current?.play || (() => {}),
       }),
       // Include 'isPlaying' as dependency because 'togglePlayback' changes when it changes
       // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/core/src/components/SectionList/SectionList.tsx
+++ b/packages/core/src/components/SectionList/SectionList.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { FlashListProps, FlashList } from "@shopify/flash-list";
 import { FlatListProps, FlatList } from "react-native";
 import SectionHeader, { DefaultSectionHeader } from "./SectionHeader";
+import { extractIfNestedInFragment } from "../../utilities";
 
 type ListComponentType = "FlatList" | "FlashList";
 
@@ -88,9 +89,10 @@ const SectionList = <T extends { [key: string]: any }>({
     }
 
     const props = element.props || {};
-    const children = React.Children.toArray(props.children).map(
-      (child) => child as React.ReactElement
+    const children = React.Children.toArray(props.children).map((child) =>
+      extractIfNestedInFragment(child as React.ReactElement)
     );
+
     if (element.type === SectionHeader) {
       return element;
     } else {

--- a/packages/core/src/components/SwipeableItem/SwipeableItem.tsx
+++ b/packages/core/src/components/SwipeableItem/SwipeableItem.tsx
@@ -12,6 +12,7 @@ import {
   extractBorderAndMarginStyles,
   extractEffectStyles,
   extractFlexItemStyles,
+  extractIfNestedInFragment,
   extractPositionStyles,
   extractSizeStyles,
   extractStyles,
@@ -74,7 +75,7 @@ type Props = SwipeableItemProps & RightSwipeProps & LeftSwipeProps;
 const SwipeableItem: React.FC<React.PropsWithChildren<Props>> = ({
   theme,
   style,
-  children,
+  children: childrenProp,
   Icon,
   closeOnPress,
   leftOpenValue,
@@ -124,9 +125,18 @@ const SwipeableItem: React.FC<React.PropsWithChildren<Props>> = ({
   const [componentWidth, setComponentWidth] = React.useState<number | null>(
     null
   );
+
+  const children: React.ReactNode[] = React.useMemo(
+    () =>
+      React.Children.toArray(childrenProp).map((child) =>
+        extractIfNestedInFragment(child as React.ReactElement)
+      ),
+    [childrenProp]
+  );
+
   const leftSwipeButtons = React.useMemo(
     () =>
-      React.Children.toArray(children).filter(
+      children.filter(
         (child) =>
           React.isValidElement(child) &&
           child.type === SwipeableItemButton &&
@@ -137,7 +147,7 @@ const SwipeableItem: React.FC<React.PropsWithChildren<Props>> = ({
 
   const rightSwipeButtons = React.useMemo(
     () =>
-      React.Children.toArray(children).filter(
+      children.filter(
         (child) =>
           React.isValidElement(child) &&
           child.type === SwipeableItemButton &&

--- a/packages/core/src/components/TabView/TabView.tsx
+++ b/packages/core/src/components/TabView/TabView.tsx
@@ -12,7 +12,7 @@ import TabViewItem from "./TabViewItem";
 import type { IconSlot } from "../../interfaces/Icon";
 import { withTheme } from "../../theming";
 import type { Theme } from "../../styles/DefaultTheme";
-import { extractStyles } from "../../utilities";
+import { extractIfNestedInFragment, extractStyles } from "../../utilities";
 
 type SceneProps = SceneRendererProps & {
   route: Route;
@@ -54,7 +54,7 @@ const TabViewComponent: React.FC<React.PropsWithChildren<TabViewProps>> = ({
   tabsBackgroundColor,
   style,
   theme,
-  children,
+  children: childrenProp,
 }) => {
   const [index, setIndex] = React.useState(0);
   const [routes, setRoutes] = React.useState<Route[]>([]);
@@ -62,12 +62,20 @@ const TabViewComponent: React.FC<React.PropsWithChildren<TabViewProps>> = ({
 
   const { textStyles, viewStyles } = extractStyles(style);
 
+  const children: React.ReactNode[] = React.useMemo(
+    () =>
+      React.Children.toArray(childrenProp).map((child) =>
+        extractIfNestedInFragment(child as React.ReactElement)
+      ),
+    [childrenProp]
+  );
+
   //Populate routes and scenes based on children
   React.useEffect(() => {
     const newRoutes: Route[] = [];
     const scenes: { [key: string]: React.ReactElement } = {};
 
-    React.Children.toArray(children)
+    children
       .filter(
         (child) => React.isValidElement(child) && child.type === TabViewItem
       )

--- a/packages/core/src/components/TabView/TabView.tsx
+++ b/packages/core/src/components/TabView/TabView.tsx
@@ -26,6 +26,7 @@ type KeyboardDismissMode = "none" | "auto" | "on-drag";
 type TabViewProps = {
   onIndexChanged?: (index: number) => void;
   onEndReached?: () => void;
+  initialTabIndex?: number;
   tabBarPosition?: TabBarPosition;
   keyboardDismissMode?: KeyboardDismissMode;
   swipeEnabled?: boolean;
@@ -43,6 +44,7 @@ const TabViewComponent: React.FC<React.PropsWithChildren<TabViewProps>> = ({
   Icon,
   onIndexChanged,
   onEndReached,
+  initialTabIndex = 0,
   tabBarPosition,
   keyboardDismissMode,
   swipeEnabled,
@@ -56,7 +58,7 @@ const TabViewComponent: React.FC<React.PropsWithChildren<TabViewProps>> = ({
   theme,
   children: childrenProp,
 }) => {
-  const [index, setIndex] = React.useState(0);
+  const [index, setIndex] = React.useState(initialTabIndex);
   const [routes, setRoutes] = React.useState<Route[]>([]);
   const [tabScenes, setTabScenes] = React.useState<{ [key: string]: any }>({});
 

--- a/packages/core/src/utilities.ts
+++ b/packages/core/src/utilities.ts
@@ -1,3 +1,4 @@
+import React from "react";
 import { StyleSheet, StyleProp, TextStyle } from "react-native";
 import { isString, isNumber, pick, pickBy, identity } from "lodash";
 
@@ -227,4 +228,20 @@ export function getValueForRadioButton(value: string | number) {
   } else {
     throw new Error(`Invalid value: ${value}`);
   }
+}
+
+export function extractIfNestedInFragment(
+  component: React.ReactElement
+): React.ReactElement {
+  if (component.type === React.Fragment) {
+    const children = React.Children.toArray(
+      (component.props as any)?.children
+    ) as React.ReactElement[];
+
+    if (children.length === 1) {
+      return children[0];
+    }
+  }
+
+  return component;
 }

--- a/packages/core/src/utilities.ts
+++ b/packages/core/src/utilities.ts
@@ -230,6 +230,8 @@ export function getValueForRadioButton(value: string | number) {
   }
 }
 
+// This is done to ensure that operations that depend on a particular child type still work even when wrapped in a react fragment (ex: .type checks or prop extraction of child)
+// Wrapping in a fragment can happen in Draftbit when a component is wrapped in a conditional for example or inside a Fetch component
 export function extractIfNestedInFragment(
   component: React.ReactElement
 ): React.ReactElement {

--- a/packages/maps/package.json
+++ b/packages/maps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draftbit/maps",
-  "version": "48.2.2",
+  "version": "48.2.3",
   "description": "Map Components",
   "main": "lib/commonjs/index.js",
   "types": "lib/typescript/src/index.d.ts",

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draftbit/native",
-  "version": "48.2.2",
+  "version": "48.2.3",
   "description": "Draftbit UI Components that Depend on Native Components",
   "main": "lib/commonjs/index.js",
   "types": "lib/typescript/src/index.d.ts",
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/draftbit/react-native-jigsaw#readme",
   "dependencies": {
-    "@draftbit/types": "48.2.2",
+    "@draftbit/types": "48.2.3",
     "@expo/vector-icons": "^13.0.0",
     "@react-native-community/datetimepicker": "6.3.5",
     "@react-native-community/slider": "4.4.2",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draftbit/types",
-  "version": "48.2.2",
+  "version": "48.2.3",
   "description": "Shared constants and types between native and core components",
   "main": "lib/commonjs/index.js",
   "types": "lib/typescript/src/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@draftbit/core": "48.2.2",
     "@draftbit/native": "48.2.2",
-    "react-native-reanimated": "~2.12.0"
+    "react-native-reanimated": "~2.14.4"
   },
   "eslintIgnore": [
     "node_modules/",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draftbit/ui",
-  "version": "48.2.2",
+  "version": "48.2.3",
   "description": "Draftbit UI Library",
   "main": "lib/commonjs/index.js",
   "types": "lib/typescript/src/index.d.ts",
@@ -43,8 +43,8 @@
   },
   "homepage": "https://github.com/draftbit/react-native-jigsaw#readme",
   "dependencies": {
-    "@draftbit/core": "48.2.2",
-    "@draftbit/native": "48.2.2",
+    "@draftbit/core": "48.2.3",
+    "@draftbit/native": "48.2.3",
     "react-native-reanimated": "~2.14.4"
   },
   "eslintIgnore": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3974,11 +3974,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/invariant@^2.2.35":
-  version "2.2.35"
-  resolved "https://registry.yarnpkg.com/@types/invariant/-/invariant-2.2.35.tgz#cd3ebf581a6557452735688d8daba6cf0bd5a3be"
-  integrity sha512-DxX1V9P8zdJPYQat1gHyY0xj3efl8gnMVjiM9iCY6y27lj+PoQWkgjt8jDqmovPqULkKVpKRg8J36iQiA+EtEg==
-
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz#8467d4b3c087805d63580480890791277ce35c44"
@@ -15386,19 +15381,6 @@ react-native-pager-view@6.1.2:
   version "6.1.2"
   resolved "https://registry.yarnpkg.com/react-native-pager-view/-/react-native-pager-view-6.1.2.tgz#3522079b9a9d6634ca5e8d153bc0b4d660254552"
   integrity sha512-qs2KSFc+7N7B+UZ6SG2sTvCkppagm5fVyRclv1KFKc7lDtrhXLzN59tXJw575LDP/dRJoXsNwqUAhZJdws6ABQ==
-
-react-native-reanimated@~2.12.0:
-  version "2.12.0"
-  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.12.0.tgz#5821eecfb1769b1617a67a2d4dec12fdeedb2b6e"
-  integrity sha512-nrlPyw+Hx9u4iJhZk9PoTvDo/QmVAd+bo7OK9Tv3hveNEF9++5oig/g3Uv9V93shy9avTYGsUprUvAEt/xdzeQ==
-  dependencies:
-    "@babel/plugin-transform-object-assign" "^7.16.7"
-    "@babel/preset-typescript" "^7.16.7"
-    "@types/invariant" "^2.2.35"
-    invariant "^2.2.4"
-    lodash.isequal "^4.5.0"
-    setimmediate "^1.0.5"
-    string-hash-64 "^1.0.3"
 
 react-native-reanimated@~2.14.4:
   version "2.14.4"


### PR DESCRIPTION
- Add `pause` and `play` methods/actions to AudioPlayer and VideoPlayer
- Extract children of components when nested in `<></>` to ensure that the `.type` still works even when nested in a react fragment. This can happen in Draftbit when wrapped in a conditional for example.
- Added `initialTabIndex` prop to tab view

Closes https://linear.app/draftbit/issue/P-3697/audio-and-video-players
Closes https://linear.app/draftbit/issue/P-3694/not-able-to-hide-unhide-tabview-tab
Closes https://linear.app/draftbit/issue/P-3692/action-to-change-active-index-of-tab-view