### PR TITLE
Pass in border style to TextField

### DIFF
--- a/packages/core/src/components/TextField.tsx
+++ b/packages/core/src/components/TextField.tsx
@@ -416,6 +416,7 @@ class TextField extends React.Component<Props, State> {
       borderRightWidth,
       borderBottomWidth,
       borderLeftWidth,
+      borderStyle,
       borderColor: borderCol,
       ...styleProp
     } = StyleSheet.flatten(style || {}) as ViewStyle;
@@ -441,6 +442,7 @@ class TextField extends React.Component<Props, State> {
             borderRightWidth,
             borderBottomWidth,
             borderLeftWidth,
+            borderStyle,
             borderColor: borderCol,
           })}
         >


### PR DESCRIPTION
- This style was ignored and not passed in. 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Pass `borderStyle` to `TextField` component styles in `TextField.tsx`.
> 
>   - **Behavior**:
>     - Pass `borderStyle` to `TextField` component styles in `TextField.tsx`.
>     - Ensures `borderStyle` is applied to the component, which was previously ignored.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=draftbit%2Freact-native-jigsaw&utm_source=github&utm_medium=referral)<sup> for 54933dfab5001c8b7a190997b2a8eb3c0a18ab91. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->