### PR TITLE
Fix markdown bold and custom fonts not working

### DIFF
--- a/packages/core/src/components/Markdown.tsx
+++ b/packages/core/src/components/Markdown.tsx
@@ -1,9 +1,16 @@
 import * as React from "react";
-import { StyleProp, ViewStyle, StyleSheet } from "react-native";
+import {
+  Text,
+  StyleProp,
+  ViewStyle,
+  TextStyle,
+  StyleSheet,
+} from "react-native";
 import MarkdownComponent from "react-native-markdown-display";
+import { extractStyles } from "../utilities";
 
 type MarkdownProps = {
-  style?: StyleProp<ViewStyle>;
+  style?: StyleProp<ViewStyle & TextStyle>;
 };
 
 const childToString = (child?: React.ReactNode): string => {
@@ -29,10 +36,29 @@ const Markdown: React.FC<React.PropsWithChildren<MarkdownProps>> = ({
   const children = React.Children.toArray(childrenProp);
   const text = children.map(childToString).join("");
 
+  const bodyStyle = StyleSheet.flatten(style);
+  const { textStyles } = extractStyles(bodyStyle);
+
   return (
     //'body' style applies to all markdown components
     //@ts-ignore TS does not like the type of this named style for some reason
-    <MarkdownComponent style={{ body: StyleSheet.flatten(style) }}>
+    <MarkdownComponent
+      style={{ body: bodyStyle }}
+      rules={{
+        // By default, strong does not work with custom fonts on iOS. This addresses the issue
+        strong: (node) => (
+          <Text
+            key={node.key}
+            style={{
+              ...textStyles,
+              fontWeight: "bold",
+            }}
+          >
+            {node.children[0].content}
+          </Text>
+        ),
+      }}
+    >
       {text}
     </MarkdownComponent>
   );


### PR DESCRIPTION
- When using a custom font on markdown components, bold components were not bold on iOS. This overrides the `strong` rule to fix the issue.