### PR TITLE
Support disabled slider

### DIFF
--- a/example/src/SliderExample.tsx
+++ b/example/src/SliderExample.tsx
@@ -17,6 +17,14 @@ function SliderExample({ theme }) {
         />
       </Section>
 
+      <Section title="Disabled">
+        <Slider
+          disabled
+          onValueChange={console.log}
+          style={{ marginLeft: 12, marginRight: 12 }}
+        />
+      </Section>
+
       <Section title="Controlled">
         <Slider
           step={10}

--- a/packages/core/src/components/Slider.tsx
+++ b/packages/core/src/components/Slider.tsx
@@ -25,6 +25,7 @@ export type Props = {
   step: number;
   onValueChange?: (value: number) => void;
   theme: ReadTheme;
+  disabled?: boolean;
 } & IconSlot;
 
 function maybeParseValue(value: any) {
@@ -66,6 +67,7 @@ function Slider({
   onValueChange = () => {},
   style,
   theme,
+  disabled,
   ...rest
 }: Props) {
   const [internalValue, setInternalValue] = React.useState<number | undefined>(
@@ -134,6 +136,7 @@ function Slider({
         thumbTintColor={thumbColor}
         onSlidingComplete={handleSlidingComplete}
         style={styles.slider}
+        disabled={disabled}
         //@ts-ignore Not registered in types
         thumbStyle={Platform.OS === "web" ? tempThumbStyle : undefined}
       />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds support for a disabled state in the `Slider` component, with updates to `Slider.tsx` and `SliderExample.tsx`.
> 
>   - **Behavior**:
>     - Adds `disabled` prop to `Slider` component in `Slider.tsx`, allowing it to be rendered as non-interactive.
>     - Updates `SliderExample.tsx` to include a new section demonstrating a disabled slider.
>   - **Props**:
>     - Adds `disabled?: boolean` to `Props` type in `Slider.tsx`.
>   - **Rendering**:
>     - Passes `disabled` prop to `NativeSlider` in `Slider.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=draftbit%2Freact-native-jigsaw&utm_source=github&utm_medium=referral)<sup> for c3f7e53f5d6c20d9f582315fb4c5f3f3191c8002. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->