### PR TITLE
Handle type checking when child wrapped in a fragment

### DIFF
--- a/packages/core/src/__tests__/FragmentWrapped.test.tsx
+++ b/packages/core/src/__tests__/FragmentWrapped.test.tsx
@@ -1,0 +1,104 @@
+import React from "react";
+import { View } from "react-native";
+import { render, screen } from "@testing-library/react-native";
+import { SectionList, SectionHeader } from "../components/SectionList";
+import { TabView, TabViewItem } from "../components/TabView";
+import {
+  SwipeableItem,
+  SwipeableItemButton,
+} from "../components/SwipeableItem";
+import { flattenReactFragments } from "../utilities";
+
+describe("Type checked components wrapped in a fragment tests", () => {
+  describe("Type checked components render when wrapped in a fragment tests", () => {
+    test("should SectionHeader render when wrapped in fragment", () => {
+      render(
+        <SectionList
+          data={[{ test: "data" }]}
+          renderItem={() => (
+            <>
+              <SectionHeader>
+                <View testID="header" />
+              </SectionHeader>
+            </>
+          )}
+          sectionKey="test"
+        />
+      );
+
+      const headerView = screen.queryByTestId("header");
+      expect(headerView).toBeTruthy();
+    });
+
+    test("should TabViewItem render when wrapped in fragment", () => {
+      render(
+        <TabView Icon={() => <View />}>
+          <>
+            <TabViewItem title="Test">
+              <View testID="tab-item" />
+            </TabViewItem>
+          </>
+        </TabView>
+      );
+
+      const tabItem = screen.queryByTestId("tab-item");
+      expect(tabItem).toBeTruthy();
+    });
+
+    test("should SwipeableItemButton render when wrapped in fragment", () => {
+      render(
+        <SwipeableItem Icon={() => <View />}>
+          <>
+            <SwipeableItemButton revealSwipeDirection="left" title="test" />
+          </>
+        </SwipeableItem>
+      );
+
+      const swipeableButton = screen.queryByTestId("swipeable-behind-item");
+      expect(swipeableButton).toBeTruthy();
+    });
+  });
+
+  describe("flattenReactFragments tests", () => {
+    test("should extract components from react fragments", () => {
+      const components = [
+        <React.Fragment>
+          <View testID="1" />
+          <View testID="2" />
+          <View testID="3" />
+        </React.Fragment>,
+        <>
+          <View testID="4" />
+        </>,
+        <>
+          <View testID="5" />
+          <View testID="6" />
+        </>,
+      ];
+
+      const result = flattenReactFragments(components);
+      expect(result).toMatchInlineSnapshot(`
+        [
+          <View
+            testID="1"
+          />,
+          <View
+            testID="2"
+          />,
+          <View
+            testID="3"
+          />,
+          <View
+            testID="4"
+          />,
+          <View
+            testID="5"
+          />,
+          <View
+            testID="6"
+          />,
+        ]
+      `);
+    });
+  });
+});

--- a/packages/core/src/components/SectionList/SectionList.tsx
+++ b/packages/core/src/components/SectionList/SectionList.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { FlashListProps, FlashList } from "@shopify/flash-list";
 import { FlatListProps, FlatList } from "react-native";
 import SectionHeader, { DefaultSectionHeader } from "./SectionHeader";
-import { extractIfNestedInFragment } from "../../utilities";
+import { flattenReactFragments } from "../../utilities";
 
 type ListComponentType = "FlatList" | "FlashList";
 
