### PR TITLE
FlashList padding and styles fix

### DIFF
--- a/packages/core/src/components/BottomSheet/BottomSheet.tsx
+++ b/packages/core/src/components/BottomSheet/BottomSheet.tsx
@@ -11,7 +11,7 @@ import BottomSheetComponent, {
   BottomSheetScrollView,
 } from "@gorhom/bottom-sheet";
 import { useTheme } from "@draftbit/theme";
-import { useDeepCompareMemo } from "../../utilities";
+import { extractPercentNumber, useDeepCompareMemo } from "../../utilities";
 
 type SnapPosition = "top" | "middle" | "bottom";
 
@@ -143,18 +143,6 @@ function convertSnapPointsForNewImplementation(
       return point;
     }
   });
-}
-
-function extractPercentNumber(percentString: string) {
-  const percentRegex = /(\d+)?%/;
-  const matches = percentString.match(percentRegex);
-  if (matches?.length) {
-    const percentNumber = Number(matches[1]);
-    if (!isNaN(percentNumber)) {
-      return percentNumber;
-    }
-  }
-  return undefined;
 }
 
 const styles = StyleSheet.create({

--- a/packages/core/src/components/SimpleStyleScrollables/SimpleStyleFlashList.tsx
+++ b/packages/core/src/components/SimpleStyleScrollables/SimpleStyleFlashList.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import { FlashList } from "@shopify/flash-list";
 import type { FlashListProps, ContentStyle } from "@shopify/flash-list";
-import useSplitContentContainerStyles from "./useSplitContentContainerStyles";
-import { pick } from "lodash";
+import { useFlashListSplitContentContainerStyles } from "./useSplitContentContainerStyles";
 
 /**
  * A FlashList wrapper that takes a single `style` prop and internally extracts
@@ -18,26 +17,13 @@ const SimpleStyleFlashList = React.forwardRef(
     ref: React.Ref<FlashList<any>>
   ) => {
     const { style, contentContainerStyle } =
-      useSplitContentContainerStyles(styleProp);
-
-    // FlashList only supports a subset of contentContainerStyles
-    // See https://shopify.github.io/flash-list/docs/usage/#contentcontainerstyle
-    const flashListContentContainerStyle = pick(contentContainerStyle, [
-      "backgroundColor",
-      "paddingTop",
-      "paddingLeft",
-      "paddingRight",
-      "paddingBottom",
-      "padding",
-      "paddingVertical",
-      "paddingHorizontal",
-    ]);
+      useFlashListSplitContentContainerStyles(styleProp);
 
     return (
       <FlashList
         ref={ref}
         style={style}
-        contentContainerStyle={flashListContentContainerStyle as ContentStyle}
+        contentContainerStyle={contentContainerStyle as ContentStyle}
         data={data}
         {...rest}
       />

--- a/packages/core/src/components/SimpleStyleScrollables/SimpleStyleFlashList.tsx
+++ b/packages/core/src/components/SimpleStyleScrollables/SimpleStyleFlashList.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { FlashList } from "@shopify/flash-list";
 import type { FlashListProps, ContentStyle } from "@shopify/flash-list";
 import useSplitContentContainerStyles from "./useSplitContentContainerStyles";
+import { pick } from "lodash";
 
 /**
  * A FlashList wrapper that takes a single `style` prop and internally extracts
@@ -19,11 +20,24 @@ const SimpleStyleFlashList = React.forwardRef(
     const { style, contentContainerStyle } =
       useSplitContentContainerStyles(styleProp);
 
+    // FlashList only supports a subset of contentContainerStyles
+    // See https://shopify.github.io/flash-list/docs/usage/#contentcontainerstyle
+    const flashListContentContainerStyle = pick(contentContainerStyle, [
+      "backgroundColor",
+      "paddingTop",
+      "paddingLeft",
+      "paddingRight",
+      "paddingBottom",
+      "padding",
+      "paddingVertical",
+      "paddingHorizontal",
+    ]);
+
     return (
       <FlashList
         ref={ref}
         style={style}
-        contentContainerStyle={contentContainerStyle as ContentStyle}
+        contentContainerStyle={flashListContentContainerStyle as ContentStyle}
         data={data}
         {...rest}
       />

--- a/packages/core/src/components/SimpleStyleScrollables/SimpleStyleMasonryFlashList.tsx
+++ b/packages/core/src/components/SimpleStyleScrollables/SimpleStyleMasonryFlashList.tsx
@@ -6,6 +6,7 @@ import type {
   MasonryFlashListRef,
 } from "@shopify/flash-list";
 import useSplitContentContainerStyles from "./useSplitContentContainerStyles";
+import { pick } from "lodash";
 
 /**
  * A MasonryFlashList wrapper that takes a single `style` prop and internally extracts
@@ -23,11 +24,24 @@ const SimpleStyleMasonryFlashList = React.forwardRef(
     const { style, contentContainerStyle } =
       useSplitContentContainerStyles(styleProp);
 
+    // FlashList only supports a subset of contentContainerStyles
+    // See https://shopify.github.io/flash-list/docs/usage/#contentcontainerstyle
+    const flashListContentContainerStyle = pick(contentContainerStyle, [
+      "backgroundColor",
+      "paddingTop",
+      "paddingLeft",
+      "paddingRight",
+      "paddingBottom",
+      "padding",
+      "paddingVertical",
+      "paddingHorizontal",
+    ]);
+
     return (
       <MasonryFlashList
         ref={ref as any}
         style={style}
-        contentContainerStyle={contentContainerStyle as ContentStyle}
+        contentContainerStyle={flashListContentContainerStyle as ContentStyle}
         data={data}
         {...rest}
       />

--- a/packages/core/src/components/SimpleStyleScrollables/SimpleStyleMasonryFlashList.tsx
+++ b/packages/core/src/components/SimpleStyleScrollables/SimpleStyleMasonryFlashList.tsx
@@ -5,8 +5,7 @@ import type {
   ContentStyle,
   MasonryFlashListRef,
 } from "@shopify/flash-list";
-import useSplitContentContainerStyles from "./useSplitContentContainerStyles";
-import { pick } from "lodash";
+import { useFlashListSplitContentContainerStyles } from "./useSplitContentContainerStyles";
 
 /**
  * A MasonryFlashList wrapper that takes a single `style` prop and internally extracts
@@ -22,26 +21,13 @@ const SimpleStyleMasonryFlashList = React.forwardRef(
     ref: React.Ref<MasonryFlashListRef<any>>
   ) => {
     const { style, contentContainerStyle } =
-      useSplitContentContainerStyles(styleProp);
-
-    // FlashList only supports a subset of contentContainerStyles
-    // See https://shopify.github.io/flash-list/docs/usage/#contentcontainerstyle
-    const flashListContentContainerStyle = pick(contentContainerStyle, [
-      "backgroundColor",
-      "paddingTop",
-      "paddingLeft",
-      "paddingRight",
-      "paddingBottom",
-      "padding",
-      "paddingVertical",
-      "paddingHorizontal",
-    ]);
+      useFlashListSplitContentContainerStyles(styleProp);
 
     return (
       <MasonryFlashList
         ref={ref as any}
         style={style}
-        contentContainerStyle={flashListContentContainerStyle as ContentStyle}
+        contentContainerStyle={contentContainerStyle as ContentStyle}
         data={data}
         {...rest}
       />

--- a/packages/core/src/components/SimpleStyleScrollables/useSplitContentContainerStyles.ts
+++ b/packages/core/src/components/SimpleStyleScrollables/useSplitContentContainerStyles.ts
@@ -57,3 +57,25 @@ export default function useSplitContentContainerStyles(
     };
   }, [originalStyle]);
 }
+
+export function useFlashListSplitContentContainerStyles(
+  originalStyle: StyleProp<ViewStyle>
+) {
+  const { style, contentContainerStyle } =
+    useSplitContentContainerStyles(originalStyle);
+
+  // FlashList only supports a subset of contentContainerStyles
+  // See https://shopify.github.io/flash-list/docs/usage/#contentcontainerstyle
+  const flashListContentContainerStyle = pick(contentContainerStyle, [
+    "backgroundColor",
+    "paddingTop",
+    "paddingLeft",
+    "paddingRight",
+    "paddingBottom",
+    "padding",
+    "paddingVertical",
+    "paddingHorizontal",
+  ]);
+
+  return { style, contentContainerStyle: flashListContentContainerStyle };
+}

--- a/packages/core/src/components/SimpleStyleScrollables/useSplitContentContainerStyles.ts
+++ b/packages/core/src/components/SimpleStyleScrollables/useSplitContentContainerStyles.ts
@@ -1,6 +1,9 @@
-import { StyleProp, ViewStyle, StyleSheet } from "react-native";
+import { StyleProp, ViewStyle, StyleSheet, Dimensions } from "react-native";
 import { pick, omit } from "lodash";
-import { useDeepCompareMemo } from "../../utilities";
+import { extractPercentNumber, useDeepCompareMemo } from "../../utilities";
+
+const DEVICE_WIDTH = Dimensions.get("window").width;
+const DEVICE_HEIGHT = Dimensions.get("window").width;
 
 interface Styles {
   style?: StyleProp<ViewStyle>;
@@ -60,7 +63,7 @@ export default function useSplitContentContainerStyles(
 
 export function useFlashListSplitContentContainerStyles(
   originalStyle: StyleProp<ViewStyle>
-) {
+): Styles {
   const { style, contentContainerStyle } =
     useSplitContentContainerStyles(originalStyle);
 
@@ -75,7 +78,35 @@ export function useFlashListSplitContentContainerStyles(
     "padding",
     "paddingVertical",
     "paddingHorizontal",
-  ]);
+  ]) as { [key: string]: any };
 
-  return { style, contentContainerStyle: flashListContentContainerStyle };
+  // FlashList percentage paddings cause it to freeze and crash
+  // This converts them to numbers based on device width/height
+  for (const [key, value] of Object.entries(flashListContentContainerStyle)) {
+    if (typeof value === "string" && key.includes("padding")) {
+      const asNumber = extractPercentNumber(value);
+      if (asNumber !== undefined) {
+        switch (key) {
+          case "padding":
+          case "paddingLeft":
+          case "paddingRight":
+          case "paddingHorizontal":
+            flashListContentContainerStyle[key] =
+              DEVICE_WIDTH * (asNumber / 100);
+            break;
+          case "paddingTop":
+          case "paddingBottom":
+          case "paddingVertical":
+            flashListContentContainerStyle[key] =
+              DEVICE_HEIGHT * (asNumber / 100);
+            break;
+        }
+      }
+    }
+  }
+
+  return {
+    style,
+    contentContainerStyle: flashListContentContainerStyle,
+  };
 }

--- a/packages/core/src/utilities.ts
+++ b/packages/core/src/utilities.ts
@@ -305,3 +305,15 @@ export function useDeepCompareEffect(
   // eslint-disable-next-line react-hooks/exhaustive-deps
   return React.useEffect(effect, deps?.map(useDeepCompareMemoize));
 }
+
+export function extractPercentNumber(percentString: string) {
+  const percentRegex = /(\d+)?%/;
+  const matches = percentString.match(percentRegex);
+  if (matches?.length) {
+    const percentNumber = Number(matches[1]);
+    if (!isNaN(percentNumber)) {
+      return percentNumber;
+    }
+  }
+  return undefined;
+}


### PR DESCRIPTION
- Limit what is passed to flash list's styles based on https://shopify.github.io/flash-list/docs/usage/#contentcontainerstyle. Otherwise it shows a warning
- Convert any percent padding values of the flash list to be numbers, otherwise it leads to freezing and eventually crashing apps.

Closes https://linear.app/draftbit/issue/P-5282/page-freezes-when-padding-is-defined-for-flashlist-component
Closes https://linear.app/draftbit/issue/P-5294/warning-about-padding-for-flashlist