### PR TITLE
Set `<NativeTextInput>` `editable` prop depending on `disabled` prop

### DIFF
--- a/packages/core/src/components/TextInput.tsx
+++ b/packages/core/src/components/TextInput.tsx
@@ -10,6 +10,7 @@ export interface TextInputProps extends NativeTextInputProps {
   webShowOutline?: boolean;
   onChangeTextDelayed?: (text: string) => void;
   changeTextDelay?: number;
+  disabled?: boolean;
 }
 
 const TextInput = React.forwardRef<NativeTextInput, TextInputProps>(
@@ -19,6 +20,7 @@ const TextInput = React.forwardRef<NativeTextInput, TextInputProps>(
       changeTextDelay = 500,
       webShowOutline = true,
       style,
+      disabled,
       value,
       ...rest
     },
@@ -37,6 +39,7 @@ const TextInput = React.forwardRef<NativeTextInput, TextInputProps>(
         testID="native-text-input"
         ref={ref}
         value={value}
+        editable={!disabled}
         style={[
           //@ts-ignore Web specific prop. Removes default blue outline that appears on the hidden TextInput
           Platform.OS === "web" && !webShowOutline ? { outlineWidth: 0 } : {},


### PR DESCRIPTION
React native text input doesn't really understand `disabled` property, however it has an `editable` attribute working exactly the same (`DatePicker` has the same issue as well).  This should fix https://linear.app/draftbit/issue/P-4735/textinput-component-not-disabled-in-mobile-previews-when-disabled