### PR TITLE
Fix youtube player not respecting sizes

### DIFF
--- a/packages/core/src/components/YoutubePlayer/YoutubePlayer.native.tsx
+++ b/packages/core/src/components/YoutubePlayer/YoutubePlayer.native.tsx
@@ -33,6 +33,19 @@ const YoutubePlayer: React.FC<YoutubePlayerProps> = ({
           opacity: viewStyles.opacity < 0.99 ? viewStyles.opacity : 0.99,
         },
       ]}
+      /**
+       * Addresses issue where webview is locked by aspect ratio and refuses to
+       * change height according to provided style props.
+       * See:
+       * https://github.com/LonelyCpp/react-native-youtube-iframe/issues/13#issuecomment-611753123
+       */
+      webViewProps={{
+        injectedJavaScript: `
+            var element = document.getElementsByClassName('container')[0];
+            element.style.position = 'unset';
+            true;
+          `,
+      }}
     />
   );
 };

--- a/packages/core/src/components/YoutubePlayer/YoutubePlayer.tsx
+++ b/packages/core/src/components/YoutubePlayer/YoutubePlayer.tsx
@@ -26,6 +26,7 @@ const YoutubePlayer: React.FC<YoutubePlayerProps> = ({
   return (
     <View style={viewStyles}>
       <YouTube
+        style={{ flex: 1 }}
         videoId={!videoId && !playlist ? defaultVideoId : videoId}
         opts={options}
       />


### PR DESCRIPTION
- YouTube player was not respecting the set height and size could only be changed by changing the width and the height would then be according to the video's aspect ratio.
- This PR gives full control of the size to the styles
- See https://github.com/LonelyCpp/react-native-youtube-iframe/issues/13#issuecomment-611753123