### PR TITLE
Map Marker Clustering (47)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,11 @@ jobs:
       - name: Lint
         run: yarn lint
 
-      - name: Test
-        run: yarn test
-
       - name: Build
         run: yarn build
+
+      - name: Test
+        run: yarn test
 
       - name: Release next packages
         if: github.event_name == 'pull_request'

--- a/example/src/MapViewExample.js
+++ b/example/src/MapViewExample.js
@@ -1,7 +1,14 @@
 import React from "react";
-import { MapView, MapMarker, MapCallout } from "@draftbit/maps";
+import {
+  MapView,
+  MapMarker,
+  MapCallout,
+  MapMarkerCluster,
+  MapMarkerView,
+} from "@draftbit/maps";
 import { ButtonSolid, withTheme } from "@draftbit/ui";
 import { StyleSheet, Text, View } from "react-native";
+import { MapMarkerClusterView } from "@draftbit/maps";
 
 const MapViewExample = ({ theme }) => {
   const mapRef = React.createRef();
@@ -12,7 +19,8 @@ const MapViewExample = ({ theme }) => {
         ref={mapRef}
         showsCompass={true}
         style={styles.map}
-        latitude={40.741895}
+        latitude={43.741895}
+        autoClusterMarkers
         longitude={-73.989308}
         zoom={16}
       >
@@ -25,6 +33,23 @@ const MapViewExample = ({ theme }) => {
         />
         <MapMarker
           latitude={40.741895}
+          longitude={-73.979308}
+          pinColor={theme.colors.secondary}
+        >
+          <MapCallout showTooltip>
+            <Text>With Callout</Text>
+          </MapCallout>
+        </MapMarker>
+
+        <MapMarker
+          latitude={43.741895}
+          longitude={-73.989308}
+          pinColor={theme.colors.primary}
+          title="Draftbit"
+          description="A simple MapView example"
+        />
+        <MapMarker
+          latitude={43.741895}
           longitude={-73.979308}
           pinColor={theme.colors.secondary}
         >

--- a/packages/maps/package.json
+++ b/packages/maps/package.json
@@ -39,6 +39,7 @@
   },
   "homepage": "https://github.com/draftbit/react-native-jigsaw#readme",
   "dependencies": {
+    "@draftbit/ui": "48.2.3",
     "@teovilla/react-native-web-maps": "^0.9.1",
     "react-native-maps": "1.3.2"
   },

--- a/packages/maps/package.json
+++ b/packages/maps/package.json
@@ -48,13 +48,17 @@
     "lib/"
   ],
   "jest": {
-    "preset": "react-native",
+    "preset": "jest-expo",
     "setupFilesAfterEnv": [
       "@testing-library/jest-native/extend-expect"
     ],
     "testPathIgnorePatterns": [
       "lib",
       "__mocks__"
-    ]
+    ],
+    "transformIgnorePatterns": [
+      "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg)"
+    ],
+    "testEnvironment": "node"
   }
 }

--- a/packages/maps/package.json
+++ b/packages/maps/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/draftbit/react-native-jigsaw#readme",
   "dependencies": {
-    "@draftbit/ui": "48.2.3",
+    "@draftbit/ui": "47.5.3",
     "@teovilla/react-native-web-maps": "^0.9.1",
     "react-native-maps": "1.3.2"
   },

