### PR TITLE
Fix picker issue when long press (47)

### DIFF
--- a/packages/core/src/components/Picker/PickerInputContainer.tsx
+++ b/packages/core/src/components/Picker/PickerInputContainer.tsx
@@ -81,6 +81,7 @@ const PickerInputContainer: React.FC<
         style={StyleSheet.absoluteFillObject}
         disabled={disabled}
         onPress={onPress}
+        onLongPress={onPress}
       />
       {children}
     </View>


### PR DESCRIPTION
- Picker had some inconsistent behavior when triggering it using a long press on Android. Explicitly adding the `onLongPress` prop addresses the issue.