### PR TITLE
Change to using Flatlist from gesture-handler - 52

### DIFF
--- a/packages/core/src/components/FlatList.tsx
+++ b/packages/core/src/components/FlatList.tsx
@@ -1,14 +1,20 @@
 import React from "react";
-import { FlatList as FlatListstComponent } from "react-native";
+import {
+  FlatList as FlatListComponent,
+  NativeViewGestureHandlerProps,
+} from "react-native-gesture-handler";
 import type { FlatListProps } from "react-native";
 
-const FlatList = React.forwardRef<FlatListstComponent, FlatListProps<any>>(
+const FlatList = React.forwardRef<
+  FlatListComponent,
+  FlatListProps<any> & NativeViewGestureHandlerProps
+>(
   <T extends any>(
-    { numColumns, ...rest }: FlatListProps<T>,
-    ref: React.Ref<FlatListstComponent>
+    { numColumns, ...rest }: FlatListProps<T> & NativeViewGestureHandlerProps,
+    ref: React.Ref<FlatListComponent>
   ) => {
     return (
-      <FlatListstComponent
+      <FlatListComponent
         key={numColumns} // Changing numColumns requires re-rendering, setting it as the key ensures list is re-rendered when it changes
         numColumns={numColumns}
         ref={ref}

--- a/packages/core/src/components/FlatList.tsx
+++ b/packages/core/src/components/FlatList.tsx
@@ -1,16 +1,10 @@
 import React from "react";
-import {
-  FlatList as FlatListComponent,
-  NativeViewGestureHandlerProps,
-} from "react-native-gesture-handler";
+import { FlatList as FlatListComponent } from "react-native-gesture-handler";
 import type { FlatListProps } from "react-native";
 
-const FlatList = React.forwardRef<
-  FlatListComponent,
-  FlatListProps<any> & NativeViewGestureHandlerProps
->(
+const FlatList = React.forwardRef<FlatListComponent, FlatListProps<any>>(
   <T extends any>(
-    { numColumns, ...rest }: FlatListProps<T> & NativeViewGestureHandlerProps,
+    { numColumns, ...rest }: FlatListProps<T>,
     ref: React.Ref<FlatListComponent>
   ) => {
     return (

--- a/packages/core/src/components/SectionList/SectionList.tsx
+++ b/packages/core/src/components/SectionList/SectionList.tsx
@@ -1,6 +1,10 @@
 import React from "react";
 import { FlashListProps, FlashList } from "@shopify/flash-list";
-import { FlatListProps, FlatList as FlatListComponent } from "react-native";
+import { FlatListProps } from "react-native";
+import {
+  FlatList as FlatListComponent,
+  NativeViewGestureHandlerProps,
+} from "react-native-gesture-handler";
 import SectionHeader, { DefaultSectionHeader } from "./SectionHeader";
 import { flattenReactFragments } from "../../utilities";
 import FlatList from "../FlatList";
@@ -192,7 +196,8 @@ const SectionList = React.forwardRef(
           <FlatList
             ref={ref as React.Ref<FlatListComponent>}
             stickyHeaderIndices={sectionHeaderIndicies}
-            {...(rest as FlatListProps<SectionListItem<T>>)}
+            {...(rest as FlatListProps<SectionListItem<T>> &
+              NativeViewGestureHandlerProps)}
             data={dataWithSections}
             renderItem={renderItem}
             keyExtractor={keyExtractor}

--- a/packages/core/src/components/SectionList/SectionList.tsx
+++ b/packages/core/src/components/SectionList/SectionList.tsx
@@ -1,10 +1,7 @@
 import React from "react";
 import { FlashListProps, FlashList } from "@shopify/flash-list";
 import { FlatListProps } from "react-native";
-import {
-  FlatList as FlatListComponent,
-  NativeViewGestureHandlerProps,
-} from "react-native-gesture-handler";
+import { FlatList as FlatListComponent } from "react-native-gesture-handler";
 import SectionHeader, { DefaultSectionHeader } from "./SectionHeader";
 import { flattenReactFragments } from "../../utilities";
 import FlatList from "../FlatList";
@@ -196,8 +193,7 @@ const SectionList = React.forwardRef(
           <FlatList
             ref={ref as React.Ref<FlatListComponent>}
             stickyHeaderIndices={sectionHeaderIndicies}
-            {...(rest as FlatListProps<SectionListItem<T>> &
-              NativeViewGestureHandlerProps)}
+            {...(rest as FlatListProps<SectionListItem<T>>)}
             data={dataWithSections}
             renderItem={renderItem}
             keyExtractor={keyExtractor}

--- a/packages/core/src/components/SimpleStyleScrollables/SimpleStyleFlatList.tsx
+++ b/packages/core/src/components/SimpleStyleScrollables/SimpleStyleFlatList.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 import FlatList from "../FlatList";
-import { FlatList as FlatListComponent } from "react-native";
+import {
+  FlatList as FlatListComponent,
+  NativeViewGestureHandlerProps,
+} from "react-native-gesture-handler";
 import type { FlatListProps } from "react-native";
 import useSplitContentContainerStyles from "./useSplitContentContainerStyles";
 
@@ -14,7 +17,8 @@ const SimpleStyleFlatList = React.forwardRef(
       style: styleProp,
       data,
       ...rest
-    }: Omit<FlatListProps<T>, "contentContainerStyle">,
+    }: Omit<FlatListProps<T>, "contentContainerStyle"> &
+      NativeViewGestureHandlerProps,
     ref: React.Ref<FlatListComponent>
   ) => {
     const { style, contentContainerStyle } =

--- a/packages/core/src/components/SimpleStyleScrollables/SimpleStyleFlatList.tsx
+++ b/packages/core/src/components/SimpleStyleScrollables/SimpleStyleFlatList.tsx
@@ -1,9 +1,6 @@
 import React from "react";
 import FlatList from "../FlatList";
-import {
-  FlatList as FlatListComponent,
-  NativeViewGestureHandlerProps,
-} from "react-native-gesture-handler";
+import { FlatList as FlatListComponent } from "react-native-gesture-handler";
 import type { FlatListProps } from "react-native";
 import useSplitContentContainerStyles from "./useSplitContentContainerStyles";
 
@@ -17,8 +14,7 @@ const SimpleStyleFlatList = React.forwardRef(
       style: styleProp,
       data,
       ...rest
-    }: Omit<FlatListProps<T>, "contentContainerStyle"> &
-      NativeViewGestureHandlerProps,
+    }: Omit<FlatListProps<T>, "contentContainerStyle">,
     ref: React.Ref<FlatListComponent>
   ) => {
     const { style, contentContainerStyle } =

--- a/packages/core/src/components/SimpleStyleScrollables/SimpleStyleSectionList.tsx
+++ b/packages/core/src/components/SimpleStyleScrollables/SimpleStyleSectionList.tsx
@@ -5,7 +5,7 @@ import type {
   FlashListSectionListProps,
 } from "../SectionList";
 import useSplitContentContainerStyles from "./useSplitContentContainerStyles";
-import { FlatList } from "react-native";
+import { FlatList as FlatListComponent } from "react-native-gesture-handler";
 import { FlashList } from "@shopify/flash-list";
 
 /**
@@ -22,7 +22,7 @@ const SimpleStyleSectionList = React.forwardRef(
       FlatListSectionListProps<T> | FlashListSectionListProps<T>,
       "contentContainerStyle"
     >,
-    ref: React.Ref<FlatList | FlashList<any>>
+    ref: React.Ref<FlatListComponent | FlashList<any>>
   ) => {
     const { style, contentContainerStyle } =
       useSplitContentContainerStyles(styleProp);

--- a/packages/core/src/components/SimpleStyleScrollables/SimpleStyleSwipeableList.tsx
+++ b/packages/core/src/components/SimpleStyleScrollables/SimpleStyleSwipeableList.tsx
@@ -5,7 +5,7 @@ import type {
   FlatListSwipeableListProps,
 } from "../SwipeableItem";
 import useSplitContentContainerStyles from "./useSplitContentContainerStyles";
-import { FlatList } from "react-native";
+import { FlatList as FlatListComponent } from "react-native-gesture-handler";
 import { FlashList } from "@shopify/flash-list";
 
 /**
@@ -22,7 +22,7 @@ const SimpleStyleSwipeableList = React.forwardRef(
       FlashListSwipeableListProps<T> | FlatListSwipeableListProps<T>,
       "contentContainerStyle"
     >,
-    ref: React.Ref<FlatList | FlashList<any>>
+    ref: React.Ref<FlatListComponent | FlashList<any>>
   ) => {
     const { style, contentContainerStyle } =
       useSplitContentContainerStyles(styleProp);

--- a/packages/core/src/components/SwipeableItem/SwipeableList.tsx
+++ b/packages/core/src/components/SwipeableItem/SwipeableList.tsx
@@ -1,6 +1,10 @@
 import React from "react";
 import { FlashListProps, FlashList } from "@shopify/flash-list";
-import { FlatListProps, FlatList as FlatListComponent } from "react-native";
+import { FlatListProps } from "react-native";
+import {
+  FlatList as FlatListComponent,
+  NativeViewGestureHandlerProps,
+} from "react-native-gesture-handler";
 import FlatList from "../FlatList";
 
 type ListComponentType = "FlatList" | "FlashList";
@@ -54,7 +58,7 @@ const SwipeableList = React.forwardRef(
           return (
             <FlatList
               ref={ref as React.Ref<FlatListComponent>}
-              {...(rest as FlatListProps<T>)}
+              {...(rest as FlatListProps<T> & NativeViewGestureHandlerProps)}
             />
           );
         case "FlashList":

--- a/packages/core/src/components/SwipeableItem/SwipeableList.tsx
+++ b/packages/core/src/components/SwipeableItem/SwipeableList.tsx
@@ -1,10 +1,7 @@
 import React from "react";
 import { FlashListProps, FlashList } from "@shopify/flash-list";
 import { FlatListProps } from "react-native";
-import {
-  FlatList as FlatListComponent,
-  NativeViewGestureHandlerProps,
-} from "react-native-gesture-handler";
+import { FlatList as FlatListComponent } from "react-native-gesture-handler";
 import FlatList from "../FlatList";
 
 type ListComponentType = "FlatList" | "FlashList";
@@ -58,7 +55,7 @@ const SwipeableList = React.forwardRef(
           return (
             <FlatList
               ref={ref as React.Ref<FlatListComponent>}
-              {...(rest as FlatListProps<T> & NativeViewGestureHandlerProps)}
+              {...(rest as FlatListProps<T>)}
             />
           );
         case "FlashList":


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Switch `FlatList` usage from `react-native` to `react-native-gesture-handler` across multiple components for improved gesture handling.
> 
>   - **Imports**:
>     - Change `FlatList` import from `react-native` to `react-native-gesture-handler` in `FlatList.tsx`, `SectionList.tsx`, and `SimpleStyleScrollables` components.
>   - **Type References**:
>     - Update type references from `FlatList` to `FlatListComponent` in `FlatList.tsx`, `SimpleStyleSectionList.tsx`, and `SimpleStyleSwipeableList.tsx`.
>   - **Components**:
>     - Modify `FlatList` component in `FlatList.tsx` to use `FlatListComponent` from `react-native-gesture-handler`.
>     - Update `SectionList`, `SimpleStyleFlatList`, `SimpleStyleSectionList`, and `SimpleStyleSwipeableList` to use `FlatListComponent` from `react-native-gesture-handler`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=draftbit%2Freact-native-jigsaw&utm_source=github&utm_medium=referral)<sup> for ed1a3a856ca56ade1db9714e3a5a41cf02af623a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->