### PR TITLE
Support debouncing value when using 'defaultValue' (49)

### DIFF
--- a/packages/core/src/components/NumberInput.tsx
+++ b/packages/core/src/components/NumberInput.tsx
@@ -30,7 +30,8 @@ const NumberInput = React.forwardRef<NativeTextInput, Props>(
     const [currentStringNumberValue, setCurrentStringNumberValue] =
       useState("");
 
-    const delayedValue = useDebounce(value, changeTextDelay);
+    const [valueToDebounce, setValueToDebounce] = React.useState(value);
+    const delayedValue = useDebounce(valueToDebounce, changeTextDelay);
 
     const formatValueToStringNumber = (valueToFormat?: number | string) => {
       if (valueToFormat != null) {
@@ -92,7 +93,10 @@ const NumberInput = React.forwardRef<NativeTextInput, Props>(
         ref={ref}
         keyboardType="numeric"
         value={currentStringNumberValue}
-        onChangeText={handleChangeText}
+        onChangeText={(newValue) => {
+          handleChangeText(newValue);
+          setValueToDebounce(newValue);
+        }}
         {...props}
       />
     );

--- a/packages/core/src/components/TextInput.tsx
+++ b/packages/core/src/components/TextInput.tsx
@@ -24,12 +24,14 @@ const TextInput = React.forwardRef<NativeTextInput, TextInputProps>(
       disabled = false,
       editable = true,
       value,
+      onChangeText,
       ...rest
     },
     ref
   ) => {
     const theme = useTheme();
-    const delayedValue = useDebounce(value, changeTextDelay);
+    const [valueToDebounce, setValueToDebounce] = React.useState(value);
+    const delayedValue = useDebounce(valueToDebounce, changeTextDelay);
 
     useOnUpdate(() => {
       if (delayedValue !== undefined) {
@@ -49,6 +51,10 @@ const TextInput = React.forwardRef<NativeTextInput, TextInputProps>(
           { color: theme.colors.text.strong },
           style,
         ]}
+        onChangeText={(newValue) => {
+          onChangeText?.(newValue);
+          setValueToDebounce(newValue);
+        }}
         {...rest}
       />
     );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 31ba87dd6594fe7602ca9b7368da7ecb1619ca27  | 
|--------|--------|

### Summary:
Added support for debouncing with `defaultValue` in `NumberInput` and `TextInput` by introducing `valueToDebounce` state and updating `onChangeText` handlers.

**Key points**:
- Introduced `valueToDebounce` state in `NumberInput` and `TextInput` components to manage debounced values.
- Updated `onChangeText` handlers to set `valueToDebounce` in `packages/core/src/components/NumberInput.tsx` and `packages/core/src/components/TextInput.tsx`.
- Utilized `useDebounce` hook with `valueToDebounce` to handle debouncing logic.
- Ensured `onChangeTextDelayed` is called with the debounced value in both components.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->