### PR TITLE
Fix callouts not showing on IOS

### DIFF
--- a/packages/maps/src/components/MapView.tsx
+++ b/packages/maps/src/components/MapView.tsx
@@ -179,10 +179,17 @@ class MapView<T> extends React.Component<
   }
 
   // Dismiss all other callouts except the one just pressed. Maintains that only one is opened at a time
-  private onMarkerPress(markerIdentifier: string) {
-    for (const [idenfitifer, markerRef] of this.markerRefs) {
-      if (idenfitifer !== markerIdentifier) markerRef.current?.hideCallout();
+  // Web specfic, this is the default on native
+  private dismissAllOtherCallouts(markerIdentifier: string) {
+    if (Platform.OS === "web") {
+      for (const [idenfitifer, markerRef] of this.markerRefs) {
+        if (idenfitifer !== markerIdentifier) markerRef.current?.hideCallout();
+      }
     }
+  }
+
+  private onMarkerPress(markerIdentifier: string) {
+    this.dismissAllOtherCallouts(markerIdentifier);
   }
 
   private getMarkerRef(markerIdentifier: string) {


### PR DESCRIPTION
- I made some changes to auto-dismiss callouts on web. This logic messes with ios and causes callouts to instantly hide when shown. Since the logic is only needed for web anyways, I wrapped it in a `Platform.OS` check.