### PR TITLE
Adjust onSettle index of Bottomsheet (49)

### DIFF
--- a/example/src/BottomSheetExample.tsx
+++ b/example/src/BottomSheetExample.tsx
@@ -7,7 +7,17 @@ const BottomSheetExample: React.FC = () => {
   const bottomSheetRef = React.useRef<any>();
   return (
     <View style={{ flex: 1 }}>
-      <BottomSheet style={{ alignItems: "center" }} ref={bottomSheetRef}>
+      <BottomSheet
+        style={{ alignItems: "center" }}
+        ref={bottomSheetRef}
+        onSettle={(newIndex: number) => {
+          try {
+            console.log("onSettle", newIndex);
+          } catch (error) {
+            console.error("Error in onSettle:", error);
+          }
+        }}
+      >
         <Text>This is a bottom Sheet</Text>
       </BottomSheet>
       <Button

--- a/example/src/BottomSheetExample.tsx
+++ b/example/src/BottomSheetExample.tsx
@@ -5,14 +5,17 @@ import { Button } from "@draftbit/core";
 
 const BottomSheetExample: React.FC = () => {
   const bottomSheetRef = React.useRef<any>();
+  const [snapIndex, setSnapIndex] = React.useState(0);
   return (
     <View style={{ flex: 1 }}>
       <BottomSheet
+        enableDynamicSizing={false}
         style={{ alignItems: "center" }}
         ref={bottomSheetRef}
         onSettle={(newIndex: number) => {
           try {
             console.log("onSettle", newIndex);
+            setSnapIndex(newIndex);
           } catch (error) {
             console.error("Error in onSettle:", error);
           }
@@ -29,10 +32,10 @@ const BottomSheetExample: React.FC = () => {
         }}
       />
       <Button
-        title="Snap to index 2"
+        title="Snap to index 1"
         onPress={() => {
           if (bottomSheetRef && bottomSheetRef?.current) {
-            bottomSheetRef?.current?.snapToIndex(2);
+            bottomSheetRef?.current?.snapToIndex(1);
           }
         }}
       />
@@ -52,6 +55,7 @@ const BottomSheetExample: React.FC = () => {
           }
         }}
       />
+      <Text>Snap index: {snapIndex}</Text>
     </View>
   );
 };

--- a/packages/core/src/components/BottomSheet/BottomSheet.tsx
+++ b/packages/core/src/components/BottomSheet/BottomSheet.tsx
@@ -35,6 +35,7 @@ export interface BottomSheetProps extends ScrollViewProps {
   topBorderRadius?: number;
   borderWidth?: number;
   borderColor?: string;
+  enableDynamicSizing?: boolean;
   onSettle?: (index: number) => void;
   style?: StyleProp<ViewStyle>;
 }
@@ -56,6 +57,7 @@ const BottomSheet = React.forwardRef<BottomSheetComponent, BottomSheetProps>(
       topBorderRadius = 20,
       borderWidth = 1,
       borderColor,
+      enableDynamicSizing = true,
       onSettle,
       style,
       children,
@@ -92,6 +94,7 @@ const BottomSheet = React.forwardRef<BottomSheetComponent, BottomSheetProps>(
     return (
       <BottomSheetComponent
         ref={ref}
+        enableDynamicSizing={enableDynamicSizing}
         snapPoints={mappedSnapPoints}
         index={
           initialSnapIndex !== undefined
@@ -109,7 +112,13 @@ const BottomSheet = React.forwardRef<BottomSheetComponent, BottomSheetProps>(
           borderWidth,
           borderColor: borderColor ?? theme.colors.border.brand,
         }}
-        onChange={(index) => onSettle?.(index)}
+        onChange={(index) =>
+          // Convert bottom-sheet index to match our top-to-bottom ordering
+          // When dynamic sizing is enabled, we don't need to subtract 1 since an extra snap point may be added
+          enableDynamicSizing
+            ? onSettle?.(mappedSnapPoints.length - index)
+            : onSettle?.(mappedSnapPoints.length - index - 1)
+        }
       >
         <BottomSheetScrollView
           contentContainerStyle={[styles.contentContainerStyle, style]}

--- a/packages/core/src/components/BottomSheet/BottomSheet.tsx
+++ b/packages/core/src/components/BottomSheet/BottomSheet.tsx
@@ -109,7 +109,7 @@ const BottomSheet = React.forwardRef<BottomSheetComponent, BottomSheetProps>(
           borderWidth,
           borderColor: borderColor ?? theme.colors.border.brand,
         }}
-        onChange={(index) => onSettle?.(mappedSnapPoints.length - index - 1)}
+        onChange={(index) => onSettle?.(index)}
       >
         <BottomSheetScrollView
           contentContainerStyle={[styles.contentContainerStyle, style]}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Updated `BottomSheet` to use direct index for `onSettle` callback, with `enableDynamicSizing` prop to control behavior.
> 
>   - **Behavior**:
>     - Updated `onChange` in `BottomSheet.tsx` to use direct index for `onSettle` callback, removing index reversal logic.
>     - Introduced `enableDynamicSizing` prop in `BottomSheet.tsx` to control index calculation.
>   - **Example**:
>     - Added `onSettle` logging and state update in `BottomSheetExample.tsx` to demonstrate new behavior.
>     - Changed button snap index from 2 to 1 in `BottomSheetExample.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=draftbit%2Freact-native-jigsaw&utm_source=github&utm_medium=referral)<sup> for 1f737e5126611874c373fdcfddbe450bd3ee4535. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->