### PR TITLE
Add props to change default section header colors

### DIFF
--- a/packages/core/src/components/SectionList/SectionHeader.tsx
+++ b/packages/core/src/components/SectionList/SectionHeader.tsx
@@ -15,15 +15,17 @@ const SectionHeader: React.FC<React.PropsWithChildren<SectionHeaderProps>> = ({
 interface DefaultSectionHeaderProps {
   title: string;
   theme: ReadTheme;
+  backgroundColor?: string;
+  textColor?: string;
 }
 export const DefaultSectionHeader = withTheme(
-  ({ title, theme }: DefaultSectionHeaderProps) => {
+  ({ title, theme, backgroundColor, textColor }: DefaultSectionHeaderProps) => {
     return (
       <Text
         testID="default-section-header"
         style={{
-          color: theme.colors.background.base,
-          backgroundColor: theme.colors.branding.primary,
+          color: textColor ?? theme.colors.background.base,
+          backgroundColor: backgroundColor ?? theme.colors.branding.primary,
           fontSize: 16,
           padding: 10,
         }}

--- a/packages/core/src/components/SectionList/SectionList.tsx
+++ b/packages/core/src/components/SectionList/SectionList.tsx
@@ -18,6 +18,8 @@ interface AdditionalSectionListProps<T> {
   }) => JSX.Element;
   keyExtractor?: (item: T, index: number) => string;
   listComponent?: ListComponentType;
+  sectionHeaderBackgroundColor?: string;
+  sectionHeaderTextColor?: string;
 }
 
 export type FlatListSectionListProps<T> = Omit<FlatListProps<T>, "renderItem"> &
@@ -52,6 +54,8 @@ const SectionList = React.forwardRef(
       data: dataProp,
       renderItem: renderItemProp,
       keyExtractor: keyExtractorProp,
+      sectionHeaderBackgroundColor,
+      sectionHeaderTextColor,
       ...rest
     }: FlatListSectionListProps<T> | FlashListSectionListProps<T>,
     ref: React.Ref<FlatListComponent | FlashList<any>>
@@ -161,7 +165,11 @@ const SectionList = React.forwardRef(
           });
           return (
             extractSectionHeader(renderedItem) || (
-              <DefaultSectionHeader title={item.title} />
+              <DefaultSectionHeader
+                title={item.title}
+                backgroundColor={sectionHeaderBackgroundColor}
+                textColor={sectionHeaderTextColor}
+              />
             )
           );
         }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add props to `SectionList` for customizable section header colors, updating `DefaultSectionHeader` to use these props.
> 
>   - **Behavior**:
>     - Adds `sectionHeaderBackgroundColor` and `sectionHeaderTextColor` props to `SectionList` in `SectionList.tsx` to customize section header colors.
>     - Updates `DefaultSectionHeader` in `SectionHeader.tsx` to use `backgroundColor` and `textColor` props, defaulting to theme colors if not provided.
>   - **Components**:
>     - Modifies `DefaultSectionHeader` to accept and apply new color props.
>     - Updates `SectionList` to pass new color props to `DefaultSectionHeader`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=draftbit%2Freact-native-jigsaw&utm_source=github&utm_medium=referral)<sup> for ad6feb6873c5051e47fb8534332d81ce7b49fcc8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->