--- a/packages/maps/src/__tests__/MapMarker.test.tsx
+++ b/packages/maps/src/__tests__/MapMarker.test.tsx
@@ -1,0 +1,114 @@
+import React from "react";
+import { View } from "react-native";
+import { render, screen } from "@testing-library/react-native";
+import MapView from "../components/MapView";
+import MapMarker from "../components/MapMarker";
+import MapCallout from "../components/MapCallout";
+import { Callout as MapCalloutComponent } from "../components/react-native-maps";
+
+jest.mock("../components/react-native-maps", () => {
+  const React = require("react");
+
+  class MapView extends React.Component {
+    render(): React.ReactNode {
+      return <>{this.props.children}</>;
+    }
+  }
+
+  class Marker extends React.Component {
+    render(): React.ReactNode {
+      return <>{this.props.children}</>;
+    }
+  }
+
+  const Callout = (props: any) => {
+    return <>{props.children}</>;
+  };
+
+  return {
+    __esModule: true,
+    default: MapView,
+    Marker,
+    Callout,
+  };
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("MapMarker tests", () => {
+  test("should render default MapCallout when title and description provided", () => {
+    const title = "Title";
+    const description = "Some description";
+
+    render(
+      <MapView apiKey="">
+        <MapMarker
+          latitude={43.741895}
+          longitude={-73.989308}
+          title={title}
+          description={description}
+        />
+      </MapView>
+    );
+
+    const callout = screen.UNSAFE_queryByType(MapCalloutComponent);
+    const titleText = screen.queryByText(title);
+    const descriptionText = screen.queryByText(description);
+
+    expect(callout).toBeTruthy();
+    expect(titleText).toBeTruthy();
+    expect(descriptionText).toBeTruthy();
+  });
+
+  test("should render MapCallout children as a callout", () => {
+    render(
+      <MapView apiKey="">
+        <MapMarker latitude={43.741895} longitude={-73.989308}>
+          <MapCallout>
+            <View testID="callout-view" />
+          </MapCallout>
+        </MapMarker>
+      </MapView>
+    );
+
+    const callout = screen.UNSAFE_queryByType(MapCalloutComponent);
+    const calloutView = screen.queryByTestId("callout-view");
+
+    expect(callout).toBeTruthy();
+    expect(calloutView).toBeTruthy();
+  });
+
+  test("should render non MapCallout children as a custom marker", () => {
+    render(
+      <MapView apiKey="">
+        <MapMarker latitude={43.741895} longitude={-73.989308}>
+          <View testID="custom-marker" />
+        </MapMarker>
+      </MapView>
+    );
+
+    const callout = screen.UNSAFE_queryByType(MapCalloutComponent);
+    const customMarker = screen.queryByTestId("custom-marker");
+
+    expect(callout).toBeFalsy();
+    expect(customMarker).toBeTruthy();
+  });
+
+  test("should render Image as a custom marker when pinImage is provided", () => {
+    render(
+      <MapView apiKey="">
+        <MapMarker
+          latitude={43.741895}
+          longitude={-73.989308}
+          pinImage={"image"}
+        />
+      </MapView>
+    );
+
+    const markerPinImage = screen.queryByTestId("map-marker-pin-image");
+
+    expect(markerPinImage).toBeTruthy();
+  });
+});

--- a/packages/maps/src/__tests__/MapMarkerCluster.test.tsx
+++ b/packages/maps/src/__tests__/MapMarkerCluster.test.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+import { Text } from "react-native";
+import { render, screen } from "@testing-library/react-native";
+import MapMarker from "../components/MapMarker";
+import {
+  MapMarkerCluster,
+  MapMarkerClusterView,
+} from "../components/marker-cluster";
+import { Marker as MapMarkerComponent } from "../components/react-native-maps";
+
+jest.mock("../components/react-native-maps", () => {
+  const React = require("react");
+
+  class MapView extends React.Component {
+    render(): React.ReactNode {
+      return <>{this.props.children}</>;
+    }
+  }
+
+  const Marker = (props: any) => {
+    return <>{props.children}</>;
+  };
+
+  return {
+    __esModule: true,
+    default: MapView,
+    Marker,
+  };
+});
+
+jest.mock("@teovilla/react-native-web-maps", () => {
+  const React = require("react");
+
+  class MarkerClusterer extends React.Component {
+    render(): React.ReactNode {
+      return (
+        <>
+          {this.props.renderCluster?.({
+            pointCount: React.Children.toArray(this.props.children).length,
+            coordinate: { latitude: 0, longitude: 0 },
+            expansionZoom: 4,
+          })}
+          {this.props.children}
+        </>
+      );
+    }
+  }
+
+  return {
+    MarkerClusterer,
+  };
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("MapMarkerCluster tests", () => {
+  test("should render markers provided as children", () => {
+    render(
+      <MapMarkerCluster>
+        <MapMarker latitude={41.741895} longitude={-73.989308} />
+        <MapMarker latitude={42.741895} longitude={-73.989308} />
+        <MapMarker latitude={43.741895} longitude={-73.989308} />
+        <MapMarker latitude={44.741895} longitude={-73.989308} />
+      </MapMarkerCluster>
+    );
+
+    const renderedMarkers = screen.UNSAFE_queryAllByType(MapMarkerComponent);
+
+    expect(renderedMarkers.length).toBe(4 + 1); //4 clustered markers, cluster itself is also rendered as it's own marker (reasoning behind the +1)
+  });
+
+  test("should render default cluster view when none provided", () => {
+    render(
+      <MapMarkerCluster>
+        <MapMarker latitude={41.741895} longitude={-73.989308} />
+      </MapMarkerCluster>
+    );
+
+    const defaultClusterView = screen.queryByTestId(
+      "default-map-marker-cluster-view"
+    );
+
+    expect(defaultClusterView).toBeTruthy();
+  });
+
+  test("should render custom cluster view when provided", () => {
+    render(
+      <MapMarkerCluster>
+        <MapMarkerClusterView
+          renderItem={({ markerCount }) => (
+            <Text testID="custom-cluster-view">{markerCount}</Text>
+          )}
+        />
+        <MapMarker latitude={41.741895} longitude={-73.989308} />
+        <MapMarker latitude={42.741895} longitude={-73.989308} />
+        <MapMarker latitude={43.741895} longitude={-73.989308} />
+      </MapMarkerCluster>
+    );
+
+    const customClusterView = screen.queryByTestId("custom-cluster-view");
+
+    expect(customClusterView).toBeTruthy();
+    expect(customClusterView?.props).toMatchInlineSnapshot(`
+      {
+        "children": 3,
+        "testID": "custom-cluster-view",
+      }
+    `);
+  });
+});

--- a/packages/maps/src/__tests__/MapView.test.tsx
+++ b/packages/maps/src/__tests__/MapView.test.tsx
@@ -1,0 +1,282 @@
+import React from "react";
+import { act, render, screen } from "@testing-library/react-native";
+import MapView from "../components/MapView";
+import MapMarker from "../components/MapMarker";
+import { MapMarkerCluster } from "../components/marker-cluster";
+import { Marker as MapMarkerComponent } from "../components/react-native-maps";
+import { MarkerClusterer } from "@teovilla/react-native-web-maps";
+
+const mockAnimateCamera = jest.fn();
+
+jest.mock("../components/react-native-maps", () => {
+  const React = require("react");
+
+  class MapView extends React.Component {
+    render(): React.ReactNode {
+      return <>{this.props.children}</>;
+    }
+
+    animateCamera = mockAnimateCamera;
+  }
+
+  const Marker = (props: any) => {
+    return <>{props.children}</>;
+  };
+
+  return {
+    __esModule: true,
+    default: MapView,
+    Marker,
+  };
+});
+
+jest.mock("@teovilla/react-native-web-maps", () => {
+  const MarkerClusterer = (props: any) => {
+    return <>{props.children}</>;
+  };
+
+  return {
+    MarkerClusterer,
+  };
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("MapView tests", () => {
+  test("should animateToLocation update map location", () => {
+    const ref = React.createRef<MapView<any>>();
+
+    render(<MapView ref={ref} apiKey="" />);
+
+    act(() => {
+      ref.current?.animateToLocation({
+        latitude: 40.741895,
+        longitude: -73.989308,
+        zoom: 10,
+      });
+    });
+
+    expect(mockAnimateCamera.mock.lastCall).toMatchInlineSnapshot(`
+      [
+        {
+          "altitude": 86346.53718958268,
+          "center": {
+            "latitude": 40.741895,
+            "longitude": -73.989308,
+          },
+          "heading": 0,
+          "pitch": 0,
+          "zoom": 10,
+        },
+      ]
+    `);
+  });
+
+  test("should render markers provided as children", () => {
+    render(
+      <MapView apiKey="">
+        <MapMarker key={1} latitude={41.741895} longitude={-73.989308} />
+        <MapMarker key={2} latitude={42.741895} longitude={-73.989308} />
+        <MapMarker key={3} latitude={43.741895} longitude={-73.989308} />
+        <MapMarker key={4} latitude={44.741895} longitude={-73.989308} />
+      </MapView>
+    );
+
+    const renderedMarkers = screen
+      .UNSAFE_queryAllByType(MapMarkerComponent)
+      .map((marker) => marker.props.coordinate);
+
+    expect(renderedMarkers).toMatchInlineSnapshot(`
+      [
+        {
+          "latitude": 41.741895,
+          "longitude": -73.989308,
+        },
+        {
+          "latitude": 42.741895,
+          "longitude": -73.989308,
+        },
+        {
+          "latitude": 43.741895,
+          "longitude": -73.989308,
+        },
+        {
+          "latitude": 44.741895,
+          "longitude": -73.989308,
+        },
+      ]
+    `);
+  });
+
+  test("should render markers provided as data using renderItem", () => {
+    const markers = [
+      { latitude: 41.741895, longitude: -73.989308 },
+      { latitude: 42.741895, longitude: -73.989308 },
+      { latitude: 43.741895, longitude: -73.989308 },
+      { latitude: 44.741895, longitude: -73.989308 },
+    ];
+
+    render(
+      <MapView
+        markersData={markers}
+        renderItem={({ item }) => (
+          <MapMarker latitude={item.latitude} longitude={item.longitude} />
+        )}
+        apiKey=""
+      />
+    );
+
+    const renderedMarkers = screen
+      .UNSAFE_queryAllByType(MapMarkerComponent)
+      .map((marker) => marker.props.coordinate);
+
+    expect(renderedMarkers).toMatchInlineSnapshot(`
+      [
+        {
+          "latitude": 41.741895,
+          "longitude": -73.989308,
+        },
+        {
+          "latitude": 42.741895,
+          "longitude": -73.989308,
+        },
+        {
+          "latitude": 43.741895,
+          "longitude": -73.989308,
+        },
+        {
+          "latitude": 44.741895,
+          "longitude": -73.989308,
+        },
+      ]
+    `);
+  });
+
+  test("should render manually created marker clusters", () => {
+    render(
+      <MapView apiKey="">
+        <MapMarkerCluster>
+          <MapMarker latitude={41.741895} longitude={-73.989308} />
+          <MapMarker latitude={42.741895} longitude={-73.989308} />
+        </MapMarkerCluster>
+
+        <MapMarkerCluster>
+          <MapMarker latitude={43.741895} longitude={-73.989308} />
+          <MapMarker latitude={44.741895} longitude={-73.989308} />
+        </MapMarkerCluster>
+      </MapView>
+    );
+
+    const renderedClusters = screen
+      .UNSAFE_queryAllByType(MarkerClusterer)
+      .map((marker) => marker.props.children);
+
+    expect(renderedClusters).toMatchInlineSnapshot(`
+      [
+        [
+          <Marker
+            coordinate={
+              {
+                "latitude": 41.741895,
+                "longitude": -73.989308,
+              }
+            }
+            onPress={[Function]}
+          />,
+          <Marker
+            coordinate={
+              {
+                "latitude": 42.741895,
+                "longitude": -73.989308,
+              }
+            }
+            onPress={[Function]}
+          />,
+        ],
+        [
+          <Marker
+            coordinate={
+              {
+                "latitude": 43.741895,
+                "longitude": -73.989308,
+              }
+            }
+            onPress={[Function]}
+          />,
+          <Marker
+            coordinate={
+              {
+                "latitude": 44.741895,
+                "longitude": -73.989308,
+              }
+            }
+            onPress={[Function]}
+          />,
+        ],
+      ]
+    `);
+  });
+
+  test("should automatically create clusters from markers when autoClusterMarkers is true", () => {
+    render(
+      <MapView apiKey="" autoClusterMarkers>
+        <MapMarker latitude={40.741895} longitude={-73.989308} />
+        <MapMarker latitude={40.741895} longitude={-73.979308} />
+
+        <MapMarker latitude={43.741895} longitude={-73.989308} />
+        <MapMarker latitude={43.741895} longitude={-73.979308} />
+      </MapView>
+    );
+
+    const renderedClusters = screen
+      .UNSAFE_queryAllByType(MarkerClusterer)
+      .map((marker) => marker.props.children);
+
+    expect(renderedClusters).toMatchInlineSnapshot(`
+      [
+        [
+          <Marker
+            coordinate={
+              {
+                "latitude": 40.741895,
+                "longitude": -73.989308,
+              }
+            }
+            onPress={[Function]}
+          />,
+          <Marker
+            coordinate={
+              {
+                "latitude": 40.741895,
+                "longitude": -73.979308,
+              }
+            }
+            onPress={[Function]}
+          />,
+        ],
+        [
+          <Marker
+            coordinate={
+              {
+                "latitude": 43.741895,
+                "longitude": -73.989308,
+              }
+            }
+            onPress={[Function]}
+          />,
+          <Marker
+            coordinate={
+              {
+                "latitude": 43.741895,
+                "longitude": -73.979308,
+              }
+            }
+            onPress={[Function]}
+          />,
+        ],
+      ]
+    `);
+  });
+});

--- a/packages/maps/src/components/MapMarker.tsx
+++ b/packages/maps/src/components/MapMarker.tsx
@@ -24,6 +24,7 @@ export interface MapMarkerProps
  * Rendering exposed as function to avoid having an intermediary component that changes the type
  *
  * This is done because the underlying package has logic dependant on the type of child
+ * See: https://github.com/teovillanueva/react-native-web-maps/blob/5f3d0ec7c24f789c3df30c1d6d7223e638ff5868/packages/react-native-web-maps/src/components/marker-clusterer/marker-clusterer.tsx#L18
  */
 const MapMarker: React.FC<React.PropsWithChildren<MapMarkerProps>> = () => {
   return null;
@@ -41,7 +42,7 @@ export function renderMarker(
     description,
     ...rest
   }: MapMarkerProps,
-  key: React.Key
+  key?: React.Key
 ) {
   const childrenArray = React.Children.toArray(children);
 

--- a/packages/maps/src/components/MapMarker.tsx
+++ b/packages/maps/src/components/MapMarker.tsx
@@ -85,6 +85,7 @@ export function renderMarker(
 
       {pinImage && (
         <Image
+          testID="map-marker-pin-image"
           source={typeof pinImage === "string" ? { uri: pinImage } : pinImage}
           style={{
             height: pinImageSize,

--- a/packages/maps/src/components/MapView.tsx
+++ b/packages/maps/src/components/MapView.tsx
@@ -20,7 +20,7 @@ export interface MapViewProps<T>
   autoClusterMarkers?: boolean;
   autoClusterMarkersDistanceMeters?: number;
   markersData?: T[];
-  keyExtractor: (item: T, index: number) => string;
+  keyExtractor?: (item: T, index: number) => string;
   renderItem?: ({ item, index }: { item: T; index: number }) => JSX.Element;
   onRegionChange?: (region: Region) => void;
 }

--- a/packages/maps/src/components/MapViewCommon.ts
+++ b/packages/maps/src/components/MapViewCommon.ts
@@ -1,0 +1,16 @@
+import React from "react";
+import { LatLng, Region } from "react-native-maps";
+
+export type ZoomLocation = LatLng & {
+  zoom?: number;
+};
+
+interface MapViewContextType {
+  region: Region | null;
+  animateToLocation: (location: ZoomLocation) => void;
+}
+
+export const MapViewContext = React.createContext<MapViewContextType>({
+  region: null,
+  animateToLocation: () => {},
+});

--- a/packages/maps/src/components/marker-cluster/MapMarkerCluster.tsx
+++ b/packages/maps/src/components/marker-cluster/MapMarkerCluster.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { MarkerClusterer } from "@teovilla/react-native-web-maps";
+import MapMarker, { renderMarker } from "../MapMarker";
+import MapMarkerClusterView, {
+  DefaultMapMarkerClusterView,
+} from "./MapMarkerClusterView";
+import { MapMarkerClusterContext } from "./MapMarkerClusterContext";
+import { MapViewContext } from "../MapViewCommon";
+
+/**
+ * Component that clusters all markers provided in as children to a single point when zoomed out, and shows the markers themselves when zoomed in
+ * Renders a default component that shows the number of components inside cluster
+ *
+ * Also accepts MapMarkerClusterView to override the rendered cluster component
+ */
+const MapMarkerCluster: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const { region, animateToLocation } = React.useContext(MapViewContext);
+
+  const markers = React.useMemo(
+    () =>
+      React.Children.toArray(children).filter(
+        (child) => (child as React.ReactElement).type === MapMarker
+      ) as React.ReactElement[],
+    [children]
+  );
+
+  const clusterView = React.useMemo(
+    () =>
+      (React.Children.toArray(children).find(
+        (child) => (child as React.ReactElement).type === MapMarkerClusterView
+      ) || <DefaultMapMarkerClusterView />) as React.ReactElement,
+    [children]
+  );
+
+  return (
+    <MarkerClusterer
+      region={region}
+      renderCluster={({ pointCount, coordinate, expansionZoom }) => {
+        const { latitude, longitude } = coordinate;
+
+        // onPress needs to be lifted out and passed to Marker directly because Marker intercepts all touch events
+        const clusterViewOnPress = clusterView.props?.onPress;
+        const zoomOnPress = clusterView.props?.zoomOnPress ?? true;
+
+        const onPress = () => {
+          clusterViewOnPress?.(latitude, longitude);
+          if (zoomOnPress) {
+            animateToLocation({
+              latitude,
+              longitude,
+              zoom: expansionZoom + 3,
+            });
+          }
+        };
+
+        return (
+          <MapMarkerClusterContext.Provider
+            value={{
+              markerCount: pointCount,
+            }}
+          >
+            {renderMarker({
+              latitude,
+              longitude,
+              children: clusterView,
+              onPress,
+            })}
+          </MapMarkerClusterContext.Provider>
+        );
+      }}
+    >
+      {markers.map((marker, index) => renderMarker(marker.props, index))}
+    </MarkerClusterer>
+  );
+};
+
+export default MapMarkerCluster;

--- a/packages/maps/src/components/marker-cluster/MapMarkerClusterContext.ts
+++ b/packages/maps/src/components/marker-cluster/MapMarkerClusterContext.ts
@@ -1,0 +1,10 @@
+import React from "react";
+
+interface MapMarkerClusterContextType {
+  markerCount: number;
+}
+
+export const MapMarkerClusterContext =
+  React.createContext<MapMarkerClusterContextType>({
+    markerCount: 0,
+  });

--- a/packages/maps/src/components/marker-cluster/MapMarkerClusterView.tsx
+++ b/packages/maps/src/components/marker-cluster/MapMarkerClusterView.tsx
@@ -32,6 +32,7 @@ export const DefaultMapMarkerClusterView = withTheme(({ theme }) => {
     <MapMarkerClusterView
       renderItem={({ markerCount }) => (
         <View
+          testID="default-map-marker-cluster-view"
           style={{
             backgroundColor: theme.colors.primary,
             borderColor: theme.colors.background,

--- a/packages/maps/src/components/marker-cluster/MapMarkerClusterView.tsx
+++ b/packages/maps/src/components/marker-cluster/MapMarkerClusterView.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { ViewStyle, StyleProp, Text, View } from "react-native";
+import { MapMarkerClusterContext } from "./MapMarkerClusterContext";
+import { withTheme } from "@draftbit/ui";
+
+interface MapMarkerClusterViewProps {
+  zoomOnPress?: boolean;
+  onPress?: (latitude: number, longitude: number) => void;
+  renderItem?: ({ markerCount }: { markerCount: number }) => JSX.Element;
+  style?: StyleProp<ViewStyle>;
+}
+
+/**
+ * Overrides the default cluster component that is rendered when a group of markers are clustered together
+ *
+ * Placed inside a MapMarkerCluster when manually creating clusters
+ * OR inside a MapView when relying on automatic clustering based on distance
+ */
+const MapMarkerClusterView: React.FC<MapMarkerClusterViewProps> = ({
+  renderItem,
+  style,
+}) => {
+  const { markerCount } = React.useContext(MapMarkerClusterContext);
+
+  return (
+    <View style={style}>{renderItem?.({ markerCount: markerCount || 0 })}</View>
+  );
+};
+
+export const DefaultMapMarkerClusterView = withTheme(({ theme }) => {
+  return (
+    <MapMarkerClusterView
+      renderItem={({ markerCount }) => (
+        <View
+          style={{
+            backgroundColor: theme.colors.primary,
+            borderColor: theme.colors.background,
+            borderWidth: 1,
+            borderRadius: 15,
+            paddingHorizontal: 3,
+            minWidth: 30,
+            minHeight: 30,
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <Text
+            style={{
+              color: theme.colors.background,
+              textAlign: "center",
+            }}
+          >
+            {markerCount}
+          </Text>
+        </View>
+      )}
+    />
+  );
+});
+
+export default MapMarkerClusterView;

--- a/packages/maps/src/components/marker-cluster/index.ts
+++ b/packages/maps/src/components/marker-cluster/index.ts
@@ -1,0 +1,2 @@
+export { default as MapMarkerCluster } from "./MapMarkerCluster";
+export { default as MapMarkerClusterView } from "./MapMarkerClusterView";

--- a/packages/maps/src/index.tsx
+++ b/packages/maps/src/index.tsx
@@ -1,3 +1,7 @@
 export { default as MapView } from "./components/MapView";
 export { default as MapMarker } from "./components/MapMarker";
+export {
+  MapMarkerCluster,
+  MapMarkerClusterView,
+} from "./components/marker-cluster";
 export { default as MapCallout } from "./components/MapCallout";

--- a/packages/maps/tsconfig.json
+++ b/packages/maps/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "extends": "../../tsconfig.json",
+  "references": [{ "path": "../ui" }],
   "compilerOptions": {
     "outDir": "./lib/typescript"
   }


### PR DESCRIPTION
- Adds `MapViewCluster` and `MapViewClusterView`
  - `MapViewCluster` is for manually creating a cluster of markers by placing them as children
  - `MapViewClusterView` is the view that is rendered to represent the cluster
  - Also added props to MapView to allow automatic clustering based on marker proximity to one another
- Added tests to the MapView components  
- Reordered CI step to build before testing (caused some failing tests)