### PR TITLE
Fix icons from being cut off/clipped

### DIFF
--- a/packages/core/src/components/Checkbox/Checkbox.tsx
+++ b/packages/core/src/components/Checkbox/Checkbox.tsx
@@ -92,7 +92,7 @@ const Checkbox: React.FC<CheckboxProps & PressableProps & IconSlot> = ({
       accessibilityState={{ disabled }}
       accessibilityRole="button"
       accessibilityLiveRegion="polite"
-      style={[styles.container, style, { width: size, height: size }]}
+      style={[styles.container, style]}
     >
       <Icon
         style={styles.icon}

--- a/packages/core/src/components/IconButton.tsx
+++ b/packages/core/src/components/IconButton.tsx
@@ -52,8 +52,6 @@ const IconButton: React.FC<React.PropsWithChildren<Props>> = ({
           styles.container,
           {
             opacity: pressed ? activeOpacity : disabled ? disabledOpacity : 1,
-            width: size,
-            height: size,
             alignItems: "center",
             justifyContent: "center",
           },

--- a/packages/native/src/components/Icon.tsx
+++ b/packages/native/src/components/Icon.tsx
@@ -1,12 +1,5 @@
 import * as React from "react";
-import {
-  View,
-  StyleSheet,
-  ViewProps,
-  StyleProp,
-  ImageStyle,
-  Platform,
-} from "react-native";
+import { ViewProps, StyleProp, ImageStyle, Platform } from "react-native";
 
 // This must use require to work in both web as a published project and in Snack
 const VectorIcons = require("@expo/vector-icons");
@@ -35,24 +28,25 @@ const Icon: React.FC<React.PropsWithChildren<Props>> = ({
   const IconSet = VectorIcons[iconSet];
 
   return (
-    <View style={[styles.container, { width: size, height: size }, style]}>
-      <IconSet {...rest} name={name} color={color} size={size} />
-    </View>
+    <IconSet
+      {...rest}
+      name={name}
+      color={color}
+      size={size}
+      style={[
+        {
+          ...Platform.select({
+            web: {
+              cursor: "pointer",
+              userSelect: "none",
+            },
+          }),
+        },
+        ,
+        style,
+      ]}
+    />
   );
 };
-
-const styles = StyleSheet.create({
-  container: {
-    alignItems: "center",
-    justifyContent: "center",
-    overflow: "hidden",
-    ...Platform.select({
-      web: {
-        cursor: "pointer",
-        userSelect: "none",
-      },
-    }),
-  },
-});
 
 export default Icon;


### PR DESCRIPTION
- Icons do not always respect the given `size` and can be slightly larger. Since we have a wrapping `View` with width and height set to that `size`, this caused the icon to sometimes be clipped and cut off since it's bigger than that size.
- The fix here is to remove the wrapping `View` and just render the Icon directly letting it take it's needed size. This means it will not exactly match the `size`. An icon with a `size` of 50 could have a width of 54 for example.