### PR TITLE
Fix Maps flickering issue with clustering

### DIFF
--- a/packages/maps/src/components/MapView.tsx
+++ b/packages/maps/src/components/MapView.tsx
@@ -75,7 +75,7 @@ const MapViewF = <T extends object>({
 }) => {
   const [currentRegion, setCurrentRegion] = React.useState<Region | null>(null);
   const delayedRegionValue = useDebounce(currentRegion, 300);
-  const contextDelayedRegionValue = useDebounce(currentRegion, 100);
+  const contextDelayedRegionValue = useDebounce(currentRegion, 50);
 
   const markerRefs = React.useMemo<
     Map<string, React.RefObject<MapMarkerRefType>>

--- a/packages/maps/src/components/MapView.tsx
+++ b/packages/maps/src/components/MapView.tsx
@@ -75,6 +75,7 @@ const MapViewF = <T extends object>({
 }) => {
   const [currentRegion, setCurrentRegion] = React.useState<Region | null>(null);
   const delayedRegionValue = useDebounce(currentRegion, 300);
+  const contextDelayedRegionValue = useDebounce(currentRegion, 100);
 
   const markerRefs = React.useMemo<
     Map<string, React.RefObject<MapMarkerRefType>>
@@ -372,7 +373,7 @@ const MapViewF = <T extends object>({
     <MapViewContext.Provider
       value={{
         animateToLocation: (location) => animateToLocation(location),
-        region: currentRegion,
+        region: contextDelayedRegionValue,
       }}
     >
       {memoizedMapView}

--- a/packages/maps/src/components/marker-cluster/MapMarkerCluster.tsx
+++ b/packages/maps/src/components/marker-cluster/MapMarkerCluster.tsx
@@ -76,10 +76,7 @@ const MapMarkerCluster: React.FC<React.PropsWithChildren> = ({
                     longitude,
                     children: clusterView,
                     onPress,
-                    tracksViewChanges:
-                      clusterView.type === DefaultMapMarkerClusterView
-                        ? false
-                        : clusterView.props.tracksViewChanges,
+                    tracksViewChanges: clusterView.props.tracksViewChanges,
                   },
                   `${latitude}-${longitude}-${pointCount}`
                 )}

--- a/packages/maps/src/components/marker-cluster/MapMarkerCluster.tsx
+++ b/packages/maps/src/components/marker-cluster/MapMarkerCluster.tsx
@@ -70,16 +70,19 @@ const MapMarkerCluster: React.FC<React.PropsWithChildren> = ({
                   markerCount: pointCount,
                 }}
               >
-                {renderMarker({
-                  latitude,
-                  longitude,
-                  children: clusterView,
-                  onPress,
-                  tracksViewChanges:
-                    clusterView.type === DefaultMapMarkerClusterView
-                      ? false
-                      : clusterView.props.tracksViewChanges,
-                })}
+                {renderMarker(
+                  {
+                    latitude,
+                    longitude,
+                    children: clusterView,
+                    onPress,
+                    tracksViewChanges:
+                      clusterView.type === DefaultMapMarkerClusterView
+                        ? false
+                        : clusterView.props.tracksViewChanges,
+                  },
+                  `${latitude}-${longitude}-${pointCount}`
+                )}
               </MapMarkerClusterContext.Provider>
             );
           }}

--- a/packages/maps/src/components/marker-cluster/MapMarkerCluster.tsx
+++ b/packages/maps/src/components/marker-cluster/MapMarkerCluster.tsx
@@ -76,7 +76,10 @@ const MapMarkerCluster: React.FC<React.PropsWithChildren> = ({
                     longitude,
                     children: clusterView,
                     onPress,
-                    tracksViewChanges: clusterView.props.tracksViewChanges,
+                    tracksViewChanges:
+                      clusterView.type === DefaultMapMarkerClusterView
+                        ? false
+                        : clusterView.props.tracksViewChanges,
                   },
                   `${latitude}-${longitude}-${pointCount}`
                 )}


### PR DESCRIPTION
- Use a debounced value for the current region in the map view context. This prevents the clusters from excessively updating and causes a bunch of flickering. 
- Added a unique key per cluster view to prevent weird transition animation between completely different clusters. 

Closes https://linear.app/draftbit/issue/P-4887/map-component-flickering-issue-with-clustering