### PR TITLE
Add props to TabView and BottomSheet (47)

### DIFF
--- a/packages/core/src/components/BottomSheet/BottomSheet.tsx
+++ b/packages/core/src/components/BottomSheet/BottomSheet.tsx
@@ -16,9 +16,12 @@ export interface BottomSheetProps extends ScrollViewProps {
   topSnapPosition?: string | number;
   middleSnapPosition?: string | number;
   bottomSnapPosition?: string | number;
-  snapPoints: (string | number)[];
+  snapPoints?: (string | number)[];
   initialSnapIndex?: number;
-  initialSnapPosition: SnapPosition;
+  initialSnapPosition?: SnapPosition;
+  enableOverScroll?: boolean;
+  friction?: number;
+  topInset?: number;
   showHandle?: boolean;
   handleColor?: string;
   topBorderRadius?: number;

--- a/packages/core/src/components/TabView/TabView.tsx
+++ b/packages/core/src/components/TabView/TabView.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { StyleProp, ViewStyle } from "react-native";
+import { StyleProp, ViewStyle, TextStyle } from "react-native";
 import {
   TabView,
   TabBar,
@@ -36,7 +36,8 @@ type TabViewProps = {
   pressColor?: string;
   indicatorColor?: string;
   tabsBackgroundColor?: string;
-  style?: StyleProp<ViewStyle>;
+  iconSize?: number;
+  style?: StyleProp<ViewStyle | TextStyle>;
   theme: Theme;
 } & IconSlot;
 
@@ -54,6 +55,7 @@ const TabViewComponent: React.FC<React.PropsWithChildren<TabViewProps>> = ({
   pressColor,
   indicatorColor,
   tabsBackgroundColor,
+  iconSize = 16,
   style,
   theme,
   children: childrenProp,
@@ -118,7 +120,7 @@ const TabViewComponent: React.FC<React.PropsWithChildren<TabViewProps>> = ({
         labelStyle={textStyles}
         renderIcon={({ route, color }) =>
           route?.icon ? (
-            <Icon name={route.icon} color={color} size={16} />
+            <Icon name={route.icon} color={color} size={iconSize} />
           ) : null
         }
         style={{


### PR DESCRIPTION
- Adds `iconSize` prop to TabView
- `enableOverScroll`, `friction`, `topInset` props to BottomSheet

Closes https://linear.app/draftbit/issue/P-3731/additional-properties-for-bottomsheet-componenet