### PR TITLE
Wrap loading indicator into a view

### DIFF
--- a/packages/core/src/components/LoadingIndicator.tsx
+++ b/packages/core/src/components/LoadingIndicator.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { StyleProp, ViewStyle } from "react-native";
+import { View, StyleProp, ViewStyle } from "react-native";
 import { withTheme } from "@draftbit/theme";
 import type { ReadTheme } from "@draftbit/theme";
 import {
@@ -64,7 +64,16 @@ const LoadingIndicator: React.FC<React.PropsWithChildren<Props>> = ({
   ...rest
 }) => {
   const SpinnerComponent = SPINNER_COMPONENTS[type];
-  return <SpinnerComponent size={size} color={color} style={style} {...rest} />;
+  return (
+    <View
+      style={{
+        justifyContent: "center",
+        alignItems: "center",
+      }}
+    >
+      <SpinnerComponent size={size} color={color} style={style} {...rest} />
+    </View>
+  );
 };
 
 export default withTheme(LoadingIndicator);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 3b2fb1e020b6f5f51ffe500c0ed40301e71d4b13  | 
|--------|--------|

### Summary:
Wraps `SpinnerComponent` in a `View` to center it in `LoadingIndicator` component.

**Key points**:
- Wraps `SpinnerComponent` in a `View` in `packages/core/src/components/LoadingIndicator.tsx`.
- Centers the loading indicator using `justifyContent: "center"` and `alignItems: "center"`.
- Affects layout by centering the spinner within its parent container.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->