### PR TITLE
Use exact version of `@react-google-maps/api` (47)

### DIFF
--- a/packages/maps/package.json
+++ b/packages/maps/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@draftbit/ui": "47.7.7",
     "@teovilla/react-native-web-maps": "^0.9.1",
+    "@react-google-maps/api": "~2.18.1",
     "lodash.isequal": "^4.5.0",
     "react-native-maps": "1.3.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3254,7 +3254,7 @@
   dependencies:
     esquery "^1.0.1"
 
-"@react-google-maps/api@^2.12.0":
+"@react-google-maps/api@^2.12.0", "@react-google-maps/api@~2.18.1":
   version "2.18.1"
   resolved "https://registry.yarnpkg.com/@react-google-maps/api/-/api-2.18.1.tgz#140bb134f50c98939b6eb440d01dbb7df562090c"
   integrity sha512-KVlUO/Shh+0g/3egWaKmY0sz6+0QOnYkBGvrBMJbz23519LauA+iJFc4NDCmWNHqD5Vhb/Bkg0kSJgq0Stz3Iw==


### PR DESCRIPTION
- Later versions of `@react-google-maps/api` break on snack causing the callout to be rendered out of place. The reason behind this is unclear at the moment.
- Explicitly pinning to an older version (`~2.18.1`) fixes the issue because it prevents using any version higher than `~2.18.x`