### PR TITLE
Clean up some warnings

### DIFF
--- a/packages/core/src/components/DatePicker/DatePicker.tsx
+++ b/packages/core/src/components/DatePicker/DatePicker.tsx
@@ -13,6 +13,7 @@ import {
   LayoutChangeEvent,
   TextInput as NativeTextInput,
   Keyboard,
+  Platform,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
@@ -188,14 +189,14 @@ const DatePicker: React.FC<React.PropsWithChildren<Props>> = ({
       Animated.timing(labeled, {
         toValue: 0,
         duration: BLUR_ANIMATION_DURATION,
-        useNativeDriver: true,
+        useNativeDriver: Platform.OS !== "web",
       }).start();
     } else {
       // _restoreLabel();
       Animated.timing(labeled, {
         toValue: 1,
         duration: FOCUS_ANIMATION_DURATION,
-        useNativeDriver: true,
+        useNativeDriver: Platform.OS !== "web",
       }).start();
     }
   }, [value, focused, placeholder1, labeled]);

--- a/packages/core/src/components/Text.tsx
+++ b/packages/core/src/components/Text.tsx
@@ -10,14 +10,6 @@ type Props = {
 class Text extends React.Component<Props> {
   _root: any;
 
-  state: any = {
-    nativeProps: {},
-  };
-
-  setNativeProps(args: TextProps) {
-    this.state.nativeProps = args || {};
-  }
-
   render() {
     const { style, ...rest } = this.props;
     const writingDirection = I18nManager.isRTL ? "rtl" : "ltr";
@@ -25,7 +17,6 @@ class Text extends React.Component<Props> {
     return (
       <NativeText
         {...rest}
-        {...this.state.nativeProps}
         ref={(c) => {
           this._root = c;
         }}

--- a/packages/core/src/components/TextField.tsx
+++ b/packages/core/src/components/TextField.tsx
@@ -54,7 +54,6 @@ export type Props = {
   IconSlot;
 
 interface State {
-  nativeProps: any;
   labeled: Animated.Value;
   focused?: boolean;
   placeholder?: string | undefined;
@@ -76,7 +75,6 @@ class TextField extends React.Component<Props, State> {
   }
 
   state: State = {
-    nativeProps: {},
     labeled: new Animated.Value(this.props.value || this.props.error ? 0 : 1),
     focused: false,
     placeholder: this.props.error ? this.props.placeholder : "",
@@ -207,15 +205,6 @@ class TextField extends React.Component<Props, State> {
   }
 
   _root: NativeTextInput | undefined = undefined;
-  /**
-   * @internal
-   */
-  setNativeProps(args: Props) {
-    this.setState((state) => ({
-      ...state,
-      nativeState: args || {},
-    }));
-  }
 
   isFocused() {
     return this._root && this._root.isFocused();
@@ -532,7 +521,6 @@ class TextField extends React.Component<Props, State> {
               : this.props.placeholder,
             placeholderTextColor: placeholderColor,
             editable: !disabled && editable,
-            disabled: disabled || !editable,
             selectionColor: activeColor,
             multiline,
             numberOfLines,
@@ -541,7 +529,6 @@ class TextField extends React.Component<Props, State> {
             underlineColorAndroid: "transparent",
             style: inputStyles,
             ...rest,
-            ...this.state.nativeProps,
             value: this.state.value,
           })}
         </View>

--- a/packages/core/src/components/TextField.tsx
+++ b/packages/core/src/components/TextField.tsx
@@ -12,6 +12,7 @@ import {
   ViewStyle,
   TextStyle,
   LayoutChangeEvent,
+  Platform,
 } from "react-native";
 import { withTheme } from "../theming";
 import type { Theme } from "../styles/DefaultTheme";
@@ -158,14 +159,14 @@ class TextField extends React.Component<Props, State> {
     Animated.timing(this.state.labeled, {
       toValue: 1,
       duration: FOCUS_ANIMATION_DURATION,
-      useNativeDriver: true,
+      useNativeDriver: Platform.OS !== "web",
     }).start();
 
   _minmizeLabel = () =>
     Animated.timing(this.state.labeled, {
       toValue: 0,
       duration: BLUR_ANIMATION_DURATION,
-      useNativeDriver: true,
+      useNativeDriver: Platform.OS !== "web",
     }).start();
 
   _handleFocus = () => {


### PR DESCRIPTION
- Remove traces of deprecated `setNativeProps`
- Only use reanimated native driver when not on web
- These should clean up some of the warnings seen in the builder