### PR TITLE
Only one opened callout at a time

### DIFF
--- a/packages/maps/src/components/MapMarker.tsx
+++ b/packages/maps/src/components/MapMarker.tsx
@@ -35,12 +35,7 @@ const MapMarker: React.FC<React.PropsWithChildren<MapMarkerProps>> = () => {
 };
 
 export function renderMarker(
-  props: MapMarkerProps,
-  key?: React.Key,
-  ref?: React.Ref<MapMarkerRefType>,
-  onMarkerPress?: () => void
-) {
-  const {
+  {
     latitude,
     longitude,
     pinImage,
@@ -50,8 +45,11 @@ export function renderMarker(
     title,
     description,
     ...rest
-  } = props;
-
+  }: MapMarkerProps,
+  key?: React.Key,
+  ref?: React.Ref<MapMarkerRefType>,
+  onMarkerPress?: () => void
+) {
   const childrenArray = flattenReactFragments(
     React.Children.toArray(children) as React.ReactElement[]
   );

--- a/packages/maps/src/components/MapMarker.tsx
+++ b/packages/maps/src/components/MapMarker.tsx
@@ -7,7 +7,10 @@ import {
   Text,
 } from "react-native";
 import { Marker as MapMarkerComponent } from "./react-native-maps";
-import type { MapMarkerProps as MapMarkerComponentProps } from "react-native-maps";
+import type {
+  MapMarkerProps as MapMarkerComponentProps,
+  MapMarker as MapMarkerRefType,
+} from "react-native-maps";
 import MapCallout, { renderCallout } from "./MapCallout";
 import { flattenReactFragments } from "@draftbit/ui";
 
@@ -32,7 +35,12 @@ const MapMarker: React.FC<React.PropsWithChildren<MapMarkerProps>> = () => {
 };
 
 export function renderMarker(
-  {
+  props: MapMarkerProps,
+  key?: React.Key,
+  ref?: React.Ref<MapMarkerRefType>,
+  onMarkerPress?: () => void
+) {
+  const {
     latitude,
     longitude,
     pinImage,
@@ -42,9 +50,8 @@ export function renderMarker(
     title,
     description,
     ...rest
-  }: MapMarkerProps,
-  key?: React.Key
-) {
+  } = props;
+
   const childrenArray = flattenReactFragments(
     React.Children.toArray(children) as React.ReactElement[]
   );
@@ -73,12 +80,14 @@ export function renderMarker(
 
   return (
     <MapMarkerComponent
+      ref={ref}
       key={key}
       coordinate={{
         latitude,
         longitude,
       }}
       onPress={(event) => {
+        onMarkerPress?.();
         const coordinate = event.nativeEvent.coordinate;
         onPress?.(coordinate.latitude, coordinate.longitude);
       }}

--- a/packages/maps/src/components/MapView.tsx
+++ b/packages/maps/src/components/MapView.tsx
@@ -178,7 +178,7 @@ class MapView<T> extends React.Component<
     return nearbyMarkers;
   }
 
-  // Dismiss all other callouts whenever except the one just pressed. Maintains that only one is opened at a time
+  // Dismiss all other callouts except the one just pressed. Maintains that only one is opened at a time
   private onMarkerPress(markerIdentifier: string) {
     for (const [idenfitifer, markerRef] of this.markerRefs) {
       if (idenfitifer !== markerIdentifier) markerRef.current?.hideCallout();


### PR DESCRIPTION
- Dismiss all opened callouts whenever another one is opened. This ensures that only one callout can be opened at a time.
- This behavior already existed on ios and Android, the changes here ensure it behaves the same on web as well.