### PR TITLE
Support debouncing value when using 'defaultValue'

### DIFF
--- a/packages/core/src/components/NumberInput.tsx
+++ b/packages/core/src/components/NumberInput.tsx
@@ -30,7 +30,8 @@ const NumberInput = React.forwardRef<NativeTextInput, Props>(
     const [currentStringNumberValue, setCurrentStringNumberValue] =
       useState("");
 
-    const delayedValue = useDebounce(value, changeTextDelay);
+    const [valueToDebounce, setValueToDebounce] = React.useState(value);
+    const delayedValue = useDebounce(valueToDebounce, changeTextDelay);
 
     const formatValueToStringNumber = (valueToFormat?: number | string) => {
       if (valueToFormat != null) {
@@ -92,7 +93,10 @@ const NumberInput = React.forwardRef<NativeTextInput, Props>(
         ref={ref}
         keyboardType="numeric"
         value={currentStringNumberValue}
-        onChangeText={handleChangeText}
+        onChangeText={(newValue) => {
+          handleChangeText(newValue);
+          setValueToDebounce(newValue);
+        }}
         {...props}
       />
     );

--- a/packages/core/src/components/TextInput.tsx
+++ b/packages/core/src/components/TextInput.tsx
@@ -24,12 +24,14 @@ const TextInput = React.forwardRef<NativeTextInput, TextInputProps>(
       disabled = false,
       editable = true,
       value,
+      onChangeText,
       ...rest
     },
     ref
   ) => {
     const theme = useTheme();
-    const delayedValue = useDebounce(value, changeTextDelay);
+    const [valueToDebounce, setValueToDebounce] = React.useState(value);
+    const delayedValue = useDebounce(valueToDebounce, changeTextDelay);
 
     useOnUpdate(() => {
       if (delayedValue !== undefined) {
@@ -49,6 +51,10 @@ const TextInput = React.forwardRef<NativeTextInput, TextInputProps>(
           { color: theme.colors.text.strong },
           style,
         ]}
+        onChangeText={(newValue) => {
+          onChangeText?.(newValue);
+          setValueToDebounce(newValue);
+        }}
         {...rest}
       />
     );


### PR DESCRIPTION
- Previously debouncing was done on the provided state `value` prop. However, that meant that using a `defaultValue` and no `value` would not trigger the onChangeTextDelayed callback.
- Instead, maintain an internal state of the value to be denounced, which allows it to work even when no `value` is provided.
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 654035474f27672ec40e692828e3974fc8c5e5ea  | 
|--------|--------|

### Summary:
Introduced `valueToDebounce` state in `NumberInput` and `TextInput` to support debouncing with `defaultValue`, ensuring `onChangeTextDelayed` triggers without `value`.

**Key points**:
- Introduced `valueToDebounce` state in `NumberInput` and `TextInput` components.
- Modified `onChangeText` handler to update `valueToDebounce`.
- Ensured `useDebounce` uses `valueToDebounce` for debouncing.
- Enabled `onChangeTextDelayed` callback to trigger with `defaultValue` in absence of `value`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->