### PR TITLE
Upgrade @react-native-community/datetimepicker version

### DIFF
--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@draftbit/types": "48.3.0",
     "@expo/vector-icons": "^13.0.0",
-    "@react-native-community/datetimepicker": "6.3.5",
+    "@react-native-community/datetimepicker": "6.7.3",
     "@react-native-community/slider": "4.4.2",
     "expo-camera": "~13.2.1",
     "expo-linear-gradient": "~12.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3586,10 +3586,10 @@
     prompts "^2.4.0"
     semver "^6.3.0"
 
-"@react-native-community/datetimepicker@6.3.5":
-  version "6.3.5"
-  resolved "https://registry.yarnpkg.com/@react-native-community/datetimepicker/-/datetimepicker-6.3.5.tgz#64c0d30d0221c887fff56084b03101a017175159"
-  integrity sha512-iiI1SRcKRj+KXlDWqJYKcfgN6N6kqz9/z/Xi3q1MMA5BfDNXcTX827gscB3PwQcA+AwitpZGjR7iIYnyDgnovg==
+"@react-native-community/datetimepicker@6.7.3":
+  version "6.7.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/datetimepicker/-/datetimepicker-6.7.3.tgz#e6d75a42729265d8404d1d668c86926564abca2f"
+  integrity sha512-fXWbEdHMLW/e8cts3snEsbOTbnFXfUHeO2pkiDFX3fWpFoDtUrRWvn50xbY13IJUUKHDhoJ+mj24nMRVIXfX1A==
   dependencies:
     invariant "^2.2.4"
 


### PR DESCRIPTION
- Since we finally fixed the issue with IOS snack, we can upgrade this to the recommended version.