### PR TITLE
Support ignore reduce motion for bottom sheet - 50

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -44,7 +44,7 @@
     "@draftbit/react-theme-provider": "^2.1.1",
     "@draftbit/theme": "50.7.0",
     "@expo/vector-icons": "^14.0.0",
-    "@gorhom/bottom-sheet": "5.0.0-alpha.7",
+    "@gorhom/bottom-sheet": "5.0.6",
     "@lottiefiles/react-lottie-player": "3.5.3",
     "@material-ui/core": "^4.11.0",
     "@material-ui/pickers": "^3.2.10",

--- a/packages/core/src/components/BottomSheet/BottomSheet.tsx
+++ b/packages/core/src/components/BottomSheet/BottomSheet.tsx
@@ -12,6 +12,7 @@ import BottomSheetComponent, {
 } from "@gorhom/bottom-sheet";
 import { useTheme } from "@draftbit/theme";
 import { extractPercentNumber, useDeepCompareMemo } from "../../utilities";
+import { ReduceMotion } from "react-native-reanimated";
 
 type SnapPosition = "top" | "middle" | "bottom";
 
@@ -38,6 +39,7 @@ export interface BottomSheetProps extends ScrollViewProps {
   enableDynamicSizing?: boolean;
   onSettle?: (index: number) => void;
   style?: StyleProp<ViewStyle>;
+  ignoreReduceMotion?: boolean;
 }
 
 // Clarification:
@@ -61,6 +63,7 @@ const BottomSheet = React.forwardRef<BottomSheetComponent, BottomSheetProps>(
       onSettle,
       style,
       children,
+      ignoreReduceMotion = true,
       ...rest
     },
     ref
@@ -118,6 +121,9 @@ const BottomSheet = React.forwardRef<BottomSheetComponent, BottomSheetProps>(
           enableDynamicSizing
             ? onSettle?.(mappedSnapPoints.length - index)
             : onSettle?.(mappedSnapPoints.length - index - 1)
+        }
+        overrideReduceMotion={
+          ignoreReduceMotion ? ReduceMotion.System : undefined
         }
       >
         <BottomSheetScrollView

--- a/packages/core/src/components/BottomSheet/BottomSheet.tsx
+++ b/packages/core/src/components/BottomSheet/BottomSheet.tsx
@@ -123,7 +123,7 @@ const BottomSheet = React.forwardRef<BottomSheetComponent, BottomSheetProps>(
             : onSettle?.(mappedSnapPoints.length - index - 1)
         }
         overrideReduceMotion={
-          ignoreReduceMotion ? ReduceMotion.System : undefined
+          ignoreReduceMotion ? ReduceMotion.Never : ReduceMotion.System
         }
       >
         <BottomSheetScrollView

--- a/yarn.lock
+++ b/yarn.lock
@@ -1915,10 +1915,10 @@
     fast-deep-equal "^3.1.3"
     supercluster "^7.1.3"
 
-"@gorhom/bottom-sheet@5.0.0-alpha.7":
-  version "5.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/@gorhom/bottom-sheet/-/bottom-sheet-5.0.0-alpha.7.tgz#bf4e89e3f1a7e43e23d30823b60ff36c155babe5"
-  integrity sha512-3Gr97lenMOjhUeExzvo+6zimcxWt5o4dQMWZ+E7b71Huqg9in+v+CrVPHAiR7sjpzjdBXwDhKkxLAH3lFRq2+A==
+"@gorhom/bottom-sheet@5.0.6":
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/@gorhom/bottom-sheet/-/bottom-sheet-5.0.6.tgz#f20736502399c7bcf8c73ea09e6b571dc07fe0eb"
+  integrity sha512-SI/AhPvgRfnCWN6/+wbE6TXwRE4X8F2fLyE4L/0bRwgE34Zenq585qLT139uEcfCIyovC2swC3ICqQpkmWEcFA==
   dependencies:
     "@gorhom/portal" "1.0.14"
     invariant "^2.2.4"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `ignoreReduceMotion` prop to `BottomSheet` to control motion reduction, updating `@gorhom/bottom-sheet` to version `5.0.6`.
> 
>   - **Behavior**:
>     - Adds `ignoreReduceMotion` prop to `BottomSheet` in `BottomSheet.tsx` to control motion reduction.
>     - Defaults `ignoreReduceMotion` to `true`, using `ReduceMotion.System` if enabled.
>   - **Dependencies**:
>     - Updates `@gorhom/bottom-sheet` from `5.0.0-alpha.7` to `5.0.6` in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=draftbit%2Freact-native-jigsaw&utm_source=github&utm_medium=referral)<sup> for c98e1bfb10f314f53c0343ce4a3e61f224078a43. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->