### PR TITLE
fix expo image relative path image

### DIFF
--- a/packages/core/src/components/ExpoImage.tsx
+++ b/packages/core/src/components/ExpoImage.tsx
@@ -60,7 +60,7 @@ const ExpoImage: React.FC<ExtendedImageProps> = ({
     source &&
     typeof source === "object" &&
     "uri" in source &&
-    !/^(http|https):\/\/|^data:/.test(source.uri || "")
+    !/^(http|https):\/\/|^data:|^\//.test(source.uri || "")
   ) {
     imageSource = { uri: "" };
   }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes URI validation in `ExpoImage` to allow relative paths, preventing crashes in Expo 50.
> 
>   - **Behavior**:
>     - Fixes URI validation in `ExpoImage` component to allow relative paths by updating regex in `ExpoImage.tsx`.
>     - Prevents crash in Expo 50 when using `expo-image` with relative paths.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=draftbit%2Freact-native-jigsaw&utm_source=github&utm_medium=referral)<sup> for b4aa87e895b2aac97ba485c0cea20cb8818004ca. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->