### PR TITLE
MapView panning fix + onPress (47)

### DIFF
--- a/example/src/MapViewDataDrivenExample.js
+++ b/example/src/MapViewDataDrivenExample.js
@@ -28,7 +28,7 @@ const MapViewDataDrivenExample = ({ theme }) => {
         latitude={33.8303}
         longitude={-116.524}
         zoom={12}
-        apiKey={"AIzaSyC53v7BvSuA1yv7Hwf1rC_9kpHMmmYJJhU"}
+        apiKey="AIzaSyBSM2NJ9iJkilKzWcZcCHklTSfZNewGIl4"
         markersData={data}
         keyExtractor={(item) => item.id}
         renderItem={({ item }) => (

--- a/example/src/MapViewExample.js
+++ b/example/src/MapViewExample.js
@@ -17,6 +17,7 @@ const MapViewExample = ({ theme }) => {
     <View style={styles.container}>
       <MapView
         ref={mapRef}
+        apiKey="AIzaSyBSM2NJ9iJkilKzWcZcCHklTSfZNewGIl4"
         showsCompass={true}
         style={styles.map}
         latitude={43.741895}

--- a/packages/maps/package.json
+++ b/packages/maps/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@draftbit/ui": "47.7.1",
     "@teovilla/react-native-web-maps": "^0.9.1",
+    "lodash.isequal": "^4.5.0",
     "react-native-maps": "1.3.2"
   },
   "eslintIgnore": [
@@ -60,5 +61,8 @@
       "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg)"
     ],
     "testEnvironment": "node"
+  },
+  "devDependencies": {
+    "@types/lodash.isequal": "^4.5.6"
   }
 }

--- a/packages/maps/src/components/MapView.tsx
+++ b/packages/maps/src/components/MapView.tsx
@@ -12,6 +12,7 @@ import { MapViewContext, ZoomLocation } from "./MapViewCommon";
 import { MapMarkerClusterView } from "./marker-cluster";
 import { flattenReactFragments } from "@draftbit/ui";
 import type { MapMarker as MapMarkerRefType } from "react-native-maps";
+import { useDeepCompareMemo } from "./useDeepCompareMemo";
 
 export interface MapMarkerContextType {
   onMarkerPress: (marker: MapMarkerProps) => void;
@@ -40,42 +41,298 @@ export interface MapViewProps<T>
   onPress?: (latitude: number, longitude: number) => void;
 }
 
-interface MapViewState {
-  region: Region | null;
-}
+const MapViewF = <T extends object>({
+  apiKey,
+  provider = Platform.OS === "web" ? "google" : undefined,
+  latitude,
+  longitude,
+  zoom,
+  showsCompass = false,
+  loadingEnabled = true,
+  autoClusterMarkers = false,
+  autoClusterMarkersDistanceMeters = 1000,
+  markersData,
+  keyExtractor,
+  renderItem,
+  children,
+  onRegionChange,
+  onPress,
+  style,
+  animateToLocation,
+  mapRef,
+  ...rest
+}: MapViewProps<T> & {
+  animateToLocation: (location: ZoomLocation) => void;
+  mapRef: React.RefObject<MapViewComponent>;
+}) => {
+  const [currentRegion, setCurrentRegion] = React.useState<Region | null>(null);
 
-class MapView<T> extends React.Component<
-  React.PropsWithChildren<MapViewProps<T>>,
-  MapViewState
-> {
-  private mapRef: React.RefObject<any>;
-  private markerRefs: Map<string, React.RefObject<MapMarkerRefType>>;
+  const markerRefs = React.useMemo<
+    Map<string, React.RefObject<MapMarkerRefType>>
+  >(() => new Map(), []);
 
-  constructor(props: React.PropsWithChildren<MapViewProps<T>>) {
-    super(props);
-    this.state = { region: null };
-    this.mapRef = React.createRef();
-    this.markerRefs = new Map();
-  }
+  const camera: Camera = React.useMemo(
+    () => ({
+      altitude: zoomToAltitude(zoom || 1),
+      heading: 0,
+      pitch: 0,
+      zoom,
+      center: {
+        latitude: latitude || 0,
+        longitude: longitude || 0,
+      },
+    }),
+    [latitude, longitude, zoom]
+  );
 
-  componentDidUpdate(prevProps: React.PropsWithChildren<MapViewProps<T>>) {
-    if (
-      prevProps.latitude != null &&
-      prevProps.longitude != null &&
-      this.props.latitude != null &&
-      this.props.longitude != null &&
-      (prevProps.latitude !== this.props.latitude ||
-        prevProps.longitude !== this.props.longitude)
-    ) {
-      this.animateToLocation({
-        latitude: this.props.latitude,
-        longitude: this.props.longitude,
-        zoom: this.props.zoom,
+  const getChildrenForType = React.useCallback(
+    (type: React.ElementType): React.ReactElement[] => {
+      if (Array.isArray(markersData) && renderItem) {
+        const markers: React.ReactElement[] = [];
+
+        markersData.forEach((item, index) => {
+          const component = renderItem?.({ item, index });
+          const flattened = flattenReactFragments([component]);
+
+          flattened.forEach((child) => {
+            if (child && child.type === type) {
+              const key = keyExtractor ? keyExtractor(item, index) : index;
+              markers.push(
+                React.cloneElement(child, {
+                  key,
+                })
+              );
+            }
+          });
+        });
+        return markers;
+      } else {
+        return flattenReactFragments(
+          React.Children.toArray(children) as React.ReactElement[]
+        ).filter((child) => child.type === type);
+      }
+    },
+    [markersData, renderItem, keyExtractor, children]
+  );
+
+  // Dismiss all other callouts except the one just pressed. Maintains that only one is opened at a time
+  // Web specfic, this is the default on native
+  const dismissAllOtherCallouts = React.useCallback(
+    (markerIdentifier: string) => {
+      if (Platform.OS === "web") {
+        for (const [idenfitifer, markerRef] of markerRefs) {
+          if (idenfitifer !== markerIdentifier)
+            markerRef.current?.hideCallout();
+        }
+      }
+    },
+    [markerRefs]
+  );
+
+  const getMarkerRef = React.useCallback(
+    (markerIdentifier: string) => {
+      if (markerRefs.has(markerIdentifier)) {
+        return markerRefs.get(markerIdentifier);
+      } else {
+        const ref = React.createRef<MapMarkerRefType>();
+        markerRefs.set(markerIdentifier, ref);
+        return ref;
+      }
+    },
+    [markerRefs]
+  );
+
+  const getNearbyMarkers = React.useCallback(
+    (
+      lat: number,
+      long: number,
+      markers: React.ReactElement[],
+      distanceMeters: number
+    ): React.ReactElement[] => {
+      const nearbyMarkers: React.ReactElement[] = [];
+
+      for (const marker of markers) {
+        const { latitude: lat2, longitude: long2 } =
+          marker.props as MapMarkerProps;
+
+        const distance = calculateDistanceBetween2PointsMeters(
+          lat,
+          long,
+          lat2,
+          long2
+        );
+
+        if (distance <= distanceMeters) {
+          nearbyMarkers.push(marker);
+        }
+      }
+
+      return nearbyMarkers;
+    },
+    []
+  );
+
+  const clusterMarkers = React.useCallback(
+    (
+      markers: React.ReactElement[],
+      clusters: React.ReactElement[],
+      distanceMeters: number,
+      clusterView?: React.ReactElement
+    ) => {
+      for (const marker of markers) {
+        const { latitude: lat, longitude: long } =
+          marker.props as MapMarkerProps;
+
+        const nearbyMarkers = getNearbyMarkers(
+          lat,
+          long,
+          markers,
+          distanceMeters
+        );
+
+        if (nearbyMarkers.length > 1) {
+          for (const nearbyMarker of nearbyMarkers) {
+            markers.splice(markers.indexOf(nearbyMarker), 1);
+          }
+          clusters.push(
+            <MapMarkerCluster>
+              {clusterView}
+              {nearbyMarkers}
+            </MapMarkerCluster>
+          );
+        }
+      }
+    },
+    [getNearbyMarkers]
+  );
+
+  React.useEffect(() => {
+    if (latitude && longitude) {
+      animateToLocation({
+        latitude,
+        longitude,
+        zoom,
       });
     }
+  }, [latitude, longitude, zoom, animateToLocation]);
+
+  const markers = React.useMemo(
+    () => getChildrenForType(MapMarker),
+    [getChildrenForType]
+  );
+  const clusters = React.useMemo(
+    () => getChildrenForType(MapMarkerCluster),
+    [getChildrenForType]
+  );
+  const clusterView = React.useMemo(
+    () => getChildrenForType(MapMarkerClusterView).at(0),
+    [getChildrenForType]
+  ); //Only take the first, ignore any others
+
+  if (autoClusterMarkers) {
+    clusterMarkers(
+      markers,
+      clusters,
+      autoClusterMarkersDistanceMeters,
+      clusterView
+    );
   }
 
-  animateToLocation({ latitude, longitude, zoom }: ZoomLocation) {
+  const memoizedMapView = useDeepCompareMemo(
+    () => (
+      <MapViewComponent
+        ref={mapRef}
+        onMapReady={() => {
+          // This initial animateToLocation ensures that 'region' state is initially set
+          animateToLocation({
+            latitude: latitude || 0,
+            longitude: longitude || 0,
+            zoom,
+          });
+        }}
+        provider={provider}
+        googleMapsApiKey={apiKey}
+        showsCompass={showsCompass}
+        initialCamera={camera}
+        loadingEnabled={loadingEnabled}
+        onRegionChangeComplete={(region) => {
+          onRegionChange?.(region);
+        }}
+        onRegionChange={setCurrentRegion}
+        onPress={(event) => {
+          const coordinate = event.nativeEvent.coordinate;
+          onPress?.(coordinate.latitude, coordinate.longitude);
+        }}
+        style={[styles.map, style]}
+        {...rest}
+      >
+        {markers.map((marker, index) =>
+          renderMarker(
+            marker.props,
+            index,
+            getMarkerRef(getMarkerIdentifier(marker.props)),
+            () => dismissAllOtherCallouts(getMarkerIdentifier(marker.props))
+          )
+        )}
+
+        {/* 
+            Markers within clusters also need to able to assign refs and propogate press.
+            This is done through context to prevent exposing these internal config options as props of the cluster component
+          */}
+        <MapMarkerContext.Provider
+          value={{
+            getMarkerRef: (marker) => getMarkerRef(getMarkerIdentifier(marker)),
+            onMarkerPress: (marker) =>
+              dismissAllOtherCallouts(getMarkerIdentifier(marker)),
+          }}
+        >
+          {clusters.map((cluster, index) => (
+            <React.Fragment key={index}>{cluster}</React.Fragment>
+          ))}
+        </MapMarkerContext.Provider>
+      </MapViewComponent>
+    ),
+    [
+      animateToLocation,
+      apiKey,
+      camera,
+      clusters,
+      dismissAllOtherCallouts,
+      getMarkerRef,
+      latitude,
+      loadingEnabled,
+      longitude,
+      mapRef,
+      markers,
+      onPress,
+      onRegionChange,
+      provider,
+      rest,
+      setCurrentRegion,
+      showsCompass,
+      style,
+      zoom,
+    ]
+  );
+
+  return (
+    <MapViewContext.Provider
+      value={{
+        animateToLocation: (location) => animateToLocation(location),
+        region: currentRegion,
+      }}
+    >
+      {memoizedMapView}
+    </MapViewContext.Provider>
+  );
+};
+
+class MapView<T extends object> extends React.Component<
+  React.PropsWithChildren<MapViewProps<T>>
+> {
+  private mapRef: React.RefObject<any> = React.createRef();
+
+  animateToLocation = ({ latitude, longitude, zoom }: ZoomLocation) => {
     const camera: Camera = {
       heading: 0,
       pitch: 0,
@@ -90,223 +347,16 @@ class MapView<T> extends React.Component<
       camera.zoom = zoom;
     }
 
-    this.mapRef.current.animateCamera(camera);
-  }
-
-  private getChildrenForType(type: React.ElementType): React.ReactElement[] {
-    const { markersData, renderItem, keyExtractor, children } = this.props;
-
-    if (Array.isArray(markersData) && renderItem) {
-      const markers: React.ReactElement[] = [];
-
-      markersData.forEach((item, index) => {
-        const component = renderItem?.({ item, index });
-        const flattened = flattenReactFragments([component]);
-
-        flattened.forEach((child) => {
-          if (child && child.type === type) {
-            const key = keyExtractor ? keyExtractor(item, index) : index;
-            markers.push(
-              React.cloneElement(child, {
-                key,
-              })
-            );
-          }
-        });
-      });
-      return markers;
-    } else {
-      return flattenReactFragments(
-        React.Children.toArray(children) as React.ReactElement[]
-      ).filter((child) => child.type === type);
-    }
-  }
-
-  private clusterMarkers(
-    markers: React.ReactElement[],
-    clusters: React.ReactElement[],
-    distanceMeters: number,
-    clusterView: React.ReactElement | null
-  ) {
-    for (const marker of markers) {
-      const { latitude, longitude } = marker.props as MapMarkerProps;
-
-      const nearbyMarkers = this.getNearbyMarkers(
-        latitude,
-        longitude,
-        markers,
-        distanceMeters
-      );
-
-      if (nearbyMarkers.length > 1) {
-        for (const nearbyMarker of nearbyMarkers) {
-          markers.splice(markers.indexOf(nearbyMarker), 1);
-        }
-        clusters.push(
-          <MapMarkerCluster>
-            {clusterView}
-            {nearbyMarkers}
-          </MapMarkerCluster>
-        );
-      }
-    }
-  }
-
-  private getNearbyMarkers(
-    lat: number,
-    long: number,
-    markers: React.ReactElement[],
-    distanceMeters: number
-  ): React.ReactElement[] {
-    const nearbyMarkers: React.ReactElement[] = [];
-
-    for (let i = 0; i < markers.length; i++) {
-      const marker = markers[i];
-      const { latitude: lat2, longitude: long2 } =
-        marker.props as MapMarkerProps;
-
-      const distance = calculateDistanceBetween2PointsMeters(
-        lat,
-        long,
-        lat2,
-        long2
-      );
-
-      if (distance <= distanceMeters) {
-        nearbyMarkers.push(marker);
-      }
-    }
-
-    return nearbyMarkers;
-  }
-
-  // Dismiss all other callouts except the one just pressed. Maintains that only one is opened at a time
-  // Web specfic, this is the default on native
-  private dismissAllOtherCallouts(markerIdentifier: string) {
-    if (Platform.OS === "web") {
-      for (const [idenfitifer, markerRef] of this.markerRefs) {
-        if (idenfitifer !== markerIdentifier) markerRef.current?.hideCallout();
-      }
-    }
-  }
-
-  private onMarkerPress(markerIdentifier: string) {
-    this.dismissAllOtherCallouts(markerIdentifier);
-  }
-
-  private getMarkerRef(markerIdentifier: string) {
-    if (this.markerRefs.has(markerIdentifier)) {
-      return this.markerRefs.get(markerIdentifier);
-    } else {
-      const ref = React.createRef<MapMarkerRefType>();
-      this.markerRefs.set(markerIdentifier, ref);
-      return ref;
-    }
-  }
+    this.mapRef?.current?.animateCamera(camera);
+  };
 
   render() {
-    const {
-      apiKey,
-      provider = Platform.OS === "web" ? "google" : undefined,
-      latitude,
-      longitude,
-      zoom,
-      showsCompass = false,
-      loadingEnabled = true,
-      autoClusterMarkers = false,
-      autoClusterMarkersDistanceMeters = 1000,
-      onRegionChange,
-      onPress,
-      style,
-      ...rest
-    } = this.props;
-
-    const camera: Camera = {
-      altitude: zoomToAltitude(zoom || 1),
-      heading: 0,
-      pitch: 0,
-      zoom,
-      center: {
-        latitude: latitude || 0,
-        longitude: longitude || 0,
-      },
-    };
-
-    const markers = this.getChildrenForType(MapMarker);
-    const clusters = this.getChildrenForType(MapMarkerCluster);
-
-    const clusterViews = this.getChildrenForType(MapMarkerClusterView);
-    const clusterView = clusterViews.length ? clusterViews[0] : null; //Only take the first, ignore any others
-
-    if (autoClusterMarkers) {
-      this.clusterMarkers(
-        markers,
-        clusters,
-        autoClusterMarkersDistanceMeters,
-        clusterView
-      );
-    }
-
     return (
-      <MapViewContext.Provider
-        value={{
-          animateToLocation: (location) => this.animateToLocation(location),
-          region: this.state.region,
-        }}
-      >
-        <MapViewComponent
-          ref={this.mapRef}
-          onMapReady={() =>
-            // This initial animateToLocation ensures that 'region' state is initially set
-            this.animateToLocation({
-              latitude: camera.center.latitude,
-              longitude: camera.center.longitude,
-              zoom: camera.zoom,
-            })
-          }
-          provider={provider}
-          googleMapsApiKey={apiKey}
-          showsCompass={showsCompass}
-          initialCamera={camera}
-          loadingEnabled={loadingEnabled}
-          onRegionChangeComplete={(region) => {
-            onRegionChange?.(region);
-          }}
-          onRegionChange={(region) => this.setState({ region })}
-          onPress={(event) => {
-            const coordinate = event.nativeEvent.coordinate;
-            onPress?.(coordinate.latitude, coordinate.longitude);
-          }}
-          style={[styles.map, style]}
-          {...rest}
-        >
-          {markers.map((marker, index) =>
-            renderMarker(
-              marker.props,
-              index,
-              this.getMarkerRef(getMarkerIdentifier(marker.props)),
-              () => this.onMarkerPress(getMarkerIdentifier(marker.props))
-            )
-          )}
-
-          {/* 
-            Markers within clusters also need to able to assign refs and propogate press.
-            This is done through context to prevent exposing these internal config options as props of the cluster component
-          */}
-          <MapMarkerContext.Provider
-            value={{
-              getMarkerRef: (marker) =>
-                this.getMarkerRef(getMarkerIdentifier(marker)),
-              onMarkerPress: (marker) =>
-                this.onMarkerPress(getMarkerIdentifier(marker)),
-            }}
-          >
-            {clusters.map((cluster, index) => (
-              <React.Fragment key={index}>{cluster}</React.Fragment>
-            ))}
-          </MapMarkerContext.Provider>
-        </MapViewComponent>
-      </MapViewContext.Provider>
+      <MapViewF
+        {...this.props}
+        animateToLocation={this.animateToLocation}
+        mapRef={this.mapRef}
+      />
     );
   }
 }

--- a/packages/maps/src/components/MapView.tsx
+++ b/packages/maps/src/components/MapView.tsx
@@ -26,7 +26,7 @@ export const MapMarkerContext = React.createContext<MapMarkerContextType>({
 });
 
 export interface MapViewProps<T>
-  extends Omit<MapViewComponentProps, "onRegionChangeComplete"> {
+  extends Omit<MapViewComponentProps, "onRegionChangeComplete" | "onPress"> {
   apiKey: string;
   zoom?: number;
   latitude?: number;
@@ -37,6 +37,7 @@ export interface MapViewProps<T>
   keyExtractor?: (item: T, index: number) => string;
   renderItem?: ({ item, index }: { item: T; index: number }) => JSX.Element;
   onRegionChange?: (region: Region) => void;
+  onPress?: (latitude: number, longitude: number) => void;
 }
 
 interface MapViewState {
@@ -215,6 +216,7 @@ class MapView<T> extends React.Component<
       autoClusterMarkers = false,
       autoClusterMarkersDistanceMeters = 1000,
       onRegionChange,
+      onPress,
       style,
       ...rest
     } = this.props;
@@ -271,6 +273,10 @@ class MapView<T> extends React.Component<
             onRegionChange?.(region);
           }}
           onRegionChange={(region) => this.setState({ region })}
+          onPress={(event) => {
+            const coordinate = event.nativeEvent.coordinate;
+            onPress?.(coordinate.latitude, coordinate.longitude);
+          }}
           style={[styles.map, style]}
           {...rest}
         >

--- a/packages/maps/src/components/useDeepCompareMemo.ts
+++ b/packages/maps/src/components/useDeepCompareMemo.ts
@@ -1,0 +1,23 @@
+import React from "react";
+import isEqual from "lodash.isequal";
+
+function useDeepCompareMemoize(value: any) {
+  const ref = React.useRef();
+
+  if (!isEqual(value, ref.current)) {
+    ref.current = value;
+  }
+
+  return ref.current;
+}
+
+/**
+ * useMemo counterpart that does a deep compare on the dependency list
+ */
+export function useDeepCompareMemo<T>(
+  factory: () => T,
+  deps: React.DependencyList | undefined
+): T {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  return React.useMemo(factory, deps?.map(useDeepCompareMemoize));
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3793,6 +3793,13 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
+"@types/lodash.isequal@^4.5.6":
+  version "4.5.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.isequal/-/lodash.isequal-4.5.6.tgz#ff42a1b8e20caa59a97e446a77dc57db923bc02b"
+  integrity sha512-Ww4UGSe3DmtvLLJm2F16hDwEQSv7U0Rr8SujLUA2wHI2D2dm8kPu6Et+/y303LfjTIwSBKXB/YTUcAKpem/XEg==
+  dependencies:
+    "@types/lodash" "*"
+
 "@types/lodash.isnumber@^3.0.6":
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/@types/lodash.isnumber/-/lodash.isnumber-3.0.7.tgz#0726161b5f6049759d20415fef8c6776a6a48ebf"


### PR DESCRIPTION
- Adds onPress to MapView that provides `latitude` and `longitude` on the callback
- Fixed panning / dragging issue on web
  - For some reason, the web version of the map view does not work well when the state is updated. Every time state is updated, panning is stopped. Since we update the state when the user pans, this creates an issue. 
  - To fix this, the MapView component was memorized to only be updated when it needs to
  - MapView was a class component, so it first needed to be converted to a functional component to be able to memoize.
  - Also added a `useDeepCompareMemo` utility function that is the same as `useMemo` but does a deep check on the dependencies.
  - The diff is big, but it's all just moving to a functional component and adding `useMemo` and `useCallback` in a bunch of places.