### PR TITLE
Support `secureTextEntry` in PinInput

### DIFF
--- a/packages/core/src/components/PinInput/PinInput.tsx
+++ b/packages/core/src/components/PinInput/PinInput.tsx
@@ -53,6 +53,7 @@ const PinInput = React.forwardRef<NativeTextInput, PinInputProps>(
       focusedBackgroundColor,
       focusedBorderWidth,
       focusedTextColor,
+      secureTextEntry,
       style,
       ...rest
     },
@@ -88,6 +89,9 @@ const PinInput = React.forwardRef<NativeTextInput, PinInputProps>(
       index: number,
       isFocused: boolean
     ) => {
+      if (secureTextEntry && cellValue) {
+        cellValue = "•";
+      }
       const cell = renderItem?.({ cellValue, index, isFocused }) || (
         <View
           testID="default-code-input-cell"
@@ -147,6 +151,7 @@ const PinInput = React.forwardRef<NativeTextInput, PinInputProps>(
             {renderCell(cellValue, index, isFocused)}
           </React.Fragment>
         )}
+        secureTextEntry={secureTextEntry}
         {...rest}
       />
     );


### PR DESCRIPTION
- When enabled will show `•` instead of the input text. Same as the prop for `TextInput`