### PR TITLE
Finalize MapView performance optimizations

### DIFF
--- a/packages/maps/src/__tests__/MapView.test.tsx
+++ b/packages/maps/src/__tests__/MapView.test.tsx
@@ -186,7 +186,6 @@ describe("MapView tests", () => {
               }
             }
             onPress={[Function]}
-            tracksViewChanges={true}
           />,
           <Marker
             coordinate={
@@ -196,7 +195,6 @@ describe("MapView tests", () => {
               }
             }
             onPress={[Function]}
-            tracksViewChanges={true}
           />,
         ],
         [
@@ -208,7 +206,6 @@ describe("MapView tests", () => {
               }
             }
             onPress={[Function]}
-            tracksViewChanges={true}
           />,
           <Marker
             coordinate={
@@ -218,7 +215,6 @@ describe("MapView tests", () => {
               }
             }
             onPress={[Function]}
-            tracksViewChanges={true}
           />,
         ],
       ]
@@ -251,7 +247,6 @@ describe("MapView tests", () => {
               }
             }
             onPress={[Function]}
-            tracksViewChanges={true}
           />,
           <Marker
             coordinate={
@@ -261,7 +256,6 @@ describe("MapView tests", () => {
               }
             }
             onPress={[Function]}
-            tracksViewChanges={true}
           />,
         ],
         [
@@ -273,7 +267,6 @@ describe("MapView tests", () => {
               }
             }
             onPress={[Function]}
-            tracksViewChanges={true}
           />,
           <Marker
             coordinate={
@@ -283,7 +276,6 @@ describe("MapView tests", () => {
               }
             }
             onPress={[Function]}
-            tracksViewChanges={true}
           />,
         ],
       ]
@@ -340,7 +332,6 @@ describe("MapView tests", () => {
               }
             }
             onPress={[Function]}
-            tracksViewChanges={true}
           />,
           <Marker
             coordinate={
@@ -350,7 +341,6 @@ describe("MapView tests", () => {
               }
             }
             onPress={[Function]}
-            tracksViewChanges={true}
           />,
         ],
       ]

--- a/packages/maps/src/components/MapMarker.tsx
+++ b/packages/maps/src/components/MapMarker.tsx
@@ -5,6 +5,7 @@ import {
   View,
   StyleSheet,
   Text,
+  Platform,
 } from "react-native";
 import { Marker as MapMarkerComponent } from "./react-native-maps";
 import type {
@@ -20,6 +21,7 @@ export interface MapMarkerProps
   longitude: number;
   pinImage?: string | ImageSourcePropType;
   pinImageSize?: number;
+  androidUseDefaultIconImplementation?: boolean;
   onPress?: (latitude: number, longitude: number) => void;
 }
 
@@ -40,6 +42,7 @@ export function renderMarker(
     longitude,
     pinImage,
     pinImageSize = 50,
+    androidUseDefaultIconImplementation = false,
     onPress,
     children,
     title,
@@ -76,6 +79,9 @@ export function renderMarker(
     );
   }
 
+  const shouldUseDefaultIconImplemnation =
+    Platform.OS !== "android" || !androidUseDefaultIconImplementation;
+
   return (
     <MapMarkerComponent
       ref={ref}
@@ -89,11 +95,18 @@ export function renderMarker(
         const coordinate = event.nativeEvent.coordinate;
         onPress?.(coordinate.latitude, coordinate.longitude);
       }}
+      icon={
+        shouldUseDefaultIconImplemnation
+          ? typeof pinImage === "string"
+            ? { uri: pinImage }
+            : (pinImage as any)
+          : undefined
+      }
       {...rest}
     >
       {nonCalloutChildren}
 
