### PR TITLE
Fix map circle transparency

### DIFF
--- a/packages/maps/src/components/MapCircle.tsx
+++ b/packages/maps/src/components/MapCircle.tsx
@@ -21,11 +21,17 @@ const MapCircle: React.FC<React.PropsWithChildren<MapCircleProps>> = ({
   strokeColor = theme.colors.primary,
   ...rest
 }) => {
-  // Web maps by default uses a lower opacity for the circle, native needs an extra step
-  const fillColor =
-    Platform.OS === "web"
-      ? fillColorProp
-      : Color(fillColorProp).alpha(0.3).rgb().string();
+  const parsedColor = Color(fillColorProp);
+
+  let fillColor;
+  if (parsedColor.alpha() === 0) {
+    fillColor = "transparent";
+  } else if (Platform.OS !== "web") {
+    // Web maps by default uses a lower opacity for the circle, native needs this extra step
+    fillColor = parsedColor.alpha(0.3).rgb().string();
+  } else {
+    fillColor = fillColorProp;
+  }
 
   return (
     <MapCircleComponent


### PR DESCRIPTION
- Use `transparent` color whenever a color is passed in with a 0 alpha
  - Prevents the overriding of the provided color to the default 0.3 alpha, which is not desired when passing in a transparent color. 

Closes https://linear.app/draftbit/issue/P-3965/circle-component-for-map-view