### PR TITLE
Prevent `mutedStandard` mapType on android

### DIFF
--- a/packages/maps/src/components/MapView.tsx
+++ b/packages/maps/src/components/MapView.tsx
@@ -68,7 +68,7 @@ const MapViewF = <T extends object>({
   style,
   animateToLocation,
   mapRef,
-  mapType = "standard",
+  mapType: mapTypeProp = "standard",
   ...rest
 }: MapViewProps<T> & {
   animateToLocation: (location: ZoomLocation) => void;
@@ -78,6 +78,7 @@ const MapViewF = <T extends object>({
   const delayedRegionValue = useDebounce(currentRegion, 300);
   const contextDelayedRegionValue = useDebounce(currentRegion, 50);
 
+  let mapType = mapTypeProp;
   if (mapType === "mutedStandard" && Platform.OS === "android") {
     console.warn(
       "Map type 'mutedStandard' is not supported on Android. Defaulting to 'standard'"

--- a/packages/maps/src/components/MapView.tsx
+++ b/packages/maps/src/components/MapView.tsx
@@ -68,6 +68,7 @@ const MapViewF = <T extends object>({
   style,
   animateToLocation,
   mapRef,
+  mapType = "standard",
   ...rest
 }: MapViewProps<T> & {
   animateToLocation: (location: ZoomLocation) => void;
@@ -76,6 +77,13 @@ const MapViewF = <T extends object>({
   const [currentRegion, setCurrentRegion] = React.useState<Region | null>(null);
   const delayedRegionValue = useDebounce(currentRegion, 300);
   const contextDelayedRegionValue = useDebounce(currentRegion, 50);
+
+  if (mapType === "mutedStandard" && Platform.OS === "android") {
+    console.warn(
+      "Map type 'mutedStandard' is not supported on Android. Defaulting to 'standard'"
+    );
+    mapType = "standard";
+  }
 
   const markerRefs = React.useMemo<
     Map<string, React.RefObject<MapMarkerRefType>>
@@ -316,6 +324,7 @@ const MapViewF = <T extends object>({
           onPress?.(coordinate.latitude, coordinate.longitude);
         }}
         style={[styles.map, style]}
+        mapType={mapType}
         {...rest}
       >
         {unClusteredMarkers.map((marker, index) =>


### PR DESCRIPTION
- It's not supported on android, and crashed when selected
<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 23bdd0f0b3a040a7d6bc0112a9a2b8552bd359ab  | 
|--------|--------|

### Summary:
Prevents Android crash by defaulting `mapType` to `standard` when `mutedStandard` is selected in `MapViewF`.

**Key points**:
- Prevents crash on Android by defaulting `mapType` to `standard` when `mutedStandard` is selected.
- Implemented in `MapViewF` function in `packages/maps/src/components/MapView.tsx`.
- Adds `mapType` prop with default value `standard`.
- Checks if `mapType` is `mutedStandard` and platform is Android, logs a warning, and defaults to `standard`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->