-      {pinImage && (
+      {pinImage && !shouldUseDefaultIconImplemnation && (
         <Image
           testID="map-marker-pin-image"
           source={typeof pinImage === "string" ? { uri: pinImage } : pinImage}

--- a/packages/maps/src/components/MapMarker.tsx
+++ b/packages/maps/src/components/MapMarker.tsx
@@ -80,7 +80,7 @@ export function renderMarker(
   }
 
   const shouldUseDefaultIconImplemnation =
-    Platform.OS !== "android" || !androidUseDefaultIconImplementation;
+    Platform.OS === "android" && androidUseDefaultIconImplementation;
 
   return (
     <MapMarkerComponent

--- a/packages/maps/src/components/MapMarker.tsx
+++ b/packages/maps/src/components/MapMarker.tsx
@@ -79,7 +79,7 @@ export function renderMarker(
     );
   }
 
-  const shouldUseDefaultIconImplemnation =
+  const shouldUseDefaultIconImplementation =
     Platform.OS === "android" && androidUseDefaultIconImplementation;
 
   return (
@@ -96,7 +96,7 @@ export function renderMarker(
         onPress?.(coordinate.latitude, coordinate.longitude);
       }}
       icon={
-        shouldUseDefaultIconImplemnation
+        shouldUseDefaultIconImplementation
           ? typeof pinImage === "string"
             ? { uri: pinImage }
             : (pinImage as any)
@@ -106,7 +106,7 @@ export function renderMarker(
     >
       {nonCalloutChildren}
 
-      {pinImage && !shouldUseDefaultIconImplemnation && (
+      {pinImage && !shouldUseDefaultIconImplementation && (
         <Image
           testID="map-marker-pin-image"
           source={typeof pinImage === "string" ? { uri: pinImage } : pinImage}

--- a/packages/maps/src/components/MapView.tsx
+++ b/packages/maps/src/components/MapView.tsx
@@ -184,10 +184,10 @@ const MapViewF = <T extends object>({
   const clusterMarkers = React.useCallback(
     (
       markers: React.ReactElement[],
-      clusters: React.ReactElement[],
       distanceMeters: number,
       clusterView?: React.ReactElement
     ) => {
+      const clusters = [];
       for (const marker of markers) {
         const { latitude: lat, longitude: long } =
           marker.props as MapMarkerProps;
@@ -211,6 +211,7 @@ const MapViewF = <T extends object>({
           );
         }
       }
+      return clusters;
     },
     [getNearbyMarkers]
   );
@@ -243,27 +244,40 @@ const MapViewF = <T extends object>({
     () => getChildrenForType(MapMarker),
     [getChildrenForType]
   );
+
   const circles = React.useMemo(
     () => getChildrenForType(MapCircle),
     [getChildrenForType]
   );
-  const clusters = React.useMemo(
+
+  const manualClusters = React.useMemo(
     () => getChildrenForType(MapMarkerCluster),
     [getChildrenForType]
   );
+
   const clusterView = React.useMemo(() => {
     const clusterViews = getChildrenForType(MapMarkerClusterView);
     return clusterViews.length ? clusterViews[0] : undefined; //Only take the first, ignore any others
   }, [getChildrenForType]);
 
-  if (autoClusterMarkers) {
-    clusterMarkers(
-      markers,
-      clusters,
-      autoClusterMarkersDistanceMeters,
-      clusterView
-    );
-  }
+  const clusters = React.useMemo(() => {
+    if (autoClusterMarkers) {
+      return clusterMarkers(
+        markers,
+        autoClusterMarkersDistanceMeters,
+        clusterView
+      ).concat(manualClusters);
+    } else {
+      return manualClusters;
+    }
+  }, [
+    autoClusterMarkers,
+    autoClusterMarkersDistanceMeters,
+    markers,
+    manualClusters,
+    clusterView,
+    clusterMarkers,
+  ]);
 
   const memoizedMapView = useDeepCompareMemo(
     () => (

--- a/packages/maps/src/components/marker-cluster/MapMarkerCluster.tsx
+++ b/packages/maps/src/components/marker-cluster/MapMarkerCluster.tsx
@@ -91,4 +91,4 @@ const MapMarkerCluster: React.FC<React.PropsWithChildren> = ({
   );
 };
 
-export default React.memo(MapMarkerCluster);
+export default MapMarkerCluster;

--- a/packages/maps/src/components/marker-cluster/MapMarkerCluster.tsx
+++ b/packages/maps/src/components/marker-cluster/MapMarkerCluster.tsx
@@ -9,19 +9,15 @@ import { MapViewContext } from "../MapViewCommon";
 import { flattenReactFragments } from "@draftbit/ui";
 import { MapMarkerContext } from "../MapView";
 
-interface MapMarkerClusterProps {
-  tracksViewChanges?: boolean;
-}
-
 /**
  * Component that clusters all markers provided in as children to a single point when zoomed out, and shows the markers themselves when zoomed in
  * Renders a default component that shows the number of components inside cluster
  *
  * Also accepts MapMarkerClusterView to override the rendered cluster component
  */
-const MapMarkerCluster: React.FC<
-  React.PropsWithChildren<MapMarkerClusterProps>
-> = ({ children: childrenProp, tracksViewChanges }) => {
+const MapMarkerCluster: React.FC<React.PropsWithChildren> = ({
+  children: childrenProp,
+}) => {
   const { region, animateToLocation } = React.useContext(MapViewContext);
 
   const children = React.useMemo(
@@ -79,18 +75,14 @@ const MapMarkerCluster: React.FC<
                   longitude,
                   children: clusterView,
                   onPress,
-                  tracksViewChanges,
                 })}
               </MapMarkerClusterContext.Provider>
             );
           }}
         >
           {markers.map((marker, index) =>
-            renderMarker(
-              { ...marker.props, tracksViewChanges },
-              index,
-              getMarkerRef(marker.props),
-              () => onMarkerPress(marker.props)
+            renderMarker(marker.props, index, getMarkerRef(marker.props), () =>
+              onMarkerPress(marker.props)
             )
           )}
         </MarkerClusterer>

--- a/packages/maps/src/components/marker-cluster/MapMarkerCluster.tsx
+++ b/packages/maps/src/components/marker-cluster/MapMarkerCluster.tsx
@@ -75,6 +75,10 @@ const MapMarkerCluster: React.FC<React.PropsWithChildren> = ({
                   longitude,
                   children: clusterView,
                   onPress,
+                  tracksViewChanges:
+                    clusterView.type === DefaultMapMarkerClusterView
+                      ? false
+                      : clusterView.props.tracksViewChanges,
                 })}
               </MapMarkerClusterContext.Provider>
             );

--- a/packages/maps/src/components/marker-cluster/MapMarkerCluster.tsx
+++ b/packages/maps/src/components/marker-cluster/MapMarkerCluster.tsx
@@ -91,4 +91,4 @@ const MapMarkerCluster: React.FC<React.PropsWithChildren> = ({
   );
 };
 
-export default MapMarkerCluster;
+export default React.memo(MapMarkerCluster);

--- a/packages/maps/src/components/marker-cluster/MapMarkerClusterView.tsx
+++ b/packages/maps/src/components/marker-cluster/MapMarkerClusterView.tsx
@@ -7,6 +7,7 @@ interface MapMarkerClusterViewProps {
   zoomOnPress?: boolean;
   onPress?: (latitude: number, longitude: number) => void;
   renderItem?: ({ markerCount }: { markerCount: number }) => JSX.Element;
+  tracksViewChanges?: boolean;
   style?: StyleProp<ViewStyle>;
 }
 

--- a/packages/maps/src/components/marker-cluster/MapMarkerClusterView.tsx
+++ b/packages/maps/src/components/marker-cluster/MapMarkerClusterView.tsx
@@ -27,8 +27,8 @@ const MapMarkerClusterView: React.FC<MapMarkerClusterViewProps> = ({
   );
 };
 
-export const DefaultMapMarkerClusterView = React.memo(
-  withTheme(({ theme }: { theme: typeof DefaultTheme }) => {
+export const DefaultMapMarkerClusterView = withTheme(
+  ({ theme }: { theme: typeof DefaultTheme }) => {
     return (
       <MapMarkerClusterView
         renderItem={({ markerCount }) => (
@@ -58,7 +58,7 @@ export const DefaultMapMarkerClusterView = React.memo(
         )}
       />
     );
-  })
+  }
 );
 
 export default MapMarkerClusterView;

--- a/packages/maps/src/components/marker-cluster/MapMarkerClusterView.tsx
+++ b/packages/maps/src/components/marker-cluster/MapMarkerClusterView.tsx
@@ -27,8 +27,8 @@ const MapMarkerClusterView: React.FC<MapMarkerClusterViewProps> = ({
   );
 };
 
-export const DefaultMapMarkerClusterView = withTheme(
-  ({ theme }: { theme: typeof DefaultTheme }) => {
+export const DefaultMapMarkerClusterView = React.memo(
+  withTheme(({ theme }: { theme: typeof DefaultTheme }) => {
     return (
       <MapMarkerClusterView
         renderItem={({ markerCount }) => (
@@ -58,7 +58,7 @@ export const DefaultMapMarkerClusterView = withTheme(
         )}
       />
     );
-  }
+  })
 );
 
 export default MapMarkerClusterView;


### PR DESCRIPTION
- Reverts https://github.com/draftbit/react-native-jigsaw/pull/800
  - Resulted in more issue than it solved
- Add the `androidUseDefaultIconImplementation` prop for markers
  - When enabled, uses the default `icon` prop instead of rendering an image as a 'custom' view.  This is much better performance wise since custom views in markers on android perform really **really** bad. (common issue: https://github.com/react-native-maps/react-native-maps/issues/2658)
  - Drawback is that it loses the ability to set the icon size, instead it will use the source image size. Good as an option, but not as the default (will be used with an expert app)
  - This addresses the issue when using a custom `pinImage`
- Optimizes how auto cluster are generated to prevent recreation on every re-render.
- Disable `tracksViewChanges` for the default cluster view to improve performance of that as well  

Closes https://linear.app/draftbit/issue/P-4143/performance-issue-with-map-component-on-android