### PR TITLE
Fix Expo 49 Snack Reanimated Bug

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "clean": "rimraf lib",
     "clean:modules": "rimraf node_modules",
-    "build:commonjs": "../../node_modules/.bin/babel src --out-dir lib/commonjs --extensions .tsx,.ts,.js,.jsx",
+    "build:commonjs": "../../node_modules/.bin/babel src --out-dir lib/commonjs --extensions .tsx,.ts,.js,.jsx && ts-node scripts/polyfillReanimatedWorkletInitForSnack.ts",
     "build": "yarn clean && yarn build:commonjs  && yarn tsc",
     "test": "jest",
     "test:coverage": "jest --coverage"

--- a/packages/ui/scripts/polyfillReanimatedWorkletInitForSnack.ts
+++ b/packages/ui/scripts/polyfillReanimatedWorkletInitForSnack.ts
@@ -1,0 +1,25 @@
+import fs from "fs/promises";
+
+/**
+ * When the @draftbit/ui is used with snack, we run into the error: 'r.g.__reanimatedWorkletInit is not a function'
+ * The solution is to add a polyfill for the global.__reanimatedWorkletInit function
+ * https://forums.expo.dev/t/react-native-reanimated-error-r-g-reanimatedworkletinit-is-not-a-function/68222/3
+ *
+ * This polyfill needs to be done at the first point of execution, placing at the top of index.tsx does not guarntee that
+ * since the babel build reorders the code around which results in it not being the top most call.
+ *
+ * This script modified the built code to add the polyfill at the start
+ */
+
+const INDEX_FILE = "./lib/commonjs/index.js";
+
+async function polyfillReanimatedWorkletInitForSnack() {
+  const indexFileContents = await fs.readFile(INDEX_FILE, "utf-8");
+  const newContents =
+    "if(!global.__reanimatedWorkletInit){global.__reanimatedWorkletInit=function(){};}" +
+    indexFileContents;
+
+  await fs.writeFile(INDEX_FILE, newContents);
+}
+
+polyfillReanimatedWorkletInitForSnack();

--- a/packages/ui/scripts/polyfillReanimatedWorkletInitForSnack.ts
+++ b/packages/ui/scripts/polyfillReanimatedWorkletInitForSnack.ts
@@ -5,10 +5,10 @@ import fs from "fs/promises";
  * The solution is to add a polyfill for the global.__reanimatedWorkletInit function
  * https://forums.expo.dev/t/react-native-reanimated-error-r-g-reanimatedworkletinit-is-not-a-function/68222/3
  *
- * This polyfill needs to be done at the first point of execution, placing at the top of index.tsx does not guarntee that
+ * This polyfill needs to be done at the first point of execution, placing at the top of index.tsx does not guarantee that
  * since the babel build reorders the code around which results in it not being the top most call.
  *
- * This script modified the built code to add the polyfill at the start
+ * This script modifies the built code to add the polyfill at the start
  */
 
 const INDEX_FILE = "./lib/commonjs/index.js";

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -1,5 +1,3 @@
-//@ts-ignore
-global.__reanimatedWorkletInit = function () {};
 import { Icon } from "@draftbit/native";
 export { Icon, LinearGradient, WebView } from "@draftbit/native";
 

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -1,3 +1,5 @@
+//@ts-ignore
+global.__reanimatedWorkletInit = function () {};
 import { Icon } from "@draftbit/native";
 export { Icon, LinearGradient, WebView } from "@draftbit/native";
 

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -1,4 +1,3 @@
-export { default as Animated } from "react-native-reanimated"; // Ensures reanimated is imported properly into snack. Otherwise gives 'r.g.__reanimatedWorkletInit is not a function' error
 import { Icon } from "@draftbit/native";
 export { Icon, LinearGradient, WebView } from "@draftbit/native";
 


### PR DESCRIPTION
- 49 version of jigsaw was giving the error `r.g.__reanimatedWorkletInit is not a function` on Snack.
- This adds a script to polyfill `r.g.__reanimatedWorkletInit` as suggested here https://forums.expo.dev/t/react-native-reanimated-error-r-g-reanimatedworkletinit-is-not-a-function/68222/3
- See the comment in code for more details