### PR TITLE
fix: ignore textTransform uppercase label of TabView

### DIFF
--- a/packages/core/src/components/TabView/TabView.tsx
+++ b/packages/core/src/components/TabView/TabView.tsx
@@ -111,7 +111,7 @@ const TabViewComponent: React.FC<React.PropsWithChildren<TabViewProps>> = ({
         indicatorStyle={{
           backgroundColor: indicatorColor || theme.colors.primary,
         }}
-        labelStyle={textStyles}
+        labelStyle={[textStyles, { textTransform: "none" }]}
         renderIcon={({ route, color }) =>
           route?.icon ? (
             <Icon name={route.icon} color={color} size={iconSize} />

--- a/packages/core/src/components/TabView/TabView.tsx
+++ b/packages/core/src/components/TabView/TabView.tsx
@@ -111,7 +111,7 @@ const TabViewComponent: React.FC<React.PropsWithChildren<TabViewProps>> = ({
         indicatorStyle={{
           backgroundColor: indicatorColor || theme.colors.primary,
         }}
-        labelStyle={[textStyles, { textTransform: "none" }]}
+        labelStyle={[{ textTransform: "none" }, textStyles]}
         renderIcon={({ route, color }) =>
           route?.icon ? (
             <Icon name={route.icon} color={color} size={iconSize} />


### PR DESCRIPTION
## Problem

File: `react-native-tab-view/TabBarItem.tsx` force label into uppercase 

<img width="554" alt="Screenshot 2023-10-04 at 17 30 42" src="https://github.com/draftbit/react-native-jigsaw/assets/7247063/6eb67686-2fe9-46ac-9dcc-99d990cc0200">

## Overview

- Add textTransform to none to prevent uppercase of Tab view title

## Demo

<img width="537" alt="Screenshot 2023-10-04 at 17 23 32" src="https://github.com/draftbit/react-native-jigsaw/assets/7247063/751f2a4d-83aa-40a9-b83d-80158ba23b6d">

Closes https://linear.app/draftbit/issue/P-4149/not-able-to-make-capitalize-tab-view-title
