### PR TITLE
Add prop to improve performance of MapView (47)

### DIFF
--- a/packages/maps/src/__tests__/MapView.test.tsx
+++ b/packages/maps/src/__tests__/MapView.test.tsx
@@ -186,6 +186,7 @@ describe("MapView tests", () => {
               }
             }
             onPress={[Function]}
+            tracksViewChanges={true}
           />,
           <Marker
             coordinate={
@@ -195,6 +196,7 @@ describe("MapView tests", () => {
               }
             }
             onPress={[Function]}
+            tracksViewChanges={true}
           />,
         ],
         [
@@ -206,6 +208,7 @@ describe("MapView tests", () => {
               }
             }
             onPress={[Function]}
+            tracksViewChanges={true}
           />,
           <Marker
             coordinate={
@@ -215,6 +218,7 @@ describe("MapView tests", () => {
               }
             }
             onPress={[Function]}
+            tracksViewChanges={true}
           />,
         ],
       ]
@@ -247,6 +251,7 @@ describe("MapView tests", () => {
               }
             }
             onPress={[Function]}
+            tracksViewChanges={true}
           />,
           <Marker
             coordinate={
@@ -256,6 +261,7 @@ describe("MapView tests", () => {
               }
             }
             onPress={[Function]}
+            tracksViewChanges={true}
           />,
         ],
         [
@@ -267,6 +273,7 @@ describe("MapView tests", () => {
               }
             }
             onPress={[Function]}
+            tracksViewChanges={true}
           />,
           <Marker
             coordinate={
@@ -276,6 +283,7 @@ describe("MapView tests", () => {
               }
             }
             onPress={[Function]}
+            tracksViewChanges={true}
           />,
         ],
       ]
@@ -332,6 +340,7 @@ describe("MapView tests", () => {
               }
             }
             onPress={[Function]}
+            tracksViewChanges={true}
           />,
           <Marker
             coordinate={
@@ -341,6 +350,7 @@ describe("MapView tests", () => {
               }
             }
             onPress={[Function]}
+            tracksViewChanges={true}
           />,
         ],
       ]

--- a/packages/maps/src/components/MapView.tsx
+++ b/packages/maps/src/components/MapView.tsx
@@ -238,7 +238,13 @@ const MapViewF = <T extends object>({
 
     callOnRegionChange();
 
+    // onRegionChange excluded to prevent calling on every rerender when using an anonymous function (which is most common)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [delayedRegionValue]);
+
+  React.useEffect(() => {
     setMarkerTracksViewChanges(true);
+
     const timeout = setTimeout(() => {
       setMarkerTracksViewChanges(false);
     }, 100);
@@ -246,9 +252,7 @@ const MapViewF = <T extends object>({
     return () => {
       clearTimeout(timeout);
     };
-    // onRegionChange excluded to prevent calling on every rerender when using an anonymous function (which is most common)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [delayedRegionValue]);
+  }, [currentRegion]);
 
   const markers = React.useMemo(
     () => getChildrenForType(MapMarker),
@@ -353,6 +357,7 @@ const MapViewF = <T extends object>({
       showsCompass,
       style,
       zoom,
+      markerTracksViewChanges,
     ]
   );
 

--- a/packages/maps/src/components/marker-cluster/MapMarkerCluster.tsx
+++ b/packages/maps/src/components/marker-cluster/MapMarkerCluster.tsx
@@ -9,15 +9,19 @@ import { MapViewContext } from "../MapViewCommon";
 import { flattenReactFragments } from "@draftbit/ui";
 import { MapMarkerContext } from "../MapView";
 
+interface MapMarkerClusterProps {
+  tracksViewChanges?: boolean;
+}
+
 /**
  * Component that clusters all markers provided in as children to a single point when zoomed out, and shows the markers themselves when zoomed in
  * Renders a default component that shows the number of components inside cluster
  *
  * Also accepts MapMarkerClusterView to override the rendered cluster component
  */
-const MapMarkerCluster: React.FC<React.PropsWithChildren> = ({
-  children: childrenProp,
-}) => {
+const MapMarkerCluster: React.FC<
+  React.PropsWithChildren<MapMarkerClusterProps>
+> = ({ children: childrenProp, tracksViewChanges }) => {
   const { region, animateToLocation } = React.useContext(MapViewContext);
 
   const children = React.useMemo(
@@ -75,14 +79,18 @@ const MapMarkerCluster: React.FC<React.PropsWithChildren> = ({
                   longitude,
                   children: clusterView,
                   onPress,
+                  tracksViewChanges,
                 })}
               </MapMarkerClusterContext.Provider>
             );
           }}
         >
           {markers.map((marker, index) =>
-            renderMarker(marker.props, index, getMarkerRef(marker.props), () =>
-              onMarkerPress(marker.props)
+            renderMarker(
+              { ...marker.props, tracksViewChanges },
+              index,
+              getMarkerRef(marker.props),
+              () => onMarkerPress(marker.props)
             )
           )}
         </MarkerClusterer>


### PR DESCRIPTION
- When the `tracksViewChanges` prop on markers is enabled, every marker on the screen keeps track of changes in the parent view. When there are many markers, this can create a sluggish and laggy map when trying to drag/pan (most noticeable on android).
  - This prop is enabled by default - https://github.com/react-native-maps/react-native-maps/blob/master/docs/marker.md#props 
- This PR temporarily disables the prop when dragging then enables it after dragging stops
- Disabling entirely creates another issue where markers and clusters are never updated, so this is best solution to prevent laggy panning while still allowing markers and clusters to be able to update.