### PR TITLE
feat: hideDots in swiper using a prop

### DIFF
--- a/example/src/SwiperExample.tsx
+++ b/example/src/SwiperExample.tsx
@@ -147,6 +147,24 @@ function SwiperExample() {
           />
         </View>
       </Section>
+
+      <Section title="Hide Dots Example" style={undefined}>
+        <Swiper
+          vertical={false}
+          hideDots
+          style={{ width: "100%", height: 300 }}
+        >
+          <SwiperItem style={[style.item, { backgroundColor: "#fdd3d3" }]}>
+            <Text>Test Slide 1</Text>
+          </SwiperItem>
+          <SwiperItem style={[style.item, { backgroundColor: "#d6d3fd" }]}>
+            <Text>Test Slide 2</Text>
+          </SwiperItem>
+          <SwiperItem style={[style.item, { backgroundColor: "#c9fdd9" }]}>
+            <Text>Test Slide 3</Text>
+          </SwiperItem>
+        </Swiper>
+      </Section>
     </Container>
   );
 }

--- a/packages/core/src/components/Swiper/Swiper.tsx
+++ b/packages/core/src/components/Swiper/Swiper.tsx
@@ -33,6 +33,7 @@ export interface SwiperProps<T> {
   minDistanceForAction?: number;
   minDistanceToCapture?: number;
   theme: ReadTheme;
+  hideDots?: boolean;
 }
 
 const Swiper = forwardRef<SwiperRef, SwiperProps<any>>(
@@ -61,6 +62,7 @@ const Swiper = forwardRef<SwiperRef, SwiperProps<any>>(
       minDistanceForAction,
       minDistanceToCapture,
       style,
+      hideDots = false,
     }: SwiperProps<any>,
     ref
   ) => {
@@ -157,10 +159,20 @@ const Swiper = forwardRef<SwiperRef, SwiperProps<any>>(
             nextTitleStyle: { color: nextTitleColor },
             dotsTouchable,
             ...(dotColor
-              ? { dotProps: { badgeStyle: { backgroundColor: dotColor } } }
+              ? {
+                  dotProps: {
+                    badgeStyle: {
+                      backgroundColor: hideDots ? "transparent" : dotColor,
+                    },
+                  },
+                }
               : {}),
             ...(dotActiveColor
-              ? { dotActiveStyle: { backgroundColor: dotActiveColor } }
+              ? {
+                  dotActiveStyle: {
+                    backgroundColor: hideDots ? "transparent" : dotActiveColor,
+                  },
+                }
               : {}),
           }}
         >


### PR DESCRIPTION
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/4d02535e-9e53-481e-b2d1-0c13a616fbc4">

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `hideDots` prop to `Swiper` component to optionally hide navigation dots, demonstrated in `SwiperExample.tsx`.
> 
>   - **Behavior**:
>     - Add `hideDots` prop to `Swiper` component in `Swiper.tsx` to hide navigation dots by setting their color to transparent.
>     - Demonstrated in `SwiperExample.tsx` with a new section titled "Hide Dots Example".
>   - **Props**:
>     - `hideDots` defaults to `false` if not provided.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=draftbit%2Freact-native-jigsaw&utm_source=github&utm_medium=referral)<sup> for ec030127744d89dcb68afff4947878f79ce3afb0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->