### PR TITLE
Fix list components not resizing when data changes

### DIFF
--- a/packages/core/src/components/SimpleStyleScrollables/SimpleStyleFlashList.tsx
+++ b/packages/core/src/components/SimpleStyleScrollables/SimpleStyleFlashList.tsx
@@ -9,6 +9,7 @@ import useSplitContentContainerStyles from "./useSplitContentContainerStyles";
  */
 const SimpleStyleFlashList = <T extends any>({
   style: styleProp,
+  data,
   ...rest
 }: Omit<FlashListProps<T>, "contentContainerStyle">) => {
   const [measuredWidth, setMeasuredWidth] = React.useState<number>();
@@ -17,7 +18,8 @@ const SimpleStyleFlashList = <T extends any>({
   const { style, contentContainerStyle } = useSplitContentContainerStyles(
     styleProp,
     measuredWidth,
-    measuredHeight
+    measuredHeight,
+    [data]
   );
 
   return (
@@ -28,6 +30,7 @@ const SimpleStyleFlashList = <T extends any>({
       }}
       style={style}
       contentContainerStyle={contentContainerStyle as ContentStyle}
+      data={data}
       {...rest}
     />
   );

--- a/packages/core/src/components/SimpleStyleScrollables/SimpleStyleFlatList.tsx
+++ b/packages/core/src/components/SimpleStyleScrollables/SimpleStyleFlatList.tsx
@@ -9,6 +9,7 @@ import useSplitContentContainerStyles from "./useSplitContentContainerStyles";
  */
 const SimpleStyleFlatList = <T extends any>({
   style: styleProp,
+  data,
   ...rest
 }: Omit<FlatListProps<T>, "contentContainerStyle">) => {
   const [measuredWidth, setMeasuredWidth] = React.useState<number>();
@@ -17,7 +18,8 @@ const SimpleStyleFlatList = <T extends any>({
   const { style, contentContainerStyle } = useSplitContentContainerStyles(
     styleProp,
     measuredWidth,
-    measuredHeight
+    measuredHeight,
+    [data]
   );
 
   return (
@@ -28,6 +30,7 @@ const SimpleStyleFlatList = <T extends any>({
       }}
       style={style}
       contentContainerStyle={contentContainerStyle}
+      data={data}
       {...rest}
     />
   );

--- a/packages/core/src/components/SimpleStyleScrollables/SimpleStyleMasonryFlashList.tsx
+++ b/packages/core/src/components/SimpleStyleScrollables/SimpleStyleMasonryFlashList.tsx
@@ -9,6 +9,7 @@ import useSplitContentContainerStyles from "./useSplitContentContainerStyles";
  */
 const SimpleStyleMasonryFlashList = <T extends any>({
   style: styleProp,
+  data,
   ...rest
 }: Omit<MasonryFlashListProps<T>, "contentContainerStyle">) => {
   const [measuredWidth, setMeasuredWidth] = React.useState<number>();
@@ -17,7 +18,8 @@ const SimpleStyleMasonryFlashList = <T extends any>({
   const { style, contentContainerStyle } = useSplitContentContainerStyles(
     styleProp,
     measuredWidth,
-    measuredHeight
+    measuredHeight,
+    [data]
   );
 
   return (
@@ -28,6 +30,7 @@ const SimpleStyleMasonryFlashList = <T extends any>({
       }}
       style={style}
       contentContainerStyle={contentContainerStyle as ContentStyle}
+      data={data}
       {...rest}
     />
   );

--- a/packages/core/src/components/SimpleStyleScrollables/SimpleStyleSectionList.tsx
+++ b/packages/core/src/components/SimpleStyleScrollables/SimpleStyleSectionList.tsx
@@ -12,6 +12,7 @@ import useSplitContentContainerStyles from "./useSplitContentContainerStyles";
  */
 const SimpleStyleSectionList = <T extends { [key: string]: any }>({
   style: styleProp,
+  data,
   ...rest
 }: Omit<
   FlatListSectionListProps<T> | FlashListSectionListProps<T>,
@@ -23,7 +24,8 @@ const SimpleStyleSectionList = <T extends { [key: string]: any }>({
   const { style, contentContainerStyle } = useSplitContentContainerStyles(
     styleProp,
     measuredWidth,
-    measuredHeight
+    measuredHeight,
+    [data]
   );
 
   return (
@@ -35,6 +37,7 @@ const SimpleStyleSectionList = <T extends { [key: string]: any }>({
       }}
       style={style}
       contentContainerStyle={contentContainerStyle}
+      data={data}
       {...rest}
     />
   );

--- a/packages/core/src/components/SimpleStyleScrollables/SimpleStyleSwipeableList.tsx
+++ b/packages/core/src/components/SimpleStyleScrollables/SimpleStyleSwipeableList.tsx
@@ -12,6 +12,7 @@ import useSplitContentContainerStyles from "./useSplitContentContainerStyles";
  */
 const SimpleStyleSwipeableList = <T extends { [key: string]: any }>({
   style: styleProp,
+  data,
   ...rest
 }: Omit<
   FlashListSwipeableListProps<T> | FlatListSwipeableListProps<T>,
@@ -23,7 +24,8 @@ const SimpleStyleSwipeableList = <T extends { [key: string]: any }>({
   const { style, contentContainerStyle } = useSplitContentContainerStyles(
     styleProp,
     measuredWidth,
-    measuredHeight
+    measuredHeight,
+    [data]
   );
 
   return (
@@ -35,6 +37,7 @@ const SimpleStyleSwipeableList = <T extends { [key: string]: any }>({
       }}
       style={style}
       contentContainerStyle={contentContainerStyle}
+      data={data}
       {...rest}
     />
   );


### PR DESCRIPTION
- The way the new list components are implemented meant that the initial rendered size never got smaller even when data changes and fewer items need to be rendered. This is because the `contentContainerStyle` sets a min-height and min-width to the initially rendered size.
- This works around that by resetting the min sizes whenever data changes, allowing a recalculation of the size.
- This is only an issue when no sizing constraints are explicitly set (flex, width, height, etc).