### PR TITLE
Support volume prop audio player

### DIFF
--- a/example/src/AudioPlayerExample.tsx
+++ b/example/src/AudioPlayerExample.tsx
@@ -25,6 +25,14 @@ export default function AudioPlayerExample() {
           isLooping
         />
       </Section>
+      <Section style={{}} title="Adjust volume">
+        <AudioPlayer
+          source={require("./assets/loop.wav")}
+          playsInBackground
+          interruptionMode="stop"
+          volume={0.3}
+        />
+      </Section>
       <Section style={{}} title="Custom styling">
         <AudioPlayer
           style={{

--- a/packages/core/src/components/MediaPlayer/AudioPlayer/AudioPlayerCommon.ts
+++ b/packages/core/src/components/MediaPlayer/AudioPlayer/AudioPlayerCommon.ts
@@ -9,6 +9,7 @@ export interface HeadlessAudioPlayerProps extends MediaPlayerProps {
   playsInSilentModeIOS?: boolean;
   playThroughEarpieceAndroid?: boolean;
   isLooping?: boolean;
+  volume?: number;
 }
 
 export interface AudioPlayerInterfaceProps {

--- a/packages/core/src/components/MediaPlayer/AudioPlayer/HeadlessAudioPlayer.tsx
+++ b/packages/core/src/components/MediaPlayer/AudioPlayer/HeadlessAudioPlayer.tsx
@@ -32,6 +32,7 @@ const HeadlessAudioPlayer = React.forwardRef<
       onPlaybackStatusUpdate: onPlaybackStatusUpdateProp,
       onPlaybackFinish,
       isLooping = false,
+      volume = 1.0,
     },
     ref
   ) => {
@@ -46,6 +47,12 @@ const HeadlessAudioPlayer = React.forwardRef<
         currentSound.setIsLoopingAsync(isLooping);
       }
     }, [currentSound, isLooping]);
+
+    React.useEffect(() => {
+      if (currentSound && typeof currentSound?.setVolumeAsync === "function") {
+        currentSound.setVolumeAsync(volume);
+      }
+    }, [currentSound, volume]);
 
     const updateAudioMode = React.useCallback(async () => {
       try {


### PR DESCRIPTION
## Overview
- Support volume prop audio player
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for `volume` prop in `AudioPlayer`, allowing volume adjustment in `HeadlessAudioPlayer`.
> 
>   - **Behavior**:
>     - Adds `volume` prop to `AudioPlayer` in `AudioPlayerExample.tsx` to demonstrate volume adjustment.
>     - Sets default `volume` to 1.0 in `HeadlessAudioPlayer.tsx`.
>     - Updates `HeadlessAudioPlayer` to apply `volume` using `setVolumeAsync()`.
>   - **Interfaces**:
>     - Adds `volume` to `HeadlessAudioPlayerProps` in `AudioPlayerCommon.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=draftbit%2Freact-native-jigsaw&utm_source=github&utm_medium=referral)<sup> for e6f5482480338091de7633f535662afd702f1df1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->