### PR TITLE
Skip first call to `onChangeTextDelayed`

### DIFF
--- a/packages/core/src/__tests__/Debouncing.test.tsx
+++ b/packages/core/src/__tests__/Debouncing.test.tsx
@@ -110,11 +110,10 @@ function testDebounce(
   act(() => fireEvent.changeText(textInput, valueTwo));
 
   act(() => jest.advanceTimersByTime(delay / 2));
-  //Only initial call should have called at this point, since delay has not passed
-  expect(onChangeTextDelayed).toHaveBeenCalledTimes(1);
-  expect(onChangeTextDelayed).toHaveBeenCalledWith(initialValue);
+  //Should not have been called at this point, since delay has not passed
+  expect(onChangeTextDelayed).toHaveBeenCalledTimes(0);
 
   act(() => jest.advanceTimersByTime(delay / 2));
-  expect(onChangeTextDelayed).toHaveBeenCalledTimes(2);
+  expect(onChangeTextDelayed).toHaveBeenCalledTimes(1);
   expect(onChangeTextDelayed).toHaveBeenCalledWith(valueTwo);
 }

--- a/packages/core/src/components/NumberInput.tsx
+++ b/packages/core/src/components/NumberInput.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { TextInput as NativeTextInput } from "react-native";
 import { isString, isNumber, isNaN } from "lodash";
 import { TextInputProps } from "./TextInput";
-import { useDebounce } from "../hooks";
+import { useDebounce, useOnUpdate } from "../hooks";
 
 interface Props
   extends Omit<
@@ -78,13 +78,12 @@ const NumberInput = React.forwardRef<NativeTextInput, Props>(
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    useEffect(() => {
+    useOnUpdate(() => {
       if (delayedValue !== undefined) {
         const newStringNumberValue = formatValueToStringNumber(delayedValue);
         const number = parseFloat(newStringNumberValue);
         onChangeTextDelayed?.(number);
       }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [delayedValue]);
 
     return (

--- a/packages/core/src/components/TextInput.tsx
+++ b/packages/core/src/components/TextInput.tsx
@@ -3,7 +3,7 @@ import {
   TextInput as NativeTextInput,
   TextInputProps as NativeTextInputProps,
 } from "react-native";
-import { useDebounce } from "../hooks";
+import { useDebounce, useOnUpdate } from "../hooks";
 
 export interface TextInputProps extends NativeTextInputProps {
   onChangeTextDelayed?: (text: string) => void;
@@ -14,11 +14,10 @@ const TextInput = React.forwardRef<NativeTextInput, TextInputProps>(
   ({ onChangeTextDelayed, changeTextDelay = 500, value, ...rest }, ref) => {
     const delayedValue = useDebounce(value, changeTextDelay);
 
-    React.useEffect(() => {
+    useOnUpdate(() => {
       if (delayedValue !== undefined) {
         onChangeTextDelayed?.(delayedValue);
       }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [delayedValue]);
 
     return (

--- a/packages/core/src/hooks.ts
+++ b/packages/core/src/hooks.ts
@@ -29,3 +29,17 @@ export const useDebounce = <T>(value: T, delay: number): T => {
 
   return debouncedValue;
 };
+
+export const useOnUpdate = (
+  onUpdate: () => void,
+  deps: React.DependencyList | undefined
+) => {
+  let mounted = React.useRef(true);
+  React.useEffect(() => {
+    if (!mounted.current) {
+      onUpdate();
+    }
+    mounted.current = false;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+};


### PR DESCRIPTION
- `onChangeTextDelayed` was being called initially with the default value, which is unintended, should only be called when the value changes
- Adds a hook that works around that (based on https://github.com/draftbit/draftbit/blob/master/builder/src/hooks/Hooks.res#L82)