### PR TITLE
Only one opened callout at a time (47)

### DIFF
--- a/packages/maps/src/components/MapMarker.tsx
+++ b/packages/maps/src/components/MapMarker.tsx
@@ -35,12 +35,7 @@ const MapMarker: React.FC<React.PropsWithChildren<MapMarkerProps>> = () => {
 };
 
 export function renderMarker(
-  props: MapMarkerProps,
-  key?: React.Key,
-  ref?: React.Ref<MapMarkerRefType>,
-  onMarkerPress?: () => void
-) {
-  const {
+  {
     latitude,
     longitude,
     pinImage,
@@ -50,8 +45,11 @@ export function renderMarker(
     title,
     description,
     ...rest
-  } = props;
-
+  }: MapMarkerProps,
+  key?: React.Key,
+  ref?: React.Ref<MapMarkerRefType>,
+  onMarkerPress?: () => void
+) {
   const childrenArray = flattenReactFragments(
     React.Children.toArray(children) as React.ReactElement[]
   );

--- a/packages/maps/src/components/MapMarker.tsx
+++ b/packages/maps/src/components/MapMarker.tsx
@@ -7,7 +7,10 @@ import {
   Text,
 } from "react-native";
 import { Marker as MapMarkerComponent } from "./react-native-maps";
-import type { MapMarkerProps as MapMarkerComponentProps } from "react-native-maps";
+import type {
+  MapMarkerProps as MapMarkerComponentProps,
+  MapMarker as MapMarkerRefType,
+} from "react-native-maps";
 import MapCallout, { renderCallout } from "./MapCallout";
 import { flattenReactFragments } from "@draftbit/ui";
 
@@ -32,7 +35,12 @@ const MapMarker: React.FC<React.PropsWithChildren<MapMarkerProps>> = () => {
 };
 
 export function renderMarker(
-  {
+  props: MapMarkerProps,
+  key?: React.Key,
+  ref?: React.Ref<MapMarkerRefType>,
+  onMarkerPress?: () => void
+) {
+  const {
     latitude,
     longitude,
     pinImage,
@@ -42,9 +50,8 @@ export function renderMarker(
     title,
     description,
     ...rest
-  }: MapMarkerProps,
-  key?: React.Key
-) {
+  } = props;
+
   const childrenArray = flattenReactFragments(
     React.Children.toArray(children) as React.ReactElement[]
   );
@@ -73,12 +80,14 @@ export function renderMarker(
 
   return (
     <MapMarkerComponent
+      ref={ref}
       key={key}
       coordinate={{
         latitude,
         longitude,
       }}
       onPress={(event) => {
+        onMarkerPress?.();
         const coordinate = event.nativeEvent.coordinate;
         onPress?.(coordinate.latitude, coordinate.longitude);
       }}

--- a/packages/maps/src/components/MapView.tsx
+++ b/packages/maps/src/components/MapView.tsx
@@ -11,6 +11,19 @@ import MapMarkerCluster from "./marker-cluster/MapMarkerCluster";
 import { MapViewContext, ZoomLocation } from "./MapViewCommon";
 import { MapMarkerClusterView } from "./marker-cluster";
 import { flattenReactFragments } from "@draftbit/ui";
+import type { MapMarker as MapMarkerRefType } from "react-native-maps";
+
+export interface MapMarkerContextType {
+  onMarkerPress: (marker: MapMarkerProps) => void;
+  getMarkerRef: (
+    marker: MapMarkerProps
+  ) => React.Ref<MapMarkerRefType> | undefined;
+}
+
+export const MapMarkerContext = React.createContext<MapMarkerContextType>({
+  onMarkerPress: () => {},
+  getMarkerRef: () => undefined,
+});
 
 export interface MapViewProps<T>
   extends Omit<MapViewComponentProps, "onRegionChangeComplete"> {
@@ -35,10 +48,13 @@ class MapView<T> extends React.Component<
   MapViewState
 > {
   private mapRef: React.RefObject<any>;
+  private markerRefs: Map<string, React.RefObject<MapMarkerRefType>>;
+
   constructor(props: React.PropsWithChildren<MapViewProps<T>>) {
     super(props);
     this.state = { region: null };
     this.mapRef = React.createRef();
+    this.markerRefs = new Map();
   }
 
   componentDidUpdate(prevProps: React.PropsWithChildren<MapViewProps<T>>) {
@@ -163,6 +179,23 @@ class MapView<T> extends React.Component<
     return nearbyMarkers;
   }
 
+  // Dismiss all other callouts whenever except the one just pressed. Maintains that only one is opened at a time
+  private onMarkerPress(markerIdentifier: string) {
+    for (const [idenfitifer, markerRef] of this.markerRefs) {
+      if (idenfitifer !== markerIdentifier) markerRef.current?.hideCallout();
+    }
+  }
+
+  private getMarkerRef(markerIdentifier: string) {
+    if (this.markerRefs.has(markerIdentifier)) {
+      return this.markerRefs.get(markerIdentifier);
+    } else {
+      const ref = React.createRef<MapMarkerRefType>();
+      this.markerRefs.set(markerIdentifier, ref);
+      return ref;
+    }
+  }
+
   render() {
     const {
       apiKey,
@@ -234,11 +267,31 @@ class MapView<T> extends React.Component<
           style={[styles.map, style]}
           {...rest}
         >
-          {markers.map((marker, index) => renderMarker(marker.props, index))}
+          {markers.map((marker, index) =>
+            renderMarker(
+              marker.props,
+              index,
+              this.getMarkerRef(getMarkerIdentifier(marker.props)),
+              () => this.onMarkerPress(getMarkerIdentifier(marker.props))
+            )
+          )}
 
-          {clusters.map((cluster, index) => (
-            <React.Fragment key={index}>{cluster}</React.Fragment>
-          ))}
+          {/* 
+            Markers within clusters also need to able to assign refs and propogate press.
+            This is done through context to prevent exposing these internal config options as props of the cluster component
+          */}
+          <MapMarkerContext.Provider
+            value={{
+              getMarkerRef: (marker) =>
+                this.getMarkerRef(getMarkerIdentifier(marker)),
+              onMarkerPress: (marker) =>
+                this.onMarkerPress(getMarkerIdentifier(marker)),
+            }}
+          >
+            {clusters.map((cluster, index) => (
+              <React.Fragment key={index}>{cluster}</React.Fragment>
+            ))}
+          </MapMarkerContext.Provider>
         </MapViewComponent>
       </MapViewContext.Provider>
     );
@@ -289,6 +342,10 @@ function calculateDistanceBetween2PointsMeters(
 
 function degreeToRadian(deg: number) {
   return deg * (Math.PI / 180);
+}
+
+function getMarkerIdentifier(marker: MapMarkerProps) {
+  return `marker-${marker.latitude}-${marker.longitude}`;
 }
 
 export default MapView;

--- a/packages/maps/src/components/MapView.tsx
+++ b/packages/maps/src/components/MapView.tsx
@@ -179,7 +179,7 @@ class MapView<T> extends React.Component<
     return nearbyMarkers;
   }
 
-  // Dismiss all other callouts whenever except the one just pressed. Maintains that only one is opened at a time
+  // Dismiss all other callouts except the one just pressed. Maintains that only one is opened at a time
   private onMarkerPress(markerIdentifier: string) {
     for (const [idenfitifer, markerRef] of this.markerRefs) {
       if (idenfitifer !== markerIdentifier) markerRef.current?.hideCallout();


### PR DESCRIPTION
- Dismiss all opened callouts whenever another one is opened. This ensures that only one callout can be opened at a time.
- This behavior already existed on ios and Android, the changes here ensure it behaves the same on web as well.