### PR TITLE
Add `swipeCard` method to DeckSwiper components

### DIFF
--- a/packages/core/src/components/DeckSwiper/DeckSwiper.tsx
+++ b/packages/core/src/components/DeckSwiper/DeckSwiper.tsx
@@ -126,6 +126,8 @@ const DeckSwiper = React.forwardRef<DeckSwiperRef, DeckSwiperProps<any>>(
           case "bottom":
             deckSwiperRef.current?.swipeBottom();
             break;
+          default:
+            deckSwiperRef.current?.swipeLeft();
         }
       },
     }));

--- a/packages/core/src/components/DeckSwiper/DeckSwiper.tsx
+++ b/packages/core/src/components/DeckSwiper/DeckSwiper.tsx
@@ -2,6 +2,10 @@ import React from "react";
 import { StyleProp, ViewStyle, StyleSheet, View } from "react-native";
 import DeckSwiperComponent from "react-native-deck-swiper";
 
+export interface DeckSwiperRef {
+  swipeCard: (direction: "left" | "right" | "top" | "bottom") => void;
+}
+
 export interface DeckSwiperProps<T> {
   onStartSwipe?: () => void;
   onEndSwipe?: () => void;
@@ -23,145 +27,169 @@ export interface DeckSwiperProps<T> {
   style?: StyleProp<ViewStyle>;
 }
 
-const DeckSwiper = <T extends object>({
-  onStartSwipe,
-  onEndSwipe,
-  onSwipe,
-  onSwipedLeft,
-  onSwipedRight,
-  onSwipedUp,
-  onSwipedDown,
-  onIndexChanged,
-  onEndReached,
-  startCardIndex = 0,
-  infiniteSwiping = false,
-  verticalEnabled = true,
-  horizontalEnabled = true,
-  visibleCardCount = 1,
-  data,
-  keyExtractor,
-  renderItem,
-  style,
-  children,
-}: React.PropsWithChildren<DeckSwiperProps<T>>) => {
-  //Both 'renderItem' and 'data' are optional to allow direct children. But if one is included, both need to be included
-  if ((data && !renderItem) || (renderItem && !data)) {
-    throw new Error(
-      "'renderItem' and 'data' need to both be provided to lazily render. Either remove them entirley or include both"
+const DeckSwiper = React.forwardRef<DeckSwiperRef, DeckSwiperProps<any>>(
+  <T extends object>(
+    {
+      onStartSwipe,
+      onEndSwipe,
+      onSwipe,
+      onSwipedLeft,
+      onSwipedRight,
+      onSwipedUp,
+      onSwipedDown,
+      onIndexChanged,
+      onEndReached,
+      startCardIndex = 0,
+      infiniteSwiping = false,
+      verticalEnabled = true,
+      horizontalEnabled = true,
+      visibleCardCount = 1,
+      data,
+      keyExtractor,
+      renderItem,
+      style,
+      children,
+    }: React.PropsWithChildren<DeckSwiperProps<T>>,
+    ref: React.Ref<DeckSwiperRef>
+  ) => {
+    //Both 'renderItem' and 'data' are optional to allow direct children. But if one is included, both need to be included
+    if ((data && !renderItem) || (renderItem && !data)) {
+      throw new Error(
+        "'renderItem' and 'data' need to both be provided to lazily render. Either remove them entirley or include both"
+      );
+    }
+
+    if (data && renderItem && children) {
+      console.warn(
+        "'children' of DeckSwiper ignored due to usage of 'data' and 'renderItem'"
+      );
+    }
+
+    const deckSwiperRef = React.useRef<DeckSwiperComponent<T>>(null);
+
+    const childrenArray = React.useMemo(
+      () => React.Children.toArray(children),
+      [children]
     );
-  }
 
-  if (data && renderItem && children) {
-    console.warn(
-      "'children' of DeckSwiper ignored due to usage of 'data' and 'renderItem'"
+    // an array of indices based on children count
+    const cardsFillerData = React.useMemo(
+      () => Array.from(Array(childrenArray.length).keys()),
+      [childrenArray]
     );
-  }
 
-  const deckSwiperRef = React.useRef<DeckSwiperComponent<T>>(null);
+    const cardsData = Array.isArray(data) ? data : cardsFillerData;
 
-  const childrenArray = React.useMemo(
-    () => React.Children.toArray(children),
-    [children]
-  );
+    const renderCard = (card: any, index: number): JSX.Element => {
+      if (renderItem) {
+        return renderItem({ item: card, index });
+      } else {
+        return <>{childrenArray[index]}</>;
+      }
+    };
 
-  // an array of indices based on children count
-  const cardsFillerData = React.useMemo(
-    () => Array.from(Array(childrenArray.length).keys()),
-    [childrenArray]
-  );
+    const renderFirstCard = (): JSX.Element | undefined => {
+      if (cardsData.length) {
+        return renderCard(cardsData[0], 0);
+      }
+      return undefined;
+    };
 
-  const cardsData = Array.isArray(data) ? data : cardsFillerData;
+    const cardKeyExtractor = (card: any) => {
+      if (keyExtractor) {
+        return keyExtractor(card);
+      } else {
+        return card?.toString();
+      }
+    };
 
-  const renderCard = (card: any, index: number): JSX.Element => {
-    if (renderItem) {
-      return renderItem({ item: card, index });
-    } else {
-      return <>{childrenArray[index]}</>;
-    }
-  };
-
-  const renderFirstCard = (): JSX.Element | undefined => {
-    if (cardsData.length) {
-      return renderCard(cardsData[0], 0);
-    }
-    return undefined;
-  };
-
-  const cardKeyExtractor = (card: any) => {
-    if (keyExtractor) {
-      return keyExtractor(card);
-    } else {
-      return card?.toString();
-    }
-  };
-
-  /* 
+    /* 
   react-native-deck-swiper does not re-render cards when parent state changes
   This forces an update on every re-render to reflect any parent state changes
   */
-  React.useEffect(() => {
-    deckSwiperRef.current?.forceUpdate();
-  });
+    React.useEffect(() => {
+      deckSwiperRef.current?.forceUpdate();
+    });
 
-  /**
-   * By default react-native-deck-swiper positions everything with absolute position.
-   * To overcome this, it is wrapped in a View to be able to add the component in any layout structure.
-   *
-   *
-   * Since all children of that View are absolutley positioned, the View does not have a height and still looks and behaves weird.
-   * To fix/mitage this without setting a static height, the first card is rendered in invisible state to take up space.
-   * This effectivley makes the default height of the container be the height of the first card.
-   */
-
-  return (
-    <View>
-      <View style={styles.containerHeightFiller}>{renderFirstCard()}</View>
-      <DeckSwiperComponent
-        ref={deckSwiperRef}
-        cards={cardsData as any[]}
-        renderCard={renderCard}
-        keyExtractor={cardKeyExtractor}
-        containerStyle={
-          StyleSheet.flatten([styles.cardsContainer, style]) as
-            | object
-            | undefined
+    React.useImperativeHandle(ref, () => ({
+      swipeCard: (direction: "left" | "right" | "top" | "bottom") => {
+        switch (direction) {
+          case "left":
+            deckSwiperRef.current?.swipeLeft();
+            break;
+          case "right":
+            deckSwiperRef.current?.swipeRight();
+            break;
+          case "top":
+            deckSwiperRef.current?.swipeTop();
+            break;
+          case "bottom":
+            deckSwiperRef.current?.swipeBottom();
+            break;
         }
-        cardStyle={styles.card as object | undefined}
-        onSwiped={onIndexChanged}
-        onSwipedAll={onEndReached}
-        cardIndex={startCardIndex}
-        infinite={infiniteSwiping}
-        verticalSwipe={verticalEnabled}
-        horizontalSwipe={horizontalEnabled}
-        showSecondCard={visibleCardCount > 1}
-        stackSize={visibleCardCount}
-        backgroundColor="transparent"
-        cardVerticalMargin={0}
-        cardHorizontalMargin={0}
-        onSwipedLeft={(index) => {
-          onSwipedLeft?.(index);
-          onSwipe?.(index);
-        }}
-        onSwipedRight={(index) => {
-          onSwipedRight?.(index);
-          onSwipe?.(index);
-        }}
-        onSwipedTop={(index) => {
-          onSwipedUp?.(index);
-          onSwipe?.(index);
-        }}
-        onSwipedBottom={(index) => {
-          onSwipedDown?.(index);
-          onSwipe?.(index);
-        }}
-        //@ts-ignore Not typed, but is implemented and works
-        dragStart={onStartSwipe}
-        //@ts-ignore
-        dragEnd={onEndSwipe}
-      />
-    </View>
-  );
-};
+      },
+    }));
+
+    /**
+     * By default react-native-deck-swiper positions everything with absolute position.
+     * To overcome this, it is wrapped in a View to be able to add the component in any layout structure.
+     *
+     *
+     * Since all children of that View are absolutley positioned, the View does not have a height and still looks and behaves weird.
+     * To fix/mitage this without setting a static height, the first card is rendered in invisible state to take up space.
+     * This effectivley makes the default height of the container be the height of the first card.
+     */
+
+    return (
+      <View>
+        <View style={styles.containerHeightFiller}>{renderFirstCard()}</View>
+        <DeckSwiperComponent
+          ref={deckSwiperRef}
+          cards={cardsData as any[]}
+          renderCard={renderCard}
+          keyExtractor={cardKeyExtractor}
+          containerStyle={
+            StyleSheet.flatten([styles.cardsContainer, style]) as
+              | object
+              | undefined
+          }
+          cardStyle={styles.card as object | undefined}
+          onSwiped={onIndexChanged}
+          onSwipedAll={onEndReached}
+          cardIndex={startCardIndex}
+          infinite={infiniteSwiping}
+          verticalSwipe={verticalEnabled}
+          horizontalSwipe={horizontalEnabled}
+          showSecondCard={visibleCardCount > 1}
+          stackSize={visibleCardCount}
+          backgroundColor="transparent"
+          cardVerticalMargin={0}
+          cardHorizontalMargin={0}
+          onSwipedLeft={(index) => {
+            onSwipedLeft?.(index);
+            onSwipe?.(index);
+          }}
+          onSwipedRight={(index) => {
+            onSwipedRight?.(index);
+            onSwipe?.(index);
+          }}
+          onSwipedTop={(index) => {
+            onSwipedUp?.(index);
+            onSwipe?.(index);
+          }}
+          onSwipedBottom={(index) => {
+            onSwipedDown?.(index);
+            onSwipe?.(index);
+          }}
+          //@ts-ignore Not typed, but is implemented and works
+          dragStart={onStartSwipe}
+          //@ts-ignore
+          dragEnd={onEndSwipe}
+        />
+      </View>
+    );
+  }
+);
 
 const styles = StyleSheet.create({
   cardsContainer: {

--- a/packages/core/src/components/DeckSwiper/index.tsx
+++ b/packages/core/src/components/DeckSwiper/index.tsx
@@ -1,2 +1,2 @@
-export { default as DeckSwiper } from "./DeckSwiper";
+export { default as DeckSwiper, DeckSwiperRef } from "./DeckSwiper";
 export { default as DeckSwiperCard } from "./DeckSwiperCard";

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -34,6 +34,7 @@ export {
 } from "./components/RadioButton/index";
 export { default as Shadow } from "./components/Shadow";
 export { DeckSwiper, DeckSwiperCard } from "./components/DeckSwiper";
+export type { DeckSwiperRef } from "./components/DeckSwiper";
 export { TabView, TabViewItem } from "./components/TabView";
 export { default as Markdown } from "./components/Markdown";
 export { BottomSheet } from "./components/BottomSheet";


### PR DESCRIPTION
- DeckSwiper has `swipeLeft`, `swipeRight` etc methods to programtically swipe card. This adds a simpler `swipeCard` method that takes `direction` as a parameter and call the appropriate function. This makes it easier to add as a single action with an argument rather than introduce 4 actions or a util function on the builder.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `swipeCard` method to `DeckSwiper` for flexible card swiping by direction.
> 
>   - **Behavior**:
>     - Adds `swipeCard` method to `DeckSwiper` in `DeckSwiper.tsx` to swipe cards in specified direction (`left`, `right`, `top`, `bottom`).
>     - Simplifies programmatic card swiping by consolidating direction-based methods.
>   - **Refactoring**:
>     - Uses `React.forwardRef` to expose `swipeCard` method via `DeckSwiperRef`.
>   - **Exports**:
>     - Exports `DeckSwiperRef` in `index.tsx` and `DeckSwiper/index.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=draftbit%2Freact-native-jigsaw&utm_source=github&utm_medium=referral)<sup> for 1abc8ba99eb529bc963488c9cafc2a0257fa69b3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->