### PR TITLE
Prevent `mutedStandard` mapType on android (49)

### DIFF
--- a/packages/maps/src/components/MapView.tsx
+++ b/packages/maps/src/components/MapView.tsx
@@ -68,7 +68,7 @@ const MapViewF = <T extends object>({
   style,
   animateToLocation,
   mapRef,
-  mapType = "standard",
+  mapType: mapTypeProp = "standard",
   ...rest
 }: MapViewProps<T> & {
   animateToLocation: (location: ZoomLocation) => void;
@@ -78,6 +78,7 @@ const MapViewF = <T extends object>({
   const delayedRegionValue = useDebounce(currentRegion, 300);
   const contextDelayedRegionValue = useDebounce(currentRegion, 50);
 
+  let mapType = mapTypeProp;
   if (mapType === "mutedStandard" && Platform.OS === "android") {
     console.warn(
       "Map type 'mutedStandard' is not supported on Android. Defaulting to 'standard'"

--- a/packages/maps/src/components/MapView.tsx
+++ b/packages/maps/src/components/MapView.tsx
@@ -68,6 +68,7 @@ const MapViewF = <T extends object>({
   style,
   animateToLocation,
   mapRef,
+  mapType = "standard",
   ...rest
 }: MapViewProps<T> & {
   animateToLocation: (location: ZoomLocation) => void;
@@ -76,6 +77,13 @@ const MapViewF = <T extends object>({
   const [currentRegion, setCurrentRegion] = React.useState<Region | null>(null);
   const delayedRegionValue = useDebounce(currentRegion, 300);
   const contextDelayedRegionValue = useDebounce(currentRegion, 50);
+
+  if (mapType === "mutedStandard" && Platform.OS === "android") {
+    console.warn(
+      "Map type 'mutedStandard' is not supported on Android. Defaulting to 'standard'"
+    );
+    mapType = "standard";
+  }
 
   const markerRefs = React.useMemo<
     Map<string, React.RefObject<MapMarkerRefType>>
@@ -316,6 +324,7 @@ const MapViewF = <T extends object>({
           onPress?.(coordinate.latitude, coordinate.longitude);
         }}
         style={[styles.map, style]}
+        mapType={mapType}
         {...rest}
       >
         {unClusteredMarkers.map((marker, index) =>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit f41aa8013f1f7570bae1e4ac5faf7ba55bbec8a6  | 
|--------|--------|

### Summary:
The PR updates `MapViewF` to default to `standard` map type and log a warning for `mutedStandard` on Android.

**Key points**:
- Update `MapViewF` in `packages/maps/src/components/MapView.tsx`.
- Default `mapType` to `standard` if `mutedStandard` is used on Android.
- Log a warning when `mutedStandard` is set on Android.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->