### PR TITLE
Allow for `null` behavior with `KeyboardAvoidingView`

### DIFF
--- a/packages/core/src/components/KeyboardAvoidingView.tsx
+++ b/packages/core/src/components/KeyboardAvoidingView.tsx
@@ -8,7 +8,7 @@ import {
 const isIos = Platform.OS === "ios";
 const isAndroid = Platform.OS === "android";
 
-type KeyboardAvoidingViewBehavior = "height" | "position" | "padding";
+type KeyboardAvoidingViewBehavior = "height" | "position" | "padding" | null;
 
 interface KeyboardAvoidingViewProps extends ViewProps {
   enabled?: boolean;
@@ -51,7 +51,7 @@ const KeyboardAvoidingView: React.FC<KeyboardAvoidingViewProps> = ({
 
   return (
     <KeyboardAvoidingViewComponent
-      behavior={behaviorResult}
+      behavior={behaviorResult ?? undefined}
       keyboardVerticalOffset={keyboardVerticalOffsetResult}
       {...rest}
     />


### PR DESCRIPTION
Sieu needs it for an app.  Types says that `behavior` can either be some value or `undefined`, but Sieu uses `null` and it works, while using `undefined` doesn't.  Se the associated Linear task.