### PR TITLE
Fix value checking of Picker

### DIFF
--- a/packages/core/src/components/Picker/PickerInputContainer.tsx
+++ b/packages/core/src/components/Picker/PickerInputContainer.tsx
@@ -53,14 +53,15 @@ const PickerInputContainer: React.FC<
     selectedLabel = selectedValue
       .map(
         (value) =>
-          options.find((option) => option.value === value)?.label.toString() ||
-          value
+          options
+            .find((option) => option.value.toString() === value.toString())
+            ?.label.toString() || value
       )
       .join(", ");
   } else {
     selectedLabel =
       options
-        .find((option) => option.value === selectedValue)
+        .find((option) => option.value.toString() === selectedValue?.toString())
         ?.label.toString() || selectedValue;
   }
 


### PR DESCRIPTION
- Add `.toString` when checking equality of value. `0` should be equal to `"0"`. This is needed because the passed in state in draftbit is always a string, even though the picker supports having numbers in the option values. So we need to able to equate a number with a string.
- A drawback is that you cannot have 2 separate option values `0` and `"0"` and expect them to be treated as different values.