### PR TITLE
Support expo image - Expo 51

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -76,6 +76,7 @@ import ThemeExample from "./ThemeExample";
 import LoadingIndicatorExample from "./LoadingIndicatorExample";
 import TimerExample from "./TimerExample";
 import LottieAnimationExample from "./LottieAnimationExample";
+import ExpoImageExample from "./ExpoImageExample";
 
 const ROUTES = {
   LottieAnimationExample: LottieAnimationExample,
@@ -120,6 +121,7 @@ const ROUTES = {
   VideoPlayer: VideoPlayerExample,
   PinInput: PinInputExample,
   KeyboardAvoidingView: KeyboardAvoidingViewExample,
+  ExpoImage: ExpoImageExample,
 };
 
 const customFonts = {

--- a/example/src/ExpoImageExample.tsx
+++ b/example/src/ExpoImageExample.tsx
@@ -1,0 +1,171 @@
+import * as React from "react";
+import { View, StyleSheet, Text } from "react-native";
+import { ExpoImage, withTheme } from "@draftbit/ui";
+import Section, { Container } from "./Section";
+
+interface WrapperProps {
+  label: string;
+  children: React.ReactNode;
+}
+
+const Wrapper: React.FC<WrapperProps> = ({ label, children }) => {
+  return (
+    <View style={styles.wrapper}>
+      <View style={styles.boxLabel}>
+        <Text>{label}</Text>
+      </View>
+      <View>{children}</View>
+    </View>
+  );
+};
+
+const ExpoImageExample: React.FC = () => {
+  return (
+    <Container style={{}}>
+      <Section title="Image Examples" style={{}}>
+        <View style={{ flexDirection: "row" }}>
+          <Wrapper label="Basic remote image">
+            <ExpoImage
+              source={{
+                uri: "https://picsum.photos/1100",
+              }}
+              style={{
+                width: 200,
+                height: 200,
+              }}
+            />
+          </Wrapper>
+          <Wrapper label="Local image">
+            <ExpoImage
+              source={require("./assets/images/hamburger.png")}
+              style={{
+                width: 200,
+                height: 200,
+              }}
+            />
+          </Wrapper>
+        </View>
+        <View style={{ flexDirection: "row" }}>
+          <Wrapper label="With aspectRatio">
+            <ExpoImage
+              source={{
+                uri: "https://picsum.photos/1200",
+              }}
+              style={{
+                width: 300,
+                aspectRatio: 16 / 9,
+              }}
+            />
+          </Wrapper>
+        </View>
+        <View style={{ flexDirection: "row" }}>
+          <Wrapper label="Content fit: contain">
+            <ExpoImage
+              source={{
+                uri: "https://picsum.photos/1300",
+              }}
+              contentFit="contain"
+              style={{
+                width: 200,
+                height: 200,
+                backgroundColor: "#f0f0f0",
+              }}
+            />
+          </Wrapper>
+          <Wrapper label="With blur hash">
+            <ExpoImage
+              source={{
+                uri: "https://picsum.photos/seed/696/3000/2000",
+              }}
+              blurhash="LEHLk~WB2yk8pyo0adR*.7kCMdnj"
+              transition={5000}
+              style={{
+                width: 200,
+                height: 200,
+              }}
+            />
+          </Wrapper>
+        </View>
+      </Section>
+      <Section title="SVG Image" style={styles.wrapper}>
+        <Wrapper label="Remote SVG Image">
+          <ExpoImage
+            source={{
+              uri: "https://upload.wikimedia.org/wikipedia/commons/3/30/Vector-based_example.svg",
+            }}
+            style={{
+              width: 200,
+              height: 200,
+            }}
+          />
+        </Wrapper>
+        <Wrapper label="Local SVG Image">
+          <ExpoImage
+            source={require("./assets/images/example.svg")}
+            style={{
+              width: 200,
+              height: 200,
+            }}
+          />
+        </Wrapper>
+      </Section>
+      <Section title="Transition Effects" style={{}}>
+        <View style={{ flexDirection: "row", flexWrap: "wrap" }}>
+          <Wrapper label="Cross Dissolve - Ease In Out">
+            <ExpoImage
+              source={{ uri: "https://picsum.photos/1400" }}
+              transitionDuration={3000}
+              transitionEffect="cross-dissolve"
+              transitionTiming="ease-in-out"
+              style={{ width: 200, height: 200 }}
+            />
+          </Wrapper>
+          <Wrapper label="Flip from Top - Ease Out">
+            <ExpoImage
+              source={{ uri: "https://picsum.photos/1500" }}
+              transitionDuration={3000}
+              transitionEffect="flip-from-top"
+              transitionTiming="ease-out"
+              style={{ width: 200, height: 200 }}
+            />
+          </Wrapper>
+          <Wrapper label="Curl Up - Linear">
+            <ExpoImage
+              source={{ uri: "https://picsum.photos/1600" }}
+              transitionDuration={3000}
+              transitionEffect="curl-up"
+              transitionTiming="linear"
+              style={{ width: 200, height: 200 }}
+            />
+          </Wrapper>
+          <Wrapper label="Cross Dissolve - Ease In Out">
+            <ExpoImage
+              source={{ uri: "https://picsum.photos/1700" }}
+              transitionDuration={3000}
+              transitionEffect="cross-dissolve"
+              transitionTiming="ease-in-out"
+              style={{ width: 200, height: 200 }}
+            />
+          </Wrapper>
+        </View>
+      </Section>
+    </Container>
+  );
+};
+
+const styles = StyleSheet.create({
+  wrapper: {
+    flex: 1,
+    display: "flex",
+    flexDirection: "column",
+    flexWrap: "wrap",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  boxLabel: {
+    margin: 10,
+    flex: 1,
+  },
+});
+
+export default withTheme(ExpoImageExample);

--- a/example/src/ExpoImageExample.tsx
+++ b/example/src/ExpoImageExample.tsx
@@ -46,19 +46,6 @@ const ExpoImageExample: React.FC = () => {
           </Wrapper>
         </View>
         <View style={{ flexDirection: "row" }}>
-          <Wrapper label="With aspectRatio">
-            <ExpoImage
-              source={{
-                uri: "https://picsum.photos/1200",
-              }}
-              style={{
-                width: 300,
-                aspectRatio: 16 / 9,
-              }}
-            />
-          </Wrapper>
-        </View>
-        <View style={{ flexDirection: "row" }}>
           <Wrapper label="Content fit: contain">
             <ExpoImage
               source={{

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,6 +56,7 @@
     "date-fns": "^4.1.0",
     "dateformat": "^5.0.3",
     "expo-av": "~14.0.7",
+    "expo-image": "~1.13.0",
     "lodash.isequal": "^4.5.0",
     "lodash.isnumber": "^3.0.3",
     "lodash.omit": "^4.5.0",

--- a/packages/core/src/components/ExpoImage.tsx
+++ b/packages/core/src/components/ExpoImage.tsx
@@ -1,0 +1,165 @@
+import React from "react";
+import { StyleSheet, ImageSourcePropType, DimensionValue } from "react-native";
+import {
+  Image,
+  ImageContentPosition,
+  ImageProps as ExpoImageProps,
+  ImageContentFit,
+} from "expo-image";
+import Config from "./Config";
+import AspectRatio from "./AspectRatio";
+
+type ImageStyleProp = {
+  width?: number;
+  height?: number;
+  aspectRatio?: number;
+};
+
+interface ExtendedImageProps extends ExpoImageProps {
+  transitionDuration?: number;
+  transitionEffect?:
+    | "cross-dissolve"
+    | "flip-from-top"
+    | "flip-from-right"
+    | "flip-from-bottom"
+    | "flip-from-left"
+    | "curl-up"
+    | "curl-down";
+  transitionTiming?: "ease-in-out" | "ease-in" | "ease-out" | "linear";
+  contentFit?: "cover" | "contain" | "fill" | "none" | "scale-down";
+  contentPosition?: ImageContentPosition;
+  cachePolicy?: "none" | "disk" | "memory" | "memory-disk";
+  allowDownscaling?: boolean;
+  blurRadius?: number;
+  blurhash?: string;
+}
+
+const generateDimensions = ({
+  aspectRatio,
+  width,
+  height,
+}: ImageStyleProp): {
+  aspectRatio?: number;
+  width?: DimensionValue;
+  height?: DimensionValue;
+} => {
+  if (aspectRatio && !width && !height) {
+    return {
+      aspectRatio,
+      width: "100%",
+    };
+  }
+
+  if (aspectRatio && height) {
+    return {
+      aspectRatio,
+      height,
+      width: aspectRatio * height,
+    };
+  }
+
+  if (aspectRatio && width) {
+    return {
+      aspectRatio,
+      width,
+      height: width / aspectRatio,
+    };
+  }
+
+  return { width, height };
+};
+
+const resizeModeToContentFit = (
+  resizeMode: "cover" | "contain" | "stretch" | "repeat" | "center"
+): ImageContentFit => {
+  const mapping: Record<typeof resizeMode, ImageContentFit> = {
+    cover: "cover",
+    contain: "contain",
+    stretch: "fill",
+    repeat: "none",
+    center: "scale-down",
+  } as const;
+  return mapping[resizeMode] ?? "cover";
+};
+
+const ExpoImage: React.FC<ExtendedImageProps> = ({
+  source,
+  resizeMode = "cover",
+  style,
+  transitionDuration = 300,
+  transitionEffect = "cross-dissolve",
+  transitionTiming = "ease-in-out",
+  contentFit = "cover",
+  contentPosition = "center",
+  cachePolicy = "memory-disk",
+  allowDownscaling = true,
+  blurRadius,
+  blurhash,
+  ...props
+}) => {
+  const imageSource =
+    source === null || source === undefined
+      ? Config.placeholderImageURL
+      : source;
+
+  const styles = StyleSheet.flatten(style || {});
+  const { aspectRatio, width, height } = generateDimensions(
+    styles as ImageStyleProp
+  );
+
+  const finalContentFit = resizeMode
+    ? resizeModeToContentFit(resizeMode)
+    : contentFit;
+
+  const transition = {
+    timing: transitionTiming,
+    duration: transitionDuration,
+    effect: transitionEffect,
+  };
+
+  if (aspectRatio) {
+    return (
+      <AspectRatio style={[style, { width, height, aspectRatio }]}>
+        <Image
+          {...props}
+          source={imageSource as ImageSourcePropType}
+          contentFit={finalContentFit}
+          placeholder={{
+            blurhash,
+          }}
+          transition={transition}
+          contentPosition={contentPosition}
+          cachePolicy={cachePolicy}
+          allowDownscaling={allowDownscaling}
+          blurRadius={blurRadius}
+          style={[
+            style,
+            {
+              height: "100%",
+              width: "100%",
+            },
+          ]}
+        />
+      </AspectRatio>
+    );
+  }
+
+  return (
+    <Image
+      {...props}
+      source={source as ImageSourcePropType}
+      contentFit={finalContentFit}
+      placeholder={{
+        blurhash,
+      }}
+      transition={transition}
+      contentPosition={contentPosition}
+      cachePolicy={cachePolicy}
+      allowDownscaling={allowDownscaling}
+      blurRadius={blurRadius}
+      style={style}
+    />
+  );
+};
+
+export default ExpoImage;

--- a/packages/core/src/components/ExpoImage.tsx
+++ b/packages/core/src/components/ExpoImage.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { StyleSheet, ImageSourcePropType, DimensionValue } from "react-native";
 import {
   Image,
   ImageContentPosition,
@@ -7,13 +6,6 @@ import {
   ImageContentFit,
 } from "expo-image";
 import Config from "./Config";
-import AspectRatio from "./AspectRatio";
-
-type ImageStyleProp = {
-  width?: number;
-  height?: number;
-  aspectRatio?: number;
-};
 
 interface ExtendedImageProps extends ExpoImageProps {
   transitionDuration?: number;
@@ -33,41 +25,6 @@ interface ExtendedImageProps extends ExpoImageProps {
   blurRadius?: number;
   blurhash?: string;
 }
-
-const generateDimensions = ({
-  aspectRatio,
-  width,
-  height,
-}: ImageStyleProp): {
-  aspectRatio?: number;
-  width?: DimensionValue;
-  height?: DimensionValue;
-} => {
-  if (aspectRatio && !width && !height) {
-    return {
-      aspectRatio,
-      width: "100%",
-    };
-  }
-
-  if (aspectRatio && height) {
-    return {
-      aspectRatio,
-      height,
-      width: aspectRatio * height,
-    };
-  }
-
-  if (aspectRatio && width) {
-    return {
-      aspectRatio,
-      width,
-      height: width / aspectRatio,
-    };
-  }
-
-  return { width, height };
-};
 
 const resizeModeToContentFit = (
   resizeMode: "cover" | "contain" | "stretch" | "repeat" | "center"
@@ -97,16 +54,7 @@ const ExpoImage: React.FC<ExtendedImageProps> = ({
   blurhash,
   ...props
 }) => {
-  const imageSource =
-    source === null || source === undefined
-      ? Config.placeholderImageURL
-      : source;
-
-  const styles = StyleSheet.flatten(style || {});
-  const { aspectRatio, width, height } = generateDimensions(
-    styles as ImageStyleProp
-  );
-
+  const imageSource = source ?? Config.placeholderImageURL;
   const finalContentFit = resizeMode
     ? resizeModeToContentFit(resizeMode)
     : contentFit;
@@ -117,37 +65,10 @@ const ExpoImage: React.FC<ExtendedImageProps> = ({
     effect: transitionEffect,
   };
 
-  if (aspectRatio) {
-    return (
-      <AspectRatio style={[style, { width, height, aspectRatio }]}>
-        <Image
-          {...props}
-          source={imageSource as ImageSourcePropType}
-          contentFit={finalContentFit}
-          placeholder={{
-            blurhash,
-          }}
-          transition={transition}
-          contentPosition={contentPosition}
-          cachePolicy={cachePolicy}
-          allowDownscaling={allowDownscaling}
-          blurRadius={blurRadius}
-          style={[
-            style,
-            {
-              height: "100%",
-              width: "100%",
-            },
-          ]}
-        />
-      </AspectRatio>
-    );
-  }
-
   return (
     <Image
       {...props}
-      source={source as ImageSourcePropType}
+      source={imageSource}
       contentFit={finalContentFit}
       placeholder={{
         blurhash,

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -82,6 +82,7 @@ export { default as SimpleStyleSwipeableList } from "./components/SimpleStyleScr
 export { default as LoadingIndicator } from "./components/LoadingIndicator";
 export { default as LottieAnimation } from "./components/LottieAnimation";
 export { default as Timer } from "./components/Timer";
+export { default as ExpoImage } from "./components/ExpoImage";
 
 /* Deprecated: Fix or Delete!  */
 export { default as AccordionItem } from "./deprecated-components/AccordionItem";

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -78,6 +78,7 @@ export {
   LoadingIndicator,
   LottieAnimation,
   Timer,
+  ExpoImage,
 } from "@draftbit/core";
 
 export {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5174,11 +5174,6 @@ core-js-compat@^3.38.0, core-js-compat@^3.38.1:
   dependencies:
     browserslist "^4.24.2"
 
-core-js@^1.0.0:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
-  integrity sha512-ZiPp9pZlgxpWRu0M+YWbm6+aQ84XEfH1JRXvfOc/fILWI0VKhLC2LX13X1NYq4fULzLMq7Hfh43CSo2/aIaUPA==
-
 core-util-is@~1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
@@ -5739,7 +5734,7 @@ encodeurl@~2.0.0:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-2.0.0.tgz#7b8ea898077d7e409d3ac45474ea38eaf0857a58"
   integrity sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==
 
-encoding@^0.1.11, encoding@^0.1.13:
+encoding@^0.1.13:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.13.tgz#56574afdd791f54a8e9b2785c0582a2d26210fa9"
   integrity sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==
@@ -5760,15 +5755,10 @@ enquirer@~2.3.6:
   dependencies:
     ansi-colors "^4.1.1"
 
-entities@^4.2.0, entities@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
-  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
-
-entities@~2.0.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.3.tgz#5c487e5742ab93c15abb5da22759b8590ec03b7f"
-  integrity sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==
+entities@^2.0.0, entities@^4.2.0, entities@^4.5.0, entities@~2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
+  integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
 
 env-editor@^0.4.1:
   version "0.4.2"
@@ -6388,19 +6378,6 @@ fbjs-css-vars@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz#216551136ae02fe255932c3ec8775f18e2c078b8"
   integrity sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==
-
-fbjs@^0.8.9:
-  version "0.8.18"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.18.tgz#9835e0addb9aca2eff53295cd79ca1cfc7c9662a"
-  integrity sha512-EQaWFK+fEPSoibjNy8IxUtaFOMXcWsY0JaVrQoZR9zC8N2Ygf9iDITPWjUTVIax95b6I742JFLqASHfsag/vKA==
-  dependencies:
-    core-js "^1.0.0"
-    isomorphic-fetch "^2.1.1"
-    loose-envify "^1.0.0"
-    object-assign "^4.1.0"
-    promise "^7.1.1"
-    setimmediate "^1.0.5"
-    ua-parser-js "^0.7.30"
 
 fbjs@^3.0.0, fbjs@^3.0.4:
   version "3.0.5"
@@ -7695,7 +7672,7 @@ is-stream@2.0.0:
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
   integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
 
-is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==
@@ -7806,14 +7783,6 @@ isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==
-
-isomorphic-fetch@^2.1.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
-  integrity sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA==
-  dependencies:
-    node-fetch "^1.0.1"
-    whatwg-fetch ">=0.10.0"
 
 istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
   version "3.2.2"
@@ -8972,7 +8941,7 @@ logkitty@^0.7.1:
     dayjs "^1.8.15"
     yargs "^15.1.0"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -9748,14 +9717,6 @@ node-fetch@2.6.7:
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
   dependencies:
     whatwg-url "^5.0.0"
-
-node-fetch@^1.0.1:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
-  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
-  dependencies:
-    encoding "^0.1.11"
-    is-stream "^1.0.1"
 
 node-fetch@^2.2.0, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.12, node-fetch@^2.6.7:
   version "2.7.0"
@@ -10764,15 +10725,7 @@ promzard@^1.0.0:
   dependencies:
     read "^3.0.1"
 
-prop-types@15.5.10:
-  version "15.5.10"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
-  integrity sha512-vCFzoUFaZkVNeFkhK1KbSq4cn97GDrpfBt9K2qLkGnPAEFhEv3M61Lk5t+B7c0QfMLWo0fPkowk/4SuXerh26Q==
-  dependencies:
-    fbjs "^0.8.9"
-    loose-envify "^1.3.1"
-
-prop-types@15.8.1, prop-types@^15.5.10, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@15.5.10, prop-types@15.8.1, prop-types@^15.5.10, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -12940,11 +12893,6 @@ typescript-eslint@^8.16.0:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.2.tgz#3169cf8c4c8a828cde53ba9ecb3d2b1d5dd67be6"
   integrity sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==
 
-ua-parser-js@^0.7.30:
-  version "0.7.39"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.39.tgz#c71efb46ebeabc461c4612d22d54f88880fabe7e"
-  integrity sha512-IZ6acm6RhQHNibSt7+c09hhvsKy9WUr4DVbeq9U8o71qxyYtJpQeDxQnMrVqnIFMLcQjHO0I9wgfO2vIahht4w==
-
 ua-parser-js@^1.0.35:
   version "1.0.39"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-1.0.39.tgz#bfc07f361549bf249bd8f4589a4cccec18fd2018"
@@ -13246,7 +13194,7 @@ whatwg-encoding@^2.0.0:
   dependencies:
     iconv-lite "0.6.3"
 
-whatwg-fetch@>=0.10.0, whatwg-fetch@^3.0.0:
+whatwg-fetch@^3.0.0:
   version "3.6.20"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz#580ce6d791facec91d37c72890995a0b48d31c70"
   integrity sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5174,6 +5174,11 @@ core-js-compat@^3.38.0, core-js-compat@^3.38.1:
   dependencies:
     browserslist "^4.24.2"
 
+core-js@^1.0.0:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
+  integrity sha512-ZiPp9pZlgxpWRu0M+YWbm6+aQ84XEfH1JRXvfOc/fILWI0VKhLC2LX13X1NYq4fULzLMq7Hfh43CSo2/aIaUPA==
+
 core-util-is@~1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
@@ -5734,7 +5739,7 @@ encodeurl@~2.0.0:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-2.0.0.tgz#7b8ea898077d7e409d3ac45474ea38eaf0857a58"
   integrity sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==
 
-encoding@^0.1.13:
+encoding@^0.1.11, encoding@^0.1.13:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.13.tgz#56574afdd791f54a8e9b2785c0582a2d26210fa9"
   integrity sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==
@@ -5755,10 +5760,15 @@ enquirer@~2.3.6:
   dependencies:
     ansi-colors "^4.1.1"
 
-entities@^2.0.0, entities@^4.2.0, entities@^4.5.0, entities@~2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
-  integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
+entities@^4.2.0, entities@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
+  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
+
+entities@~2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.3.tgz#5c487e5742ab93c15abb5da22759b8590ec03b7f"
+  integrity sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==
 
 env-editor@^0.4.1:
   version "0.4.2"
@@ -6218,6 +6228,11 @@ expo-font@~12.0.10:
   dependencies:
     fontfaceobserver "^2.1.0"
 
+expo-image@~1.13.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/expo-image/-/expo-image-1.13.0.tgz#f0ad585ecf57f6df2d8524f5e9275cb12b349836"
+  integrity sha512-0NLDcFmEn4Nh1sXeRvNzDHT+Fl6FXtTol6ki6kYYH0/iDeSFWyIy/Fek6kzDDYAmhipSMR7buPf7VVoHseTbAA==
+
 expo-keep-awake@~13.0.2:
   version "13.0.2"
   resolved "https://registry.yarnpkg.com/expo-keep-awake/-/expo-keep-awake-13.0.2.tgz#5ef31311a339671eec9921b934fdd90ab9652b0e"
@@ -6373,6 +6388,19 @@ fbjs-css-vars@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz#216551136ae02fe255932c3ec8775f18e2c078b8"
   integrity sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==
+
+fbjs@^0.8.9:
+  version "0.8.18"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.18.tgz#9835e0addb9aca2eff53295cd79ca1cfc7c9662a"
+  integrity sha512-EQaWFK+fEPSoibjNy8IxUtaFOMXcWsY0JaVrQoZR9zC8N2Ygf9iDITPWjUTVIax95b6I742JFLqASHfsag/vKA==
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.30"
 
 fbjs@^3.0.0, fbjs@^3.0.4:
   version "3.0.5"
@@ -7667,7 +7695,7 @@ is-stream@2.0.0:
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
   integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
 
-is-stream@^1.1.0:
+is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==
@@ -7778,6 +7806,14 @@ isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==
+
+isomorphic-fetch@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
+  integrity sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA==
+  dependencies:
+    node-fetch "^1.0.1"
+    whatwg-fetch ">=0.10.0"
 
 istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
   version "3.2.2"
@@ -8936,7 +8972,7 @@ logkitty@^0.7.1:
     dayjs "^1.8.15"
     yargs "^15.1.0"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -9712,6 +9748,14 @@ node-fetch@2.6.7:
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
   dependencies:
     whatwg-url "^5.0.0"
+
+node-fetch@^1.0.1:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
+  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
 
 node-fetch@^2.2.0, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.12, node-fetch@^2.6.7:
   version "2.7.0"
@@ -10720,7 +10764,15 @@ promzard@^1.0.0:
   dependencies:
     read "^3.0.1"
 
-prop-types@15.5.10, prop-types@15.8.1, prop-types@^15.5.10, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@15.5.10:
+  version "15.5.10"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
+  integrity sha512-vCFzoUFaZkVNeFkhK1KbSq4cn97GDrpfBt9K2qLkGnPAEFhEv3M61Lk5t+B7c0QfMLWo0fPkowk/4SuXerh26Q==
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+
+prop-types@15.8.1, prop-types@^15.5.10, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -12888,6 +12940,11 @@ typescript-eslint@^8.16.0:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.2.tgz#3169cf8c4c8a828cde53ba9ecb3d2b1d5dd67be6"
   integrity sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==
 
+ua-parser-js@^0.7.30:
+  version "0.7.39"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.39.tgz#c71efb46ebeabc461c4612d22d54f88880fabe7e"
+  integrity sha512-IZ6acm6RhQHNibSt7+c09hhvsKy9WUr4DVbeq9U8o71qxyYtJpQeDxQnMrVqnIFMLcQjHO0I9wgfO2vIahht4w==
+
 ua-parser-js@^1.0.35:
   version "1.0.39"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-1.0.39.tgz#bfc07f361549bf249bd8f4589a4cccec18fd2018"
@@ -13189,7 +13246,7 @@ whatwg-encoding@^2.0.0:
   dependencies:
     iconv-lite "0.6.3"
 
-whatwg-fetch@^3.0.0:
+whatwg-fetch@>=0.10.0, whatwg-fetch@^3.0.0:
   version "3.6.20"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz#580ce6d791facec91d37c72890995a0b48d31c70"
   integrity sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `ExpoImage` component with examples, update dependencies, and export in `core` and `ui` packages.
> 
>   - **Components**:
>     - Add `ExpoImage` component in `ExpoImage.tsx` with properties for transition effects, content fit, and caching.
>   - **Examples**:
>     - Add `ExpoImageExample.tsx` to demonstrate `ExpoImage` use cases: remote/local images, aspect ratio, content fit, blur hash, transition effects.
>     - Update `App.tsx` to include `ExpoImageExample` in `ROUTES`.
>   - **Dependencies**:
>     - Add `expo-image` to `package.json`.
>   - **Exports**:
>     - Export `ExpoImage` from `index.tsx` in `core` and `ui` packages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=draftbit%2Freact-native-jigsaw&utm_source=github&utm_medium=referral)<sup> for dab51beafb9da19f124cadf4bc385f5e3c7f6092. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->