### PR TITLE
fix: ensure the new date is always between max and min dates

### DIFF
--- a/example/src/DatePickerExample.jsx
+++ b/example/src/DatePickerExample.jsx
@@ -113,8 +113,8 @@ function DatePickerExample({ theme }) {
           label="Date with minimum and maximum"
           placeholder="Select a date..."
           type="solid"
-          minimumDate={new Date("April 10, 2023")}
-          maximumDate={new Date("May 10, 2023")}
+          minimumDate={new Date("2023-04-10")}
+          maximumDate={new Date("2023-05-10")}
         />
       </Section>
       <Section title="Styled">

--- a/packages/core/src/components/DatePicker/DatePicker.tsx
+++ b/packages/core/src/components/DatePicker/DatePicker.tsx
@@ -34,6 +34,7 @@ import {
   paddingStyleNames,
   positionStyleNames,
 } from "../../utilities";
+import { parseDate } from "./parseDate";
 
 const AnimatedText = Animated.createAnimatedComponent(Text);
 
@@ -399,6 +400,29 @@ const DatePicker: React.FC<React.PropsWithChildren<Props>> = ({
     type === "solid" ? { marginHorizontal: 12 } : {},
   ];
 
+  React.useEffect(() => {
+    const currentDate = parseDate(value);
+
+    if (!currentDate) return;
+
+    const minDate = parseDate(minimumDate);
+    const maxDate = parseDate(maximumDate);
+
+    let newDate = currentDate;
+
+    if (minDate && currentDate < minDate) {
+      newDate = minDate;
+    }
+    if (maxDate && currentDate > maxDate) {
+      newDate = maxDate;
+    }
+
+    if (newDate !== currentDate) {
+      setValue(newDate);
+      onDateChange(newDate);
+    }
+  }, [value, minimumDate, maximumDate, onDateChange]);
+
   const Picker = (
     <DateTimePicker
       value={getValidDate()}
@@ -618,21 +642,5 @@ const styles = StyleSheet.create({
   },
   pickerContainer: { flexDirection: "column", width: "100%", zIndex: 100 },
 });
-
-function parseDate(date?: string | Date) {
-  if (typeof date === "string") {
-    const parsed = Date.parse(date);
-    if (!isNaN(parsed)) {
-      return new Date(parsed);
-    }
-    console.warn(
-      "Invalid date string:",
-      `'${date}'.`,
-      "See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#date_time_string_format"
-    );
-    return undefined;
-  }
-  return date;
-}
 
 export default withTheme(DatePicker);

--- a/packages/core/src/components/DatePicker/parseDate.ts
+++ b/packages/core/src/components/DatePicker/parseDate.ts
@@ -1,0 +1,15 @@
+export function parseDate(date?: string | Date) {
+  if (typeof date === "string") {
+    const parsed = Date.parse(date);
+    if (!isNaN(parsed)) {
+      return new Date(parsed);
+    }
+    console.warn(
+      "Invalid date string:",
+      `'${date}'.`,
+      "See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#date_time_string_format"
+    );
+    return undefined;
+  }
+  return date;
+}


### PR DESCRIPTION
<img width="986" alt="image" src="https://github.com/user-attachments/assets/ec3f8e46-7f83-4b9e-b9a9-bc756875647e" />


https://github.com/user-attachments/assets/4fc82c3a-6c21-4712-afdd-82648df68cc6


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensures `DatePicker` selected date is within specified range and refactors `parseDate` function for modularity.
> 
>   - **Behavior**:
>     - Ensures selected date in `DatePicker` is within `minimumDate` and `maximumDate` in `DatePicker.tsx`.
>     - Adjusts date using `useEffect` if it falls outside the specified range.
>   - **Refactoring**:
>     - Moves `parseDate` function to `parseDate.ts` for modularity.
>   - **Examples**:
>     - Updates date format in `DatePickerExample.jsx` for `minimumDate` and `maximumDate`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=draftbit%2Freact-native-jigsaw&utm_source=github&utm_medium=referral)<sup> for ca74bdb31ea262e5be2671c389e622fea18c2d87. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->