### PR TITLE
Only call marker on press when `coordinate` is defined

### DIFF
--- a/packages/maps/src/components/MapMarker.tsx
+++ b/packages/maps/src/components/MapMarker.tsx
@@ -93,7 +93,9 @@ export function renderMarker(
       onPress={(event) => {
         onMarkerPress?.();
         const coordinate = event.nativeEvent.coordinate;
-        onPress?.(coordinate.latitude, coordinate.longitude);
+        if (coordinate) {
+          onPress?.(coordinate.latitude, coordinate.longitude);
+        }
       }}
       icon={
         shouldUseDefaultIconImplementation


### PR DESCRIPTION
- When many markers are pressed really fast repeatedly, sometimes the coordinate object is undefined, and trying to access its properties leads to a crash.
- I think it's fine to miss an `onPress` event when pressing is excessive, and is better than a crash.