### PR TITLE
Close Picker dropdown when disabled (47)

### DIFF
--- a/packages/core/src/components/Picker/dropdown/DropDownPicker.tsx
+++ b/packages/core/src/components/Picker/dropdown/DropDownPicker.tsx
@@ -37,6 +37,7 @@ const DropDownPicker: React.FC<
   dropDownBorderWidth = 1,
   dropDownBorderRadius = 8,
   children: childrenProp,
+  disabled,
   ...rest
 }) => {
   const [pickerVisible, setPickerVisible] = React.useState(false);
@@ -83,6 +84,10 @@ const DropDownPicker: React.FC<
     }
   }, [pickerVisible, autoDismissKeyboard]);
 
+  React.useEffect(() => {
+    setPickerVisible(false);
+  }, [disabled]);
+
   return (
     <PickerInputContainer
       testID="dropdown-picker"
@@ -92,6 +97,7 @@ const DropDownPicker: React.FC<
       options={options}
       onPress={() => setPickerVisible(!pickerVisible)}
       zIndex={pickerVisible ? 100 : undefined} // Guarantees drop down is rendered above all sibling components
+      disabled={disabled}
       {...rest}
     >
       <DropDownPickerComponent


### PR DESCRIPTION
- Closes the dropdown whenever the disabled prop changes, otherwise could still allow selection even when disabled if the dropdown was already open.