@@ -92,8 +92,8 @@ const SectionList = <T extends { [key: string]: any }>({
     }
 
     const props = element.props || {};
-    const children = React.Children.toArray(props.children).map((child) =>
-      extractIfNestedInFragment(child as React.ReactElement)
+    const children = flattenReactFragments(
+      React.Children.toArray(props.children) as React.ReactElement[]
     );
 
     if (element.type === SectionHeader) {
@@ -116,8 +116,8 @@ const SectionList = <T extends { [key: string]: any }>({
     }
 
     const props = element.props || {};
-    const children = React.Children.toArray(props.children).map(
-      (child) => child as React.ReactElement
+    const children = flattenReactFragments(
+      React.Children.toArray(props.children) as React.ReactElement[]
     );
     if (element.type === SectionHeader) {
       return null;

--- a/packages/core/src/components/SwipeableItem/SwipeableItem.tsx
+++ b/packages/core/src/components/SwipeableItem/SwipeableItem.tsx
@@ -12,10 +12,10 @@ import {
   extractBorderAndMarginStyles,
   extractEffectStyles,
   extractFlexItemStyles,
-  extractIfNestedInFragment,
   extractPositionStyles,
   extractSizeStyles,
   extractStyles,
+  flattenReactFragments,
 } from "../../utilities";
 import { SwipeRow } from "react-native-swipe-list-view";
 import { IconSlot } from "../../interfaces/Icon";
@@ -128,8 +128,8 @@ const SwipeableItem: React.FC<React.PropsWithChildren<Props>> = ({
 
   const children: React.ReactNode[] = React.useMemo(
     () =>
-      React.Children.toArray(childrenProp).map((child) =>
-        extractIfNestedInFragment(child as React.ReactElement)
+      flattenReactFragments(
+        React.Children.toArray(childrenProp) as React.ReactElement[]
       ),
     [childrenProp]
   );
@@ -187,6 +187,7 @@ const SwipeableItem: React.FC<React.PropsWithChildren<Props>> = ({
   //Renders a single 'behind' item. Used for both buttons and swipe handler
   const renderBehindItem = (item: SwipeableItemBehindItem, index: number) => (
     <Pressable
+      testID="swipeable-behind-item"
       key={index.toString()}
       onPress={() => {
         item.onPress?.();

--- a/packages/core/src/components/TabView/TabView.tsx
+++ b/packages/core/src/components/TabView/TabView.tsx
@@ -12,7 +12,7 @@ import TabViewItem from "./TabViewItem";
 import type { IconSlot } from "../../interfaces/Icon";
 import { withTheme } from "../../theming";
 import type { Theme } from "../../styles/DefaultTheme";
-import { extractIfNestedInFragment, extractStyles } from "../../utilities";
+import { flattenReactFragments, extractStyles } from "../../utilities";
 
 type SceneProps = SceneRendererProps & {
   route: Route;
@@ -66,8 +66,8 @@ const TabViewComponent: React.FC<React.PropsWithChildren<TabViewProps>> = ({
 
   const children: React.ReactNode[] = React.useMemo(
     () =>
-      React.Children.toArray(childrenProp).map((child) =>
-        extractIfNestedInFragment(child as React.ReactElement)
+      flattenReactFragments(
+        React.Children.toArray(childrenProp) as React.ReactElement[]
       ),
     [childrenProp]
   );

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -1,3 +1,4 @@
+export { flattenReactFragments } from "./utilities";
 export { injectIcon } from "./interfaces/Icon";
 export { withTheme, ThemeProvider } from "./theming";
 export { default as Provider } from "./Provider";

--- a/packages/core/src/utilities.ts
+++ b/packages/core/src/utilities.ts
@@ -230,20 +230,25 @@ export function getValueForRadioButton(value: string | number) {
   }
 }
 
-// This is done to ensure that operations that depend on a particular child type still work even when wrapped in a react fragment (ex: .type checks or prop extraction of child)
-// Wrapping in a fragment can happen in Draftbit when a component is wrapped in a conditional for example or inside a Fetch component
-export function extractIfNestedInFragment(
-  component: React.ReactElement
-): React.ReactElement {
-  if (component.type === React.Fragment) {
-    const children = React.Children.toArray(
-      (component.props as any)?.children
-    ) as React.ReactElement[];
+/**
+ * Flattens array of components to remove any top level React.Fragment's (<> </>) and returns the fragment's children in its place
+ * This is useful for operations that depend on a particular child type that would otherwise not match when wrapped in a fragment
+ */
+export function flattenReactFragments(
+  components: React.ReactElement[]
+): React.ReactElement[] {
+  const flattened = [];
+  for (const component of components) {
+    if (component.type === React.Fragment) {
+      const children = React.Children.toArray(
+        component.props?.children
+      ) as React.ReactElement[];
 
-    if (children.length === 1) {
-      return children[0];
+      flattened.push(...children);
+    } else {
+      flattened.push(component);
     }
   }
 
-  return component;
+  return flattened;
 }

--- a/packages/maps/src/__tests__/MapMarker.test.tsx
+++ b/packages/maps/src/__tests__/MapMarker.test.tsx
@@ -111,4 +111,21 @@ describe("MapMarker tests", () => {
 
     expect(markerPinImage).toBeTruthy();
   });
+
+  test("should MapCallout render when wrapped in fragment", () => {
+    render(
+      <MapView apiKey="">
+        <MapMarker latitude={43.741895} longitude={-73.989308}>
+          <>
+            <MapCallout>
+              <View testID="callout-view" />
+            </MapCallout>
+          </>
+        </MapMarker>
+      </MapView>
+    );
+
+    const calloutView = screen.queryByTestId("callout-view");
+    expect(calloutView).toBeTruthy();
+  });
 });

--- a/packages/maps/src/__tests__/MapMarkerCluster.test.tsx
+++ b/packages/maps/src/__tests__/MapMarkerCluster.test.tsx
@@ -109,4 +109,21 @@ describe("MapMarkerCluster tests", () => {
       }
     `);
   });
+
+  test("should MapMarker render when wrapped in fragment", () => {
+    render(
+      <MapMarkerCluster>
+        <>
+          <MapMarker latitude={41.741895} longitude={-73.989308} />
+        </>
+        <>
+          <MapMarker latitude={42.741895} longitude={-73.989308} />
+        </>
+      </MapMarkerCluster>
+    );
+
+    const renderedMarkers = screen.UNSAFE_queryAllByType(MapMarkerComponent);
+
+    expect(renderedMarkers.length).toBe(3); //3 markers, cluster itself + 2 markers
+  });
 });

--- a/packages/maps/src/__tests__/MapView.test.tsx
+++ b/packages/maps/src/__tests__/MapView.test.tsx
@@ -279,4 +279,69 @@ describe("MapView tests", () => {
       ]
     `);
   });
+
+  test("should MapMarker render when wrapped in fragment", () => {
+    render(
+      <MapView apiKey="">
+        <>
+          <MapMarker latitude={40.741895} longitude={-73.989308} />
+        </>
+      </MapView>
+    );
+
+    const renderedMarkers = screen
+      .UNSAFE_queryAllByType(MapMarkerComponent)
+      .map((marker) => marker.props.coordinate);
+
+    expect(renderedMarkers).toMatchInlineSnapshot(`
+      [
+        {
+          "latitude": 40.741895,
+          "longitude": -73.989308,
+        },
+      ]
+    `);
+  });
+
+  test("should MapMarkerCluster render when wrapped in fragment", () => {
+    render(
+      <MapView apiKey="">
+        <>
+          <MapMarkerCluster>
+            <MapMarker latitude={41.741895} longitude={-73.989308} />
+            <MapMarker latitude={42.741895} longitude={-73.989308} />
+          </MapMarkerCluster>
+        </>
+      </MapView>
+    );
+
+    const renderedClusters = screen
+      .UNSAFE_queryAllByType(MarkerClusterer)
+      .map((marker) => marker.props.children);
+
+    expect(renderedClusters).toMatchInlineSnapshot(`
+      [
+        [
+          <Marker
+            coordinate={
+              {
+                "latitude": 41.741895,
+                "longitude": -73.989308,
+              }
+            }
+            onPress={[Function]}
+          />,
+          <Marker
+            coordinate={
+              {
+                "latitude": 42.741895,
+                "longitude": -73.989308,
+              }
+            }
+            onPress={[Function]}
+          />,
+        ],
+      ]
+    `);
+  });
 });

--- a/packages/maps/src/components/MapMarker.tsx
+++ b/packages/maps/src/components/MapMarker.tsx
@@ -9,6 +9,7 @@ import {
 import { Marker as MapMarkerComponent } from "./react-native-maps";
 import type { MapMarkerProps as MapMarkerComponentProps } from "react-native-maps";
 import MapCallout, { renderCallout } from "./MapCallout";
+import { flattenReactFragments } from "@draftbit/ui";
 
 export interface MapMarkerProps
   extends Omit<MapMarkerComponentProps, "onPress" | "coordinate"> {
@@ -44,14 +45,16 @@ export function renderMarker(
   }: MapMarkerProps,
   key?: React.Key
 ) {
-  const childrenArray = React.Children.toArray(children);
+  const childrenArray = flattenReactFragments(
+    React.Children.toArray(children) as React.ReactElement[]
+  );
 
   const calloutChildren = childrenArray.filter(
-    (child) => (child as React.ReactElement).type === MapCallout
+    (child) => child.type === MapCallout
   );
 
   const nonCalloutChildren = childrenArray.filter(
-    (child) => (child as React.ReactElement).type !== MapCallout
+    (child) => child.type !== MapCallout
   );
 
   // Add default callout for title/description

--- a/packages/maps/src/components/MapView.tsx
+++ b/packages/maps/src/components/MapView.tsx
@@ -101,7 +101,7 @@ class MapView<T> extends React.Component<
     } else {
       return flattenReactFragments(
         React.Children.toArray(children) as React.ReactElement[]
-      ).filter((child) => (child as React.ReactElement).type === type);
+      ).filter((child) => child.type === type);
     }
   }
 

--- a/packages/maps/src/components/MapView.tsx
+++ b/packages/maps/src/components/MapView.tsx
@@ -10,6 +10,7 @@ import MapMarker, { MapMarkerProps, renderMarker } from "./MapMarker";
 import MapMarkerCluster from "./marker-cluster/MapMarkerCluster";
 import { MapViewContext, ZoomLocation } from "./MapViewCommon";
 import { MapMarkerClusterView } from "./marker-cluster";
+import { flattenReactFragments } from "@draftbit/ui";
 
 export interface MapViewProps<T>
   extends Omit<MapViewComponentProps, "onRegionChangeComplete"> {
@@ -83,21 +84,24 @@ class MapView<T> extends React.Component<
 
       markersData.forEach((item, index) => {
         const component = renderItem?.({ item, index });
+        const flattened = flattenReactFragments([component]);
 
-        if (component && component.type === type) {
-          const key = keyExtractor ? keyExtractor(item, index) : index;
-          markers.push(
-            React.cloneElement(component, {
-              key,
-            })
-          );
-        }
+        flattened.forEach((child) => {
+          if (child && child.type === type) {
+            const key = keyExtractor ? keyExtractor(item, index) : index;
+            markers.push(
+              React.cloneElement(child, {
+                key,
+              })
+            );
+          }
+        });
       });
       return markers;
     } else {
-      return React.Children.toArray(children).filter(
-        (child) => (child as React.ReactElement).type === type
-      ) as React.ReactElement[];
+      return flattenReactFragments(
+        React.Children.toArray(children) as React.ReactElement[]
+      ).filter((child) => (child as React.ReactElement).type === type);
     }
   }
 

--- a/packages/maps/src/components/marker-cluster/MapMarkerCluster.tsx
+++ b/packages/maps/src/components/marker-cluster/MapMarkerCluster.tsx
@@ -6,6 +6,7 @@ import MapMarkerClusterView, {
 } from "./MapMarkerClusterView";
 import { MapMarkerClusterContext } from "./MapMarkerClusterContext";
 import { MapViewContext } from "../MapViewCommon";
+import { flattenReactFragments } from "@draftbit/ui";
 
 /**
  * Component that clusters all markers provided in as children to a single point when zoomed out, and shows the markers themselves when zoomed in
@@ -13,22 +14,29 @@ import { MapViewContext } from "../MapViewCommon";
  *
  * Also accepts MapMarkerClusterView to override the rendered cluster component
  */
-const MapMarkerCluster: React.FC<React.PropsWithChildren> = ({ children }) => {
+const MapMarkerCluster: React.FC<React.PropsWithChildren> = ({
+  children: childrenProp,
+}) => {
   const { region, animateToLocation } = React.useContext(MapViewContext);
 
-  const markers = React.useMemo(
+  const children = React.useMemo(
     () =>
-      React.Children.toArray(children).filter(
-        (child) => (child as React.ReactElement).type === MapMarker
-      ) as React.ReactElement[],
+      flattenReactFragments(
+        React.Children.toArray(childrenProp) as React.ReactElement[]
+      ),
+    [childrenProp]
+  );
+
+  const markers = React.useMemo(
+    () => children.filter((child) => child.type === MapMarker),
     [children]
   );
 
   const clusterView = React.useMemo(
     () =>
-      (React.Children.toArray(children).find(
-        (child) => (child as React.ReactElement).type === MapMarkerClusterView
-      ) || <DefaultMapMarkerClusterView />) as React.ReactElement,
+      children.find((child) => child.type === MapMarkerClusterView) || (
+        <DefaultMapMarkerClusterView />
+      ),
     [children]
   );
 

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -3,6 +3,7 @@ import { Icon } from "@draftbit/native";
 export { Icon, LinearGradient, WebView } from "@draftbit/native";
 
 export {
+  flattenReactFragments,
   AudioPlayer,
   AudioPlayerRef,
   Avatar,


### PR DESCRIPTION
- Extract children from a `<> </>` to be able to properly check their type.
- This was implemented before but only considered a single child within a fragment, which is not always the case
  - Example on linear (https://linear.app/draftbit/issue/P-3746/mapview-does-not-support-multiple-markers-tried-rendering-using-array)
  - In this case, having multiple markers inside a `renderItem` adds them both to a fragment  which caused rendering of them to be skipped due to not matching the required type of `MapMarker`
- Also added tests to ensure this behavior does not break with future changes. 