### PR TITLE
Support light/dark colors in theme

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -163,6 +163,10 @@ const BaseTheme = createTheme({
           tablet: "yellow",
           laptop: "red",
         },
+        lightDarkTest: {
+          light: "white",
+          dark: "black",
+        },
       },
     },
     typography: {},

--- a/example/src/ThemeExample.tsx
+++ b/example/src/ThemeExample.tsx
@@ -58,6 +58,16 @@ const VideoPlayerExample: React.FC = () => {
           }}
         />
       </Section>
+      <Section style={{}} title="Light/Dark Color">
+        <View
+          style={{
+            width: 100,
+            height: 100,
+            borderWidth: 1,
+            backgroundColor: theme.colors.background.lightDarkTest,
+          }}
+        />
+      </Section>
     </Container>
   );
 };

--- a/packages/theme/src/Provider.tsx
+++ b/packages/theme/src/Provider.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Dimensions, Platform } from "react-native";
+import { Dimensions, Platform, useColorScheme } from "react-native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import createThemeValuesProxy from "./createThemeValuesProxy";
 import DefaultTheme from "./DefaultTheme";
@@ -41,6 +41,8 @@ const Provider: React.FC<React.PropsWithChildren<ProviderProps>> = ({
   const [deviceWidth, setDeviceWidth] = React.useState(
     Dimensions.get("window").width
   );
+  const colorScheme = useColorScheme();
+  const lightDarkSelection = colorScheme ?? "light";
 
   const changeTheme = React.useCallback(
     (themeName: string, options?: ChangeThemeOptions) => {
@@ -72,35 +74,40 @@ const Provider: React.FC<React.PropsWithChildren<ProviderProps>> = ({
           currentTheme.colors.branding,
           breakpoints,
           deviceWidth,
-          Platform.OS
+          Platform.OS,
+          lightDarkSelection
         ),
         text: createThemeValuesProxy(
           currentTheme.colors.text,
           breakpoints,
           deviceWidth,
-          Platform.OS
+          Platform.OS,
+          lightDarkSelection
         ),
         background: createThemeValuesProxy(
           currentTheme.colors.background,
           breakpoints,
           deviceWidth,
-          Platform.OS
+          Platform.OS,
+          lightDarkSelection
         ),
         foreground: createThemeValuesProxy(
           currentTheme.colors.foreground,
           breakpoints,
           deviceWidth,
-          Platform.OS
+          Platform.OS,
+          lightDarkSelection
         ),
         border: createThemeValuesProxy(
           currentTheme.colors.border,
           breakpoints,
           deviceWidth,
-          Platform.OS
+          Platform.OS,
+          lightDarkSelection
         ),
       },
     }),
-    [currentTheme, deviceWidth, breakpoints]
+    [currentTheme, deviceWidth, breakpoints, lightDarkSelection]
   );
 
   React.useEffect(() => {

--- a/packages/theme/src/__tests__/createThemeValuesProxy.test.ts
+++ b/packages/theme/src/__tests__/createThemeValuesProxy.test.ts
@@ -47,9 +47,22 @@ const value: any = {
       nested: "nestedMedium",
     },
   },
+  lightDark: {
+    default: "defaultLightDark",
+    light: "lightValue",
+    dark: "darkValue",
+  },
+  lightDarkNested: {
+    light: {
+      nested: "nestedLight",
+    },
+    dark: {
+      nested: "nestedDark",
+    },
+  },
 };
 
-const proxied = createThemeValuesProxy(value, {}, 400, "android")!;
+const proxied = createThemeValuesProxy(value, {}, 400, "android", "light")!;
 
 describe("createThemeValuesProxy tests", () => {
   describe("Value Returned Directly", () => {
@@ -78,29 +91,59 @@ describe("createThemeValuesProxy tests", () => {
 
   describe("Platform Value", () => {
     test("returns android value when platform is android", () => {
-      const androidProxied = createThemeValuesProxy(value, {}, 400, "android")!;
+      const androidProxied = createThemeValuesProxy(
+        value,
+        {},
+        400,
+        "android",
+        "light"
+      )!;
       expect(androidProxied.platform).toEqual(value.platform.android);
     });
 
     test("returns ios value when platform is ios", () => {
-      const iosProxied = createThemeValuesProxy(value, {}, 400, "ios")!;
+      const iosProxied = createThemeValuesProxy(
+        value,
+        {},
+        400,
+        "ios",
+        "light"
+      )!;
       expect(iosProxied.platform).toEqual(value.platform.ios);
     });
 
     test("returns default platform value when platform is not in keys", () => {
-      const windowsProxied = createThemeValuesProxy(value, {}, 400, "windows")!;
+      const windowsProxied = createThemeValuesProxy(
+        value,
+        {},
+        400,
+        "windows",
+        "light"
+      )!;
       expect(windowsProxied.platform).toEqual(value.platform.default);
     });
 
     test("returns nested android value when platform is android", () => {
-      const androidProxied = createThemeValuesProxy(value, {}, 400, "android")!;
+      const androidProxied = createThemeValuesProxy(
+        value,
+        {},
+        400,
+        "android",
+        "light"
+      )!;
       expect(androidProxied.platformNested.nested).toEqual(
         value.platformNested.android.nested
       );
     });
 
     test("returns nested ios value when platform is ios", () => {
-      const iosProxied = createThemeValuesProxy(value, {}, 400, "ios")!;
+      const iosProxied = createThemeValuesProxy(
+        value,
+        {},
+        400,
+        "ios",
+        "light"
+      )!;
       expect(iosProxied.platformNested.nested).toEqual(
         value.platformNested.ios.nested
       );
@@ -113,7 +156,8 @@ describe("createThemeValuesProxy tests", () => {
         value,
         breakpoints,
         breakpoints.small,
-        "android"
+        "android",
+        "light"
       )!;
       expect(smallProxied.breakpoint).toEqual(value.breakpoint.small);
     });
@@ -123,7 +167,8 @@ describe("createThemeValuesProxy tests", () => {
         value,
         breakpoints,
         breakpoints.small + 50,
-        "android"
+        "android",
+        "light"
       )!;
       expect(smallProxied.breakpoint).toEqual(value.breakpoint.small);
     });
@@ -133,7 +178,8 @@ describe("createThemeValuesProxy tests", () => {
         value,
         breakpoints,
         breakpoints.medium,
-        "android"
+        "android",
+        "light"
       )!;
       expect(mediumProxied.breakpoint).toEqual(value.breakpoint.medium);
     });
@@ -143,7 +189,8 @@ describe("createThemeValuesProxy tests", () => {
         value,
         breakpoints,
         breakpoints.medium + 50,
-        "android"
+        "android",
+        "light"
       )!;
       expect(mediumProxied.breakpoint).toEqual(value.breakpoint.medium);
     });
@@ -153,7 +200,8 @@ describe("createThemeValuesProxy tests", () => {
         value,
         breakpoints,
         breakpoints.large,
-        "android"
+        "android",
+        "light"
       )!;
       expect(largeProxied.breakpoint).toEqual(value.breakpoint.large);
     });
@@ -163,7 +211,8 @@ describe("createThemeValuesProxy tests", () => {
         value,
         breakpoints,
         breakpoints.large + 400,
-        "android"
+        "android",
+        "light"
       )!;
       expect(largeProxied.breakpoint).toEqual(value.breakpoint.large);
     });
@@ -173,7 +222,8 @@ describe("createThemeValuesProxy tests", () => {
         value,
         breakpoints,
         50,
-        "android"
+        "android",
+        "light"
       )!;
       expect(verySmallProxied.breakpoint).toEqual(value.breakpoint.default);
     });
@@ -183,7 +233,8 @@ describe("createThemeValuesProxy tests", () => {
         value,
         breakpoints,
         breakpoints.small,
-        "android"
+        "android",
+        "light"
       )!;
       expect(smallProxied.breakpointNested.nested).toEqual(
         value.breakpointNested.small.nested
@@ -195,10 +246,72 @@ describe("createThemeValuesProxy tests", () => {
         value,
         breakpoints,
         breakpoints.medium,
-        "android"
+        "android",
+        "light"
       )!;
       expect(mediumProxied.breakpointNested.nested).toEqual(
         value.breakpointNested.medium.nested
+      );
+    });
+  });
+
+  describe("Light Dark Value", () => {
+    test("returns light value when key is light", () => {
+      const lightProxied = createThemeValuesProxy(
+        value,
+        {},
+        400,
+        "android",
+        "light"
+      )!;
+      expect(lightProxied.lightDark).toEqual(value.lightDark.light);
+    });
+
+    test("returns dark value when key is dark", () => {
+      const darkProxied = createThemeValuesProxy(
+        value,
+        {},
+        400,
+        "android",
+        "dark"
+      )!;
+      expect(darkProxied.lightDark).toEqual(value.lightDark.dark);
+    });
+
+    test("returns default value when key is not light or dark", () => {
+      const otherProxied = createThemeValuesProxy(
+        value,
+        {},
+        400,
+        "android",
+        "other" as any
+      )!;
+      expect(otherProxied.lightDark).toEqual(value.lightDark.default);
+    });
+
+    test("returns nested light value when key is light", () => {
+      const lightProxied = createThemeValuesProxy(
+        value,
+        {},
+        400,
+        "android",
+        "light"
+      )!;
+      expect(lightProxied.lightDarkNested.nested).toEqual(
+        value.lightDarkNested.light.nested
+      );
+    });
+
+    test("returns nested dark value when key is dark", () => {
+      const darkProxied = createThemeValuesProxy(
+        value,
+        {},
+        400,
+        "android",
+        "dark"
+      )!;
+      expect(darkProxied.lightDarkNested.nested).toEqual(
+        value.lightDarkNested.dark.nested
       );
     });
   });


### PR DESCRIPTION
Similair to how themes can have different values for platform and breakpoints, this also adds the ability to have different values for light/dark modes of the device. Uses react native's `useColorScheme` hook to determine to device's current light/dark selection and chooses a color based on that.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds light/dark mode support to themes using `useColorScheme` and updates theme proxy logic.
> 
>   - **Behavior**:
>     - Adds support for light/dark mode in themes using `useColorScheme` in `Provider.tsx`.
>     - Updates `createThemeValuesProxy` to handle light/dark mode values.
>   - **Theme Proxy**:
>     - Modifies `createThemeValuesProxy` to include `currentLightDarkSelection` parameter.
>     - Adds `getLightDarkValue` function to handle light/dark mode selection.
>   - **Tests**:
>     - Adds test cases for light/dark mode in `createThemeValuesProxy.test.ts`.
>   - **Examples**:
>     - Updates `ThemeExample.tsx` to demonstrate light/dark mode color selection.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=draftbit%2Freact-native-jigsaw&utm_source=github&utm_medium=referral)<sup> for 7d1d21dea2ef4feaba8f73e51b9b93cef7f82c7a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->