### PR TITLE
Change Flatlist from RN to gesture handler

### DIFF
--- a/packages/core/src/components/FlatList.tsx
+++ b/packages/core/src/components/FlatList.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { FlatList as FlatListstComponent } from "react-native";
+import { FlatList as FlatListstComponent } from "react-native-gesture-handler";
 import type { FlatListProps } from "react-native";
 
 const FlatList = React.forwardRef<FlatListstComponent, FlatListProps<any>>(

--- a/packages/core/src/components/FlatList.tsx
+++ b/packages/core/src/components/FlatList.tsx
@@ -1,14 +1,14 @@
 import React from "react";
-import { FlatList as FlatListstComponent } from "react-native-gesture-handler";
+import { FlatList as FlatListComponent } from "react-native-gesture-handler";
 import type { FlatListProps } from "react-native";
 
-const FlatList = React.forwardRef<FlatListstComponent, FlatListProps<any>>(
+const FlatList = React.forwardRef<FlatListComponent, FlatListProps<any>>(
   <T extends any>(
     { numColumns, ...rest }: FlatListProps<T>,
-    ref: React.Ref<FlatListstComponent>
+    ref: React.Ref<FlatListComponent>
   ) => {
     return (
-      <FlatListstComponent
+      <FlatListComponent
         key={numColumns} // Changing numColumns requires re-rendering, setting it as the key ensures list is re-rendered when it changes
         numColumns={numColumns}
         ref={ref}

--- a/packages/core/src/components/SectionList/SectionList.tsx
+++ b/packages/core/src/components/SectionList/SectionList.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { FlashListProps, FlashList } from "@shopify/flash-list";
-import { FlatListProps, FlatList as FlatListComponent } from "react-native";
+import { FlatListProps } from "react-native";
+import { FlatList as FlatListComponent } from "react-native-gesture-handler";
 import SectionHeader, { DefaultSectionHeader } from "./SectionHeader";
 import { flattenReactFragments } from "../../utilities";
 import FlatList from "../FlatList";

--- a/packages/core/src/components/SimpleStyleScrollables/SimpleStyleFlatList.tsx
+++ b/packages/core/src/components/SimpleStyleScrollables/SimpleStyleFlatList.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import FlatList from "../FlatList";
-import { FlatList as FlatListComponent } from "react-native";
+import { FlatList as FlatListComponent } from "react-native-gesture-handler";
 import type { FlatListProps } from "react-native";
 import useSplitContentContainerStyles from "./useSplitContentContainerStyles";
 

--- a/packages/core/src/components/SimpleStyleScrollables/SimpleStyleSectionList.tsx
+++ b/packages/core/src/components/SimpleStyleScrollables/SimpleStyleSectionList.tsx
@@ -5,7 +5,7 @@ import type {
   FlashListSectionListProps,
 } from "../SectionList";
 import useSplitContentContainerStyles from "./useSplitContentContainerStyles";
-import { FlatList } from "react-native";
+import { FlatList } from "react-native-gesture-handler";
 import { FlashList } from "@shopify/flash-list";
 
 /**

--- a/packages/core/src/components/SimpleStyleScrollables/SimpleStyleSwipeableList.tsx
+++ b/packages/core/src/components/SimpleStyleScrollables/SimpleStyleSwipeableList.tsx
@@ -5,7 +5,7 @@ import type {
   FlatListSwipeableListProps,
 } from "../SwipeableItem";
 import useSplitContentContainerStyles from "./useSplitContentContainerStyles";
-import { FlatList } from "react-native";
+import { FlatList } from "react-native-gesture-handler";
 import { FlashList } from "@shopify/flash-list";
 
 /**

--- a/packages/core/src/components/SwipeableItem/SwipeableList.tsx
+++ b/packages/core/src/components/SwipeableItem/SwipeableList.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { FlashListProps, FlashList } from "@shopify/flash-list";
-import { FlatListProps, FlatList as FlatListComponent } from "react-native";
+import { FlatListProps } from "react-native";
+import { FlatList as FlatListComponent } from "react-native-gesture-handler";
 import FlatList from "../FlatList";
 
 type ListComponentType = "FlatList" | "FlashList";


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Change `FlatList` import to `react-native-gesture-handler` across multiple components for improved gesture handling.
> 
>   - **Imports**:
>     - Change `FlatList` import from `react-native` to `react-native-gesture-handler` in `FlatList.tsx`, `SectionList.tsx`, and `SimpleStyleScrollables` components.
>   - **Components**:
>     - Update `FlatList` component in `FlatList.tsx` to use `react-native-gesture-handler`.
>     - Update `SectionList` and `SwipeableList` to use `FlatList` from `react-native-gesture-handler`.
>     - Modify `SimpleStyleFlatList`, `SimpleStyleSectionList`, and `SimpleStyleSwipeableList` to use `FlatList` from `react-native-gesture-handler`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=draftbit%2Freact-native-jigsaw&utm_source=github&utm_medium=referral)<sup> for 50d5ac39b1c4970e549867f464182bcf5ba50860. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->