### PR TITLE
fix crash blurhash expo image web expo 50

### DIFF
--- a/packages/core/src/components/ExpoImage.tsx
+++ b/packages/core/src/components/ExpoImage.tsx
@@ -54,7 +54,16 @@ const ExpoImage: React.FC<ExtendedImageProps> = ({
   blurhash,
   ...props
 }) => {
-  const imageSource = source ?? Config.placeholderImageURL;
+  let imageSource = source ?? Config.placeholderImageURL;
+  // Prevent crash in Expo 50 when using expo-image with non-http/https URIs
+  if (
+    source &&
+    typeof source === "object" &&
+    "uri" in source &&
+    !/^(http|https):\/\//.test(source.uri || "")
+  ) {
+    imageSource = { uri: "" };
+  }
   const finalContentFit = resizeMode
     ? resizeModeToContentFit(resizeMode)
     : contentFit;


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes crash in `ExpoImage` component for non-http/https URIs by setting `imageSource` to an empty URI object.
> 
>   - **Behavior**:
>     - Fixes crash in `ExpoImage` component in `ExpoImage.tsx` when using non-http/https URIs by setting `imageSource` to an empty URI object.
>     - Applies only when `source` is an object with a `uri` property that does not start with `http` or `https`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=draftbit%2Freact-native-jigsaw&utm_source=github&utm_medium=referral)<sup> for e721e850c1f3ceab29bfbc848faa6b177ead8d16. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->