### PR TITLE
zoom in onRegionChange + MapCircle components (47)

### DIFF
--- a/packages/core/src/hooks.ts
+++ b/packages/core/src/hooks.ts
@@ -18,12 +18,12 @@ export const useDebounce = <T>(value: T, delay: number): T => {
   const [debouncedValue, setDebouncedValue] = React.useState(value);
 
   React.useEffect(() => {
-    const hanlder = setTimeout(() => {
+    const handler = setTimeout(() => {
       setDebouncedValue(value);
     }, delay);
 
     return () => {
-      clearTimeout(hanlder);
+      clearTimeout(handler);
     };
   }, [value, delay]);
 

--- a/packages/maps/package.json
+++ b/packages/maps/package.json
@@ -42,6 +42,7 @@
     "@draftbit/ui": "47.7.11",
     "@react-google-maps/api": "~2.18.1",
     "@teovilla/react-native-web-maps": "^0.9.1",
+    "color": "^4.2.3",
     "lodash.isequal": "^4.5.0",
     "react-native-maps": "1.3.2"
   },

--- a/packages/maps/src/components/MapCircle.tsx
+++ b/packages/maps/src/components/MapCircle.tsx
@@ -1,0 +1,44 @@
+import * as React from "react";
+import { Platform } from "react-native";
+import { Circle as MapCircleComponent } from "./react-native-maps";
+import type { MapCircleProps as MapCircleComponentProps } from "react-native-maps";
+import { withTheme, DefaultTheme } from "@draftbit/ui";
+import Color from "color";
+
+export interface MapCircleProps
+  extends Omit<MapCircleComponentProps, "center"> {
+  latitude: number;
+  longitude: number;
+  theme: typeof DefaultTheme;
+}
+
+const MapCircle: React.FC<React.PropsWithChildren<MapCircleProps>> = ({
+  theme,
+  latitude,
+  longitude,
+  radius = 2000,
+  fillColor: fillColorProp = theme.colors.primary,
+  strokeColor = theme.colors.primary,
+  ...rest
+}) => {
+  // Web maps by default uses a lower opacity for the circle, native needs an extra step
+  const fillColor =
+    Platform.OS === "web"
+      ? fillColorProp
+      : Color(fillColorProp).alpha(0.3).rgb().string();
+
+  return (
+    <MapCircleComponent
+      center={{
+        latitude,
+        longitude,
+      }}
+      radius={radius}
+      fillColor={fillColor}
+      strokeColor={strokeColor}
+      {...rest}
+    />
+  );
+};
+
+export default withTheme(MapCircle);

--- a/packages/maps/src/components/MapView.tsx
+++ b/packages/maps/src/components/MapView.tsx
@@ -66,7 +66,7 @@ const MapViewF = <T extends object>({
   mapRef: React.RefObject<MapViewComponent>;
 }) => {
   const [currentRegion, setCurrentRegion] = React.useState<Region | null>(null);
-  const delayedRegionValue = useDebounce(currentRegion, 500);
+  const delayedRegionValue = useDebounce(currentRegion, 300);
 
   const markerRefs = React.useMemo<
     Map<string, React.RefObject<MapMarkerRefType>>

--- a/packages/maps/src/components/MapView.tsx
+++ b/packages/maps/src/components/MapView.tsx
@@ -356,8 +356,8 @@ class MapView<T extends object> extends React.Component<
       heading: 0,
       pitch: 0,
       center: {
-        latitude,
-        longitude,
+        latitude: Number(latitude),
+        longitude: Number(longitude),
       },
     };
 

--- a/packages/maps/src/components/MapView.tsx
+++ b/packages/maps/src/components/MapView.tsx
@@ -230,7 +230,7 @@ const MapViewF = <T extends object>({
     const callOnRegionChange = async () => {
       if (delayedRegionValue) {
         const camera = await mapRef.current?.getCamera();
-        onRegionChange?.({ ...delayedRegionValue, zoom: camera?.zoom || 1 });
+        onRegionChange?.({ ...delayedRegionValue, zoom: camera?.zoom ?? 1 });
       }
     };
 

--- a/packages/maps/src/components/MapView.tsx
+++ b/packages/maps/src/components/MapView.tsx
@@ -13,6 +13,7 @@ import { MapMarkerClusterView } from "./marker-cluster";
 import { flattenReactFragments } from "@draftbit/ui";
 import type { MapMarker as MapMarkerRefType } from "react-native-maps";
 import { useDeepCompareMemo, useDebounce } from "../utils";
+import MapCircle from "./MapCircle";
 
 export interface MapMarkerContextType {
   onMarkerPress: (marker: MapMarkerProps) => void;
@@ -242,6 +243,10 @@ const MapViewF = <T extends object>({
     () => getChildrenForType(MapMarker),
     [getChildrenForType]
   );
+  const circles = React.useMemo(
+    () => getChildrenForType(MapCircle),
+    [getChildrenForType]
+  );
   const clusters = React.useMemo(
     () => getChildrenForType(MapMarkerCluster),
     [getChildrenForType]
@@ -309,6 +314,8 @@ const MapViewF = <T extends object>({
             <React.Fragment key={index}>{cluster}</React.Fragment>
           ))}
         </MapMarkerContext.Provider>
+
+        {circles}
       </MapViewComponent>
     ),
     [

--- a/packages/maps/src/components/marker-cluster/MapMarkerClusterView.tsx
+++ b/packages/maps/src/components/marker-cluster/MapMarkerClusterView.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { ViewStyle, StyleProp, Text, View } from "react-native";
 import { MapMarkerClusterContext } from "./MapMarkerClusterContext";
-import { withTheme } from "@draftbit/ui";
+import { withTheme, DefaultTheme } from "@draftbit/ui";
 
 interface MapMarkerClusterViewProps {
   zoomOnPress?: boolean;
@@ -27,36 +27,38 @@ const MapMarkerClusterView: React.FC<MapMarkerClusterViewProps> = ({
   );
 };
 
-export const DefaultMapMarkerClusterView = withTheme(({ theme }) => {
-  return (
-    <MapMarkerClusterView
-      renderItem={({ markerCount }) => (
-        <View
-          testID="default-map-marker-cluster-view"
-          style={{
-            backgroundColor: theme.colors.primary,
-            borderColor: theme.colors.background,
-            borderWidth: 1,
-            borderRadius: 15,
-            paddingHorizontal: 3,
-            minWidth: 30,
-            minHeight: 30,
-            alignItems: "center",
-            justifyContent: "center",
-          }}
-        >
-          <Text
+export const DefaultMapMarkerClusterView = withTheme(
+  ({ theme }: { theme: typeof DefaultTheme }) => {
+    return (
+      <MapMarkerClusterView
+        renderItem={({ markerCount }) => (
+          <View
+            testID="default-map-marker-cluster-view"
             style={{
-              color: theme.colors.background,
-              textAlign: "center",
+              backgroundColor: theme.colors.primary,
+              borderColor: theme.colors.background,
+              borderWidth: 1,
+              borderRadius: 15,
+              paddingHorizontal: 3,
+              minWidth: 30,
+              minHeight: 30,
+              alignItems: "center",
+              justifyContent: "center",
             }}
           >
-            {markerCount}
-          </Text>
-        </View>
-      )}
-    />
-  );
-});
+            <Text
+              style={{
+                color: theme.colors.background,
+                textAlign: "center",
+              }}
+            >
+              {markerCount}
+            </Text>
+          </View>
+        )}
+      />
+    );
+  }
+);
 
 export default MapMarkerClusterView;

--- a/packages/maps/src/components/react-native-maps/Circle.tsx
+++ b/packages/maps/src/components/react-native-maps/Circle.tsx
@@ -1,0 +1,1 @@
+export { Circle } from "react-native-maps";

--- a/packages/maps/src/components/react-native-maps/Circle.web.tsx
+++ b/packages/maps/src/components/react-native-maps/Circle.web.tsx
@@ -1,0 +1,1 @@
+export { Circle } from "@teovilla/react-native-web-maps";

--- a/packages/maps/src/components/react-native-maps/index.tsx
+++ b/packages/maps/src/components/react-native-maps/index.tsx
@@ -1,3 +1,4 @@
 export { default as default } from "./MapView";
 export { Callout } from "./Callout";
 export { Marker } from "./Marker";
+export { Circle } from "./Circle";

--- a/packages/maps/src/index.tsx
+++ b/packages/maps/src/index.tsx
@@ -5,3 +5,4 @@ export {
   MapMarkerClusterView,
 } from "./components/marker-cluster";
 export { default as MapCallout } from "./components/MapCallout";
+export { default as MapCircle } from "./components/MapCircle";

--- a/packages/maps/src/utils.ts
+++ b/packages/maps/src/utils.ts
@@ -21,3 +21,19 @@ export function useDeepCompareMemo<T>(
   // eslint-disable-next-line react-hooks/exhaustive-deps
   return React.useMemo(factory, deps?.map(useDeepCompareMemoize));
 }
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = React.useState(value);
+
+  React.useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}


### PR DESCRIPTION
- Add `MapCircle` component
- Include the current zoom in the `onRegionChange` callback
- Changed how `onRegionChange` is called
  - The web version of the maps did not call the `onRegionChangeComplete` when zoom changes
  - Instead use the state of the current region for the callback
  - Use a debounced value of the state to match the behavior of the `onRegionChangeComplete` (i.e. prevent too many calls when the user is dragging the map)
- Fixed a typo, util file, minor refactoring. 

Closes https://linear.app/draftbit/issue/P-3965/circle-component-for-map-view
Closes https://linear.app/draftbit/issue/P-4000/map-view-on-change-zoom-triger