### PR TITLE
Bump deck swiper package version

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -62,7 +62,7 @@
     "lottie-react-native": "6.5.1",
     "react-native-animated-spinkit": "1.5.2",
     "react-native-confirmation-code-field": "^7.3.1",
-    "react-native-deck-swiper": "^2.0.12",
+    "react-native-deck-swiper": "^2.0.16",
     "react-native-dropdown-picker": "^5.4.7-beta.1",
     "react-native-gesture-handler": "~2.14.0",
     "react-native-keyboard-aware-scroll-view": "^0.9.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12961,10 +12961,10 @@ react-native-confirmation-code-field@^7.3.1:
   resolved "https://registry.yarnpkg.com/react-native-confirmation-code-field/-/react-native-confirmation-code-field-7.3.1.tgz#e705ee5b73d7749cac29da287379fa8690904fe6"
   integrity sha512-5vI6BclB31e4vTYg0HmV/Vy9zI5MQZfHr1EN3kYzvaZq4GMIsyr6lrSmnQW1TtWR7Z8oURrhCpwo+JsWXxCoug==
 
-react-native-deck-swiper@^2.0.12:
-  version "2.0.12"
-  resolved "https://registry.yarnpkg.com/react-native-deck-swiper/-/react-native-deck-swiper-2.0.12.tgz#941ebfdd7e4e0cff316640dbe795a4a13714ddb5"
-  integrity sha512-fphojlLDMkg5ppHqoAh/9ZuDzsdxR/HTKGFhAkEOlNe08r/MRUpyYJHLxKS83CnPQLJvvY7ol9pHvTm9D+DSRg==
+react-native-deck-swiper@^2.0.16:
+  version "2.0.17"
+  resolved "https://registry.yarnpkg.com/react-native-deck-swiper/-/react-native-deck-swiper-2.0.17.tgz#c943133954e1ed0c5c115832b0601874157296fe"
+  integrity sha512-vOGmhBLnrVQL6WtwmgdUqKOyKwoDRmozYjEygRHvFEjHwyFohpd9scDPRNc0t9HlKcXRVNunVsN45B9emqNybw==
   dependencies:
     prop-types "15.5.10"
 


### PR DESCRIPTION
- Possibly fixes an issue faced with the deck swiper component
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump `react-native-deck-swiper` version to `^2.0.16` in `package.json`.
> 
>   - **Dependencies**:
>     - Bump `react-native-deck-swiper` version from `^2.0.12` to `^2.0.16` in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=draftbit%2Freact-native-jigsaw&utm_source=github&utm_medium=referral)<sup> for ba3f0c5ecb7b0bfabfb8394a2548ac8b9feaa9da. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->