### PR TITLE
Adjust warning for audio player when preview playsInBackground is true

### DIFF
--- a/packages/core/src/components/MediaPlayer/AudioPlayer/HeadlessAudioPlayer.tsx
+++ b/packages/core/src/components/MediaPlayer/AudioPlayer/HeadlessAudioPlayer.tsx
@@ -70,9 +70,9 @@ const HeadlessAudioPlayer = React.forwardRef<
           playThroughEarpieceAndroid,
         });
       } catch (e) {
-        console.error(
-          "Failed to set audio mode. interruptionMode, playsInBackground, playsInSilentModeIOS, playThroughEarpieceAndroid might not be set. Failed with",
-          e
+        // Warn when trying to play in background during preview mode
+        console.warn(
+          "Background audio playback only works in published apps, not in preview mode. For iOS apps, add 'audio' under UI Background Modes in Project Settings > Apple App Store."
         );
       }
     }, [

--- a/packages/core/src/components/MediaPlayer/AudioPlayer/HeadlessAudioPlayer.tsx
+++ b/packages/core/src/components/MediaPlayer/AudioPlayer/HeadlessAudioPlayer.tsx
@@ -70,10 +70,16 @@ const HeadlessAudioPlayer = React.forwardRef<
           playThroughEarpieceAndroid,
         });
       } catch (e) {
-        // Warn when trying to play in background during preview mode
-        console.warn(
-          "Background audio playback only works in published apps, not in preview mode. For iOS apps, add 'audio' under UI Background Modes in Project Settings > Apple App Store."
-        );
+        if ((e as { code?: string })?.code === "E_AUDIO_AUDIOMODE") {
+          console.warn(
+            "Background audio playback only works in published apps, not in preview mode. For iOS apps, add 'audio' under UI Background Modes in Project Settings > Apple App Store."
+          );
+        } else {
+          console.error(
+            "Failed to set audio mode. interruptionMode, playsInBackground, playsInSilentModeIOS, playThroughEarpieceAndroid might not be set. Failed with",
+            e
+          );
+        }
       }
     }, [
       interruptionMode,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adjusts warning message in `HeadlessAudioPlayer` for background audio playback during preview mode when `playsInBackground` is true.
> 
>   - **Behavior**:
>     - Adjusts warning message in `HeadlessAudioPlayer` when `playsInBackground` is true during preview mode.
>     - New warning advises that background audio playback only works in published apps and provides guidance for iOS app settings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=draftbit%2Freact-native-jigsaw&utm_source=github&utm_medium=referral)<sup> for c3195cb821db2b566e69bcb7db54c3aca648f0a0. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->