### PR TITLE
Add a way to persist theme selection

### DIFF
--- a/packages/core/jest-setup.js
+++ b/packages/core/jest-setup.js
@@ -21,3 +21,7 @@ jest.mock("expo-asset", () => {
   }
   return { ...actual, Asset, getManifestBaseUrl: () => "" };
 });
+
+jest.mock("@react-native-async-storage/async-storage", () =>
+  require("@react-native-async-storage/async-storage/jest/async-storage-mock")
+);

--- a/packages/maps/jest-setup.js
+++ b/packages/maps/jest-setup.js
@@ -18,3 +18,7 @@ jest.mock("expo-asset", () => {
   }
   return { ...actual, Asset, getManifestBaseUrl: () => "" };
 });
+
+jest.mock("@react-native-async-storage/async-storage", () =>
+  require("@react-native-async-storage/async-storage/jest/async-storage-mock")
+);

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -42,7 +42,8 @@
     "color": "^4.2.3",
     "deepmerge": "^4.3.1",
     "lodash.isobject": "^3.0.2",
-    "react-native-typography": "^1.4.1"
+    "react-native-typography": "^1.4.1",
+    "@react-native-async-storage/async-storage": "1.21.0"
   },
   "eslintIgnore": [
     "node_modules/",

--- a/packages/theme/src/types.ts
+++ b/packages/theme/src/types.ts
@@ -39,3 +39,5 @@ export type ColorPalettes = {
 export type Breakpoints = {
   [key: string]: number;
 };
+
+export type ChangeThemeOptions = { persistent?: boolean };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3371,6 +3371,13 @@
   resolved "https://registry.yarnpkg.com/@react-google-maps/marker-clusterer/-/marker-clusterer-2.16.1.tgz#882878a7b49ce9ae44c7b02ff6fbc4c2aeb77c95"
   integrity sha512-jOuyqzWLeXvQcoAu6TCVWHAuko+sDt0JjawNHBGqUNLywMtTCvYP0L0PiqJZOUCUeRYGdUy0AKxQ+30vAkvwag==
 
+"@react-native-async-storage/async-storage@1.21.0":
+  version "1.21.0"
+  resolved "https://registry.yarnpkg.com/@react-native-async-storage/async-storage/-/async-storage-1.21.0.tgz#d7e370028e228ab84637016ceeb495878b7a44c8"
+  integrity sha512-JL0w36KuFHFCvnbOXRekqVAUplmOyT/OuCQkogo6X98MtpSaJOKEAeZnYO8JB0U/RIEixZaGI5px73YbRm/oag==
+  dependencies:
+    merge-options "^3.0.4"
+
 "@react-native-community/cli-clean@12.3.6":
   version "12.3.6"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-clean/-/cli-clean-12.3.6.tgz#e8a7910bebc97266fd5068649013a03958021fc4"
@@ -9117,7 +9124,7 @@ is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==
 
-is-plain-obj@^2.0.0:
+is-plain-obj@^2.0.0, is-plain-obj@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
   integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
@@ -10730,6 +10737,13 @@ merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
   integrity sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==
+
+merge-options@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/merge-options/-/merge-options-3.0.4.tgz#84709c2aa2a4b24c1981f66c179fe5565cc6dbb7"
+  integrity sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==
+  dependencies:
+    is-plain-obj "^2.1.0"
 
 merge-stream@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
- When we eventually add themes to draftbit and an action to change the theme, we should also have a way to persist that selection so that the theme does not reset every time an app is relaunched. 
<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit fa62274096f6e9b9d97808cbd02358e4fab377d6  | 
|--------|--------|

### Summary:
This PR adds theme persistence using AsyncStorage and updates jest setup files to mock AsyncStorage for testing.

**Key points**:
- Adds theme persistence using AsyncStorage in the Provider component.
- Updates jest setup files to mock AsyncStorage for testing.
- Adds `@react-native-async-storage/async-storage` to dependencies.
- Persists theme selection using `AsyncStorage` in `Provider.tsx`.
- Introduces `SAVED_SELECTED_THEME_KEY` constant for storage key.
- Modifies `changeTheme` function to accept `ChangeThemeOptions`.
- Adds `React.useEffect` to load persisted theme on initialization.
- Updates `useChangeTheme` hook to support `ChangeThemeOptions`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->