### PR TITLE
Fix android youtube crash (47)

### DIFF
--- a/packages/core/src/components/YoutubePlayer/YoutubePlayer.native.tsx
+++ b/packages/core/src/components/YoutubePlayer/YoutubePlayer.native.tsx
@@ -20,6 +20,7 @@ const YoutubePlayer: React.FC<YoutubePlayerProps> = ({
       videoId={!videoId && !playlist ? defaultVideoId : videoId}
       playList={playlist}
       webViewStyle={viewStyles}
+      webViewProps={{ androidLayerType: "software" }} //Addresses a webview bug causing crashes on android: https://stackoverflow.com/a/71642894/8805150
     />
   );
 };


### PR DESCRIPTION
- The youtube player uses an iframe under the hood which can occasionally lead to a crash `Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x20 in tid 6568 (RenderThread), pid 6519 ()`
- https://stackoverflow.com/a/71642894/8805150 Added a workaround as seen in this thread that prevents this issue.