### PR TITLE
Support prop ignore reduce motion for bottom sheet

### DIFF
--- a/packages/core/src/components/BottomSheet/BottomSheet.tsx
+++ b/packages/core/src/components/BottomSheet/BottomSheet.tsx
@@ -123,7 +123,7 @@ const BottomSheet = React.forwardRef<BottomSheetComponent, BottomSheetProps>(
             : onSettle?.(mappedSnapPoints.length - index - 1)
         }
         overrideReduceMotion={
-          ignoreReduceMotion ? ReduceMotion.Always : ReduceMotion.System
+          ignoreReduceMotion ? ReduceMotion.Never : ReduceMotion.System
         }
       >
         <BottomSheetScrollView

--- a/packages/core/src/components/BottomSheet/BottomSheet.tsx
+++ b/packages/core/src/components/BottomSheet/BottomSheet.tsx
@@ -12,6 +12,7 @@ import BottomSheetComponent, {
 } from "@gorhom/bottom-sheet";
 import { useTheme } from "@draftbit/theme";
 import { extractPercentNumber, useDeepCompareMemo } from "../../utilities";
+import { ReduceMotion } from "react-native-reanimated";
 
 type SnapPosition = "top" | "middle" | "bottom";
 
@@ -38,6 +39,7 @@ export interface BottomSheetProps extends ScrollViewProps {
   enableDynamicSizing?: boolean;
   onSettle?: (index: number) => void;
   style?: StyleProp<ViewStyle>;
+  ignoreReduceMotion?: boolean;
 }
 
 // Clarification:
@@ -61,6 +63,7 @@ const BottomSheet = React.forwardRef<BottomSheetComponent, BottomSheetProps>(
       onSettle,
       style,
       children,
+      ignoreReduceMotion,
       ...rest
     },
     ref
@@ -118,6 +121,9 @@ const BottomSheet = React.forwardRef<BottomSheetComponent, BottomSheetProps>(
           enableDynamicSizing
             ? onSettle?.(mappedSnapPoints.length - index)
             : onSettle?.(mappedSnapPoints.length - index - 1)
+        }
+        overrideReduceMotion={
+          ignoreReduceMotion ? ReduceMotion.Always : ReduceMotion.System
         }
       >
         <BottomSheetScrollView

--- a/packages/core/src/components/BottomSheet/BottomSheet.tsx
+++ b/packages/core/src/components/BottomSheet/BottomSheet.tsx
@@ -63,7 +63,7 @@ const BottomSheet = React.forwardRef<BottomSheetComponent, BottomSheetProps>(
       onSettle,
       style,
       children,
-      ignoreReduceMotion,
+      ignoreReduceMotion = true,
       ...rest
     },
     ref


### PR DESCRIPTION
## Overview
- support prop ignore reduce motion for bottom sheet
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `ignoreReduceMotion` prop to `BottomSheet` to control motion settings in `BottomSheet.tsx`.
> 
>   - **Behavior**:
>     - Adds `ignoreReduceMotion` prop to `BottomSheet` in `BottomSheet.tsx`.
>     - Sets `overrideReduceMotion` in `BottomSheetComponent` to `ReduceMotion.Never` if `ignoreReduceMotion` is true, otherwise `ReduceMotion.System`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=draftbit%2Freact-native-jigsaw&utm_source=github&utm_medium=referral)<sup> for a615865a70fcd3a332e35943d5e2ab98b8fd913d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->