### PR TITLE
Add active opacity to action sheet item

### DIFF
--- a/packages/core/src/components/ActionSheet/ActionSheetItem.tsx
+++ b/packages/core/src/components/ActionSheet/ActionSheetItem.tsx
@@ -14,6 +14,7 @@ type Props = {
   color: string;
   style?: StyleProp<ViewStyle | TextStyle>;
   onPress?: () => void;
+  activeOpacity?: number;
 };
 
 const ActionSheetItem: React.FC<React.PropsWithChildren<Props>> = ({
@@ -21,11 +22,12 @@ const ActionSheetItem: React.FC<React.PropsWithChildren<Props>> = ({
   style,
   color,
   onPress,
+  activeOpacity = 0.7,
 }) => {
   const { textStyles, viewStyles } = extractStyles(style);
   return (
     <TouchableOpacity
-      activeOpacity={0.7}
+      activeOpacity={activeOpacity}
       style={[styles.wrapper, viewStyles]}
       onPress={onPress}
     >


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `activeOpacity` prop to `ActionSheetItem` for customizable touch feedback opacity.
> 
>   - **Behavior**:
>     - Adds `activeOpacity` prop to `ActionSheetItem` in `ActionSheetItem.tsx` to allow customization of touch feedback opacity.
>     - Default `activeOpacity` set to `0.7` if not provided.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=draftbit%2Freact-native-jigsaw&utm_source=github&utm_medium=referral)<sup> for d9877f4bcd81fcd68dd89fff17565c6501ae5aad. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->