### PR TITLE
Fix type checking of picker options

### DIFF
--- a/packages/core/src/components/Picker/PickerCommon.ts
+++ b/packages/core/src/components/Picker/PickerCommon.ts
@@ -59,14 +59,18 @@ export function normalizeToPickerOptions(
 
   const firstOption = options[0];
 
-  if (typeof firstOption === ("string" || "number")) {
+  if (typeof firstOption === "string" || typeof firstOption === "number") {
     return options.map((option) => ({
       label: option as string | number,
       value: option as string | number,
     }));
   }
 
-  if (isObject(firstOption) && firstOption.value && firstOption.label) {
+  if (
+    isObject(firstOption) &&
+    firstOption.value !== undefined &&
+    firstOption.label !== undefined
+  ) {
     return (options as PickerOption[]).map((option) => {
       return {
         label: option.label,


### PR DESCRIPTION
- Was producing 'invalid options' error even when valid. 
  - `typeof firstOption === ("string" || "number")` does not seem to do what I intended, which is check if it is a string or a number
  -  `firstOption.value` or `firstOption.label` could be `0` which is falsy