### PR TITLE
Disable `tracksViewChanges` on marker clusters

### DIFF
--- a/packages/maps/src/components/marker-cluster/MapMarkerCluster.tsx
+++ b/packages/maps/src/components/marker-cluster/MapMarkerCluster.tsx
@@ -74,6 +74,7 @@ const MapMarkerCluster: React.FC<React.PropsWithChildren> = ({
                   latitude,
                   longitude,
                   children: clusterView,
+                  tracksViewChanges: false,
                   onPress,
                 })}
               </MapMarkerClusterContext.Provider>


### PR DESCRIPTION
- Disabling this prop can improve performance for custom markers (which is what a cluster is). It would only need to be enabled if the custom marker would dynamically change, which is not the case for clusters.