### PR TITLE
feat: support mode modal for picker component

### DIFF
--- a/example/src/PickerExample.tsx
+++ b/example/src/PickerExample.tsx
@@ -57,6 +57,64 @@ function PickerExample() {
         />
       </Picker>
 
+      <Section style={{}} title="Picker - Modal">
+        <></>
+      </Section>
+      <Picker
+        label="Make"
+        placeholder="Select a make..."
+        options={OPTIONS}
+        value={value1}
+        mode="modal"
+        dropDownTextColor="red"
+        onValueChange={(value) => setValue(value.toString())}
+        style={{ marginBottom: 20 }}
+      />
+
+      <Section style={{}} title="Picker - Dropdown (customized item)">
+        <></>
+      </Section>
+      <Picker
+        label="Make"
+        placeholder="Select a make..."
+        options={OPTIONS}
+        value={value1}
+        mode="modal"
+        onValueChange={(value) => setValue(value.toString())}
+        style={{ marginBottom: 20 }}
+        selectedIconColor="white"
+      >
+        <PickerItem
+          style={{ color: "red", fontWeight: 600 }}
+          selectedTextColor="white"
+          selectedBackgroundColor="black"
+          selectedTextSize={22}
+        />
+      </Picker>
+      <Section
+        style={{}}
+        title="Picker - Dropdown (customize dropdown background)"
+      >
+        <></>
+      </Section>
+      <Picker
+        label="Make"
+        placeholder="Select a make..."
+        options={OPTIONS}
+        value={value1}
+        mode="modal"
+        onValueChange={(value) => setValue(value.toString())}
+        style={{ marginBottom: 20 }}
+        selectedIconColor="white"
+        dropdownOverlayColor="transparent"
+      >
+        <PickerItem
+          style={{ color: "red", fontWeight: 600 }}
+          selectedTextColor="white"
+          selectedBackgroundColor="black"
+          selectedTextSize={22}
+        />
+      </Picker>
       <Section style={{}} title="Multiselect Picker">
         <></>
       </Section>

--- a/example/src/PickerExample.tsx
+++ b/example/src/PickerExample.tsx
@@ -93,7 +93,7 @@ function PickerExample() {
       </Picker>
       <Section
         style={{}}
-        title="Picker - Dropdown (customize dropdown background)"
+        title="Picker - Dropdown (custom transparent dropdown overlay)"
       >
         <></>
       </Section>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,6 +60,7 @@
     "react-native-confirmation-code-field": "^7.3.1",
     "react-native-deck-swiper": "^2.0.12",
     "react-native-dropdown-picker": "^5.4.7-beta.1",
+    "react-native-select-dropdown": "4.0.1",
     "react-native-gesture-handler": "~2.14.0",
     "react-native-keyboard-aware-scroll-view": "^0.9.5",
     "react-native-markdown-display": "^7.0.0-alpha.2",

--- a/packages/core/src/components/Picker/PickerCommon.ts
+++ b/packages/core/src/components/Picker/PickerCommon.ts
@@ -40,6 +40,10 @@ export interface MultiSelectPickerProps {
   onValueChange: (value: (string | number)[]) => void;
 }
 
+export interface ModalPickerProps {
+  dropdownOverlayColor?: string;
+}
+
 export interface CommonDropDownPickerProps extends CommonPickerProps {
   selectedIconName?: string;
   selectedIconColor?: string;

--- a/packages/core/src/components/Picker/index.tsx
+++ b/packages/core/src/components/Picker/index.tsx
@@ -1,11 +1,19 @@
 import React from "react";
-import { CommonDropDownPickerProps, SinglePickerProps } from "./PickerCommon";
+import {
+  CommonDropDownPickerProps,
+  ModalPickerProps,
+  SinglePickerProps,
+} from "./PickerCommon";
 import NativePicker from "./NativePicker";
 import DropDownPicker from "./dropdown/DropDownPicker";
+import ModalPicker from "./modal/ModalPicker";
 import { withTheme } from "../../theming";
 
-interface PickerProps extends CommonDropDownPickerProps, SinglePickerProps {
-  mode?: "native" | "dropdown";
+interface PickerProps
+  extends CommonDropDownPickerProps,
+    SinglePickerProps,
+    ModalPickerProps {
+  mode?: "native" | "dropdown" | "modal";
 }
 
 const SinglePicker: React.FC<React.PropsWithChildren<PickerProps>> = ({
@@ -19,6 +27,9 @@ const SinglePicker: React.FC<React.PropsWithChildren<PickerProps>> = ({
     case "dropdown":
       //@ts-ignore
       return <DropDownPicker {...rest} />;
+    case "modal":
+      //@ts-ignore Ignore theme type issues
+      return <ModalPicker {...rest} />;
   }
 };
 

--- a/packages/core/src/components/Picker/modal/ModalPicker.tsx
+++ b/packages/core/src/components/Picker/modal/ModalPicker.tsx
@@ -1,0 +1,179 @@
+import * as React from "react";
+import { View, Text, Keyboard } from "react-native";
+import {
+  extractStyles,
+  flattenReactFragments,
+  useDeepCompareMemo,
+} from "../../../utilities";
+import {
+  CommonDropDownPickerProps,
+  ModalPickerProps,
+  SinglePickerProps,
+  normalizeToPickerOptions,
+} from "../PickerCommon";
+import PickerInputContainer from "../PickerInputContainer";
+import ModalPickerComponent from "react-native-select-dropdown";
+import { withTheme } from "../../../theming";
+import PickerItem, { PickerItemProps } from "../dropdown/PickerItem";
+import { useOnUpdate } from "../../../hooks";
+
+const ModalPicker: React.FC<
+  React.PropsWithChildren<
+    CommonDropDownPickerProps & SinglePickerProps & ModalPickerProps
+  >
+> = ({
+  theme,
+  options: optionsProp = [],
+  onValueChange,
+  Icon,
+  placeholder,
+  value,
+  autoDismissKeyboard = true,
+  selectedIconName = "Feather/check",
+  selectedIconColor = theme.colors.strong,
+  selectedIconSize = 20,
+  dropDownBackgroundColor = theme.colors.background,
+  dropDownBorderColor = theme.colors.divider,
+  dropDownTextColor = theme.colors.strong,
+  dropDownBorderWidth = 1,
+  dropDownBorderRadius = 8,
+  children: childrenProp,
+  disabled,
+  dropdownOverlayColor,
+  ...rest
+}) => {
+  const dropdownRef = React.useRef();
+
+  const [pickerVisible, setPickerVisible] = React.useState(false);
+  const [internalValue, setInternalValue] = React.useState<
+    string | number | (string | number)[] | undefined
+  >(value);
+
+  const isMultiSelect = Array.isArray(value);
+
+  const pickerItemProps: PickerItemProps = React.useMemo(() => {
+    const children = flattenReactFragments(
+      React.Children.toArray(childrenProp) as React.ReactElement[]
+    );
+
+    // Only the props of the first PickerItem are used, any others are ignored
+    const firstPickerItem = children.find((child) => child.type === PickerItem);
+
+    return firstPickerItem?.props || {};
+  }, [childrenProp]);
+
+  const { viewStyles: pickerItemViewStyles, textStyles: pickerItemTextStyles } =
+    extractStyles(pickerItemProps.style);
+
+  const options = useDeepCompareMemo(
+    () =>
+      normalizeToPickerOptions(optionsProp).map((option) => ({
+        label: option.label.toString(),
+        value: option.value,
+      })),
+    [optionsProp]
+  );
+
+  useOnUpdate(() => {
+    onValueChange?.(
+      (isMultiSelect ? internalValue ?? [] : internalValue ?? "") as any // cannot determine if multiselect or not on compile time
+    );
+    // onValueChange excluded to prevent running on every re-render when using an anoymous function, which is the common case
+  }, [internalValue]);
+
+  React.useEffect(() => {
+    if (pickerVisible && autoDismissKeyboard) {
+      Keyboard.dismiss();
+    }
+  }, [pickerVisible, autoDismissKeyboard]);
+
+  React.useEffect(() => {
+    if (disabled) {
+      setPickerVisible(false);
+    }
+  }, [disabled]);
+
+  const defaultValue = options.find((item) => item.value === value);
+
+  return (
+    <PickerInputContainer
+      testID="dropdown-picker"
+      Icon={Icon}
+      placeholder={placeholder}
+      selectedValue={value}
+      options={options}
+      onPress={() => {
+        setPickerVisible(!pickerVisible);
+        // @ts-ignore
+        dropdownRef.current.openDropdown();
+      }}
+      zIndex={pickerVisible ? 100 : undefined} // Guarantees drop down is rendered above all sibling components
+      disabled={disabled}
+      {...rest}
+    >
+      <ModalPickerComponent
+        // @ts-ignore
+        ref={dropdownRef}
+        data={options}
+        defaultValue={defaultValue}
+        onSelect={(selectedItem, index) => {
+          console.log(selectedItem, index);
+          setInternalValue(selectedItem.value);
+        }}
+        renderButton={() => {
+          return <View />;
+        }}
+        renderItem={(item, _index, isSelected) => {
+          const selectedBackgroundColor = isSelected
+            ? pickerItemProps.selectedBackgroundColor
+            : pickerItemViewStyles.backgroundColor;
+          const selectedTextColor = isSelected
+            ? pickerItemProps.selectedTextColor || dropDownTextColor
+            : dropDownTextColor;
+          const selectedTextSize = isSelected
+            ? pickerItemProps.selectedTextSize || 14
+            : 14;
+          const iconColor = isSelected ? selectedIconColor : "transparent";
+
+          return (
+            <View
+              style={{
+                padding: 10,
+                flexDirection: "row",
+                alignItems: "center",
+                backgroundColor: selectedBackgroundColor,
+              }}
+            >
+              <Text
+                style={{
+                  color: selectedTextColor,
+                  fontSize: selectedTextSize,
+                  flex: 1,
+                  ...pickerItemTextStyles,
+                }}
+              >
+                {item.label}
+              </Text>
+              <Icon
+                name={selectedIconName}
+                size={selectedIconSize}
+                color={iconColor}
+              />
+            </View>
+          );
+        }}
+        showsVerticalScrollIndicator={false}
+        dropdownOverlayColor={dropdownOverlayColor}
+        dropdownStyle={{
+          borderColor: dropDownBorderColor,
+          borderWidth: dropDownBorderWidth,
+          borderRadius: dropDownBorderRadius,
+          backgroundColor: dropDownBackgroundColor,
+        }}
+        disableAutoScroll={true}
+      />
+    </PickerInputContainer>
+  );
+};
+
+export default withTheme(ModalPicker);

--- a/yarn.lock
+++ b/yarn.lock
@@ -13022,6 +13022,11 @@ react-native-screens@~3.29.0:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"
 
+react-native-select-dropdown@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/react-native-select-dropdown/-/react-native-select-dropdown-4.0.1.tgz#5789bdf60742f8ca881391e6f47a5b285ee407d8"
+  integrity sha512-t4se17kALFcPb9wMbxig5dS1BE3pWRC6HPuFlM0J2Y6yhB1GsLqboy6an6R9rML8pRuGIJIxL29cbwEvPQwKxQ==
+
 react-native-shadow-2@^7.0.7:
   version "7.0.7"
   resolved "https://registry.yarnpkg.com/react-native-shadow-2/-/react-native-shadow-2-7.0.7.tgz#f83ac2dda5ac202281d9a06cdb239d9c8829e7d2"


### PR DESCRIPTION
## Overview

Support new mode is modal picker

- Prevent the issue concerning zIndex conflicts.
- Introduces an enhancement to dismiss the picker by tapping outside the modal. This is crucial as it aligns with the standard user experience of modal operation.
- Adds a feature to customize the backdrop overlay of the modal. This help user can fully customize the overlay, to make the UI behavior exactly the same as dropdown picker mode
- ❌ This mode not supported multipicker

## Existing problem

We have some problem if picker got wrap by the View

![Screenshot 2024-05-15 at 21 18 30](https://github.com/draftbit/react-native-jigsaw/assets/159281348/b2c52f0c-009d-4816-9db4-8574fa98da3a)

## Demo

https://github.com/draftbit/react-native-jigsaw/assets/159281348/0f660a9a-4736-434d-90ef-feb2fdc40